### PR TITLE
feat(observe): GitHub CI observation provider

### DIFF
--- a/internal/observe/github/ci/ci.go
+++ b/internal/observe/github/ci/ci.go
@@ -1,0 +1,62 @@
+package ci
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/k-shibuki/reinguard/internal/githubapi"
+)
+
+type combinedStatus struct {
+	State string `json:"state"`
+}
+
+// Collect returns a coarse CI rollup for HEAD of the current branch.
+func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir string) (map[string]any, []string, error) {
+	if c == nil {
+		return nil, nil, fmt.Errorf("nil client")
+	}
+	var warnings []string
+	sha, err := headSHA(ctx, workDir)
+	if err != nil {
+		warnings = append(warnings, err.Error())
+		return map[string]any{
+			"ci": map[string]any{
+				"ci_status": "unknown",
+				"head_sha":  "",
+			},
+		}, warnings, nil
+	}
+	u := fmt.Sprintf("%s/repos/%s/%s/commits/%s/status", c.APIBase(), owner, repo, sha)
+	var st combinedStatus
+	if err := c.GetJSON(ctx, u, &st); err != nil {
+		return nil, warnings, err
+	}
+	status := strings.ToLower(st.State)
+	if status == "" {
+		status = "unknown"
+	}
+	return map[string]any{
+		"ci": map[string]any{
+			"ci_status": status,
+			"head_sha":  sha,
+		},
+	}, warnings, nil
+}
+
+func headSHA(ctx context.Context, wd string) (string, error) {
+	var buf bytes.Buffer
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "HEAD")
+	if wd != "" {
+		cmd.Dir = wd
+	}
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git rev-parse: %w: %s", err, strings.TrimSpace(buf.String()))
+	}
+	return strings.TrimSpace(buf.String()), nil
+}

--- a/internal/observe/github/ci/ci_test.go
+++ b/internal/observe/github/ci/ci_test.go
@@ -1,0 +1,48 @@
+package ci
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+
+	"github.com/k-shibuki/reinguard/internal/githubapi"
+)
+
+func TestCollect_status(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"state":"success"}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "t", BaseURL: srv.URL}
+	m, warns, err := Collect(context.Background(), c, "o", "r", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("%v", warns)
+	}
+	cimap := m["ci"].(map[string]any)
+	if cimap["ci_status"].(string) != "success" {
+		t.Fatalf("%v", cimap)
+	}
+}
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command("git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
# Summary

Adds the GitHub **CI / checks** observation facet under `internal/observe/github/ci` with tests.

## Definition of Done

- [x] Tests added or updated (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. `go test ./... -race -count=1` — passes.
2. `go vet ./...` — clean.

## Linked issues

Closes #13

Refs: #13

## Exception

- Type: (n/a)
- Justification: (n/a)

## Traceability

Closes #13


## Risk / Impact

- Affected area: see Summary.
- Breaking change: no (update if yes).


## Rollback Plan

Revert this PR on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new internal GitHub observation module and test without changing existing behavior; main risk is reliance on local `git` execution and GitHub API response shape.
> 
> **Overview**
> Adds a new `internal/observe/github/ci` collector that shells out to `git rev-parse HEAD` and queries GitHub’s combined commit status endpoint to return a normalized `ci_status` plus `head_sha`, emitting warnings (but not errors) when the local SHA can’t be determined.
> 
> Includes a unit test using an `httptest` GitHub API stub and a temporary git repo to validate the success-path status mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e69b5928280e94fe40cacdfbbb863e25ae2c0b70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->