### PR TITLE
chore(ci): verify yq checksums and darwin bundle for sync templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Review routing for touched areas is defined in **[`CODEOWNERS`](CODEOWNERS)**.
 
 - **Go**: match `go.mod` / CI (toolchain **1.26.1** as of this writing).
 - **golangci-lint**: optional locally; CI runs it on every PR.
-- **`yq`**: **[mikefarah/yq](https://github.com/mikefarah/yq) v4** — required for local runs of `.reinguard/scripts/check-commit-msg.sh`, `check-pr-policy.sh`, `check-issue-policy.sh`, and for `.reinguard/scripts/sync-issue-templates.sh` (CI installs a pinned binary in workflows).
+- **`yq`**: **[mikefarah/yq](https://github.com/mikefarah/yq) v4** — required for local runs of `.reinguard/scripts/check-commit-msg.sh`, `check-pr-policy.sh`, `check-issue-policy.sh`, and for `.reinguard/scripts/sync-issue-templates.sh`. GitHub Actions installs a pinned release via [`.github/scripts/install-mikefarah-yq.sh`](scripts/install-mikefarah-yq.sh), which checks **SHA-256** against the upstream `checksums` file before `sudo install`. On **macOS or Linux**, if `yq` on your `PATH` is not mikefarah v4, `sync-issue-templates.sh` downloads a verified binary to `.reinguard/scripts/.bin/yq` on first run; otherwise install from Homebrew or the [yq releases](https://github.com/mikefarah/yq/releases) page.
 - **`gh`**: required only when using commands that call the GitHub API (e.g.
   `rgd observe github`, or live observation in `rgd state eval` / `rgd context build`
   without `--observation-file`). See ADR-0006.

--- a/.github/scripts/install-mikefarah-yq.sh
+++ b/.github/scripts/install-mikefarah-yq.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Install mikefarah yq for GitHub Actions (Linux) with SHA-256 verification against
+# the release checksums file (https://github.com/mikefarah/yq/releases).
+#
+# Env: YQ_VER (default 4.45.1). Optional first argument overrides the version.
+set -euo pipefail
+
+YQ_VER="${YQ_VER:-${1:-4.45.1}}"
+ARCH_RAW="$(uname -m)"
+case "$ARCH_RAW" in
+x86_64) ARCH=amd64 ;;
+aarch64 | arm64) ARCH=arm64 ;;
+*)
+  echo "ERROR: unsupported runner arch for yq: $ARCH_RAW" >&2
+  exit 1
+  ;;
+esac
+
+ASSET="yq_linux_${ARCH}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+BASE="https://github.com/mikefarah/yq/releases/download/v${YQ_VER}"
+curl -fsSL "$BASE/checksums" -o "$TMP/checksums"
+curl -fsSL "$BASE/checksums_hashes_order" -o "$TMP/checksums_hashes_order"
+curl -fsSL "$BASE/extract-checksum.sh" -o "$TMP/extract-checksum.sh"
+chmod +x "$TMP/extract-checksum.sh"
+curl -fsSL "$BASE/${ASSET}" -o /tmp/yq
+
+(
+  cd "$TMP"
+  ./extract-checksum.sh SHA-256 "$ASSET" | awk '{print $2 "  /tmp/yq"}' | sha256sum -c -
+)
+
+sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+yq --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,9 @@ jobs:
 
       - name: Install mikefarah yq
         if: github.event_name == 'pull_request'
-        run: |
-          set -euo pipefail
-          YQ_VER=4.45.1
-          curl -sSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_amd64" -o /tmp/yq
-          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
-          yq --version
+        env:
+          YQ_VER: "4.45.1"
+        run: bash .github/scripts/install-mikefarah-yq.sh
 
       - name: Skip policy check (non-PR events)
         if: github.event_name != 'pull_request'
@@ -106,12 +103,9 @@ jobs:
         run: go mod download
 
       - name: Install mikefarah yq (for check-issue-policy.sh integration tests)
-        run: |
-          set -euo pipefail
-          YQ_VER=4.45.1
-          curl -sSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_amd64" -o /tmp/yq
-          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
-          yq --version
+        env:
+          YQ_VER: "4.45.1"
+        run: bash .github/scripts/install-mikefarah-yq.sh
 
       - name: go test
         run: go test ./... -race -coverpkg=./... -coverprofile=coverage.out -count=1

--- a/.github/workflows/issue-label.yaml
+++ b/.github/workflows/issue-label.yaml
@@ -19,12 +19,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Install mikefarah yq
-        run: |
-          set -euo pipefail
-          YQ_VER=4.45.1
-          curl -sSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_amd64" -o /tmp/yq
-          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
-          yq --version
+        env:
+          YQ_VER: "4.45.1"
+        run: bash .github/scripts/install-mikefarah-yq.sh
 
       - name: Extract label config
         run: yq -o json .reinguard/labels.yaml > /tmp/labels.json

--- a/.github/workflows/pr-policy.yaml
+++ b/.github/workflows/pr-policy.yaml
@@ -17,12 +17,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Install mikefarah yq
-        run: |
-          set -euo pipefail
-          YQ_VER=4.45.1
-          curl -sSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VER}/yq_linux_amd64" -o /tmp/yq
-          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
-          yq --version
+        env:
+          YQ_VER: "4.45.1"
+        run: bash .github/scripts/install-mikefarah-yq.sh
 
       - name: Extract label config for PR policy
         run: yq -o json .reinguard/labels.yaml > /tmp/labels.json

--- a/.reinguard/scripts/sync-issue-templates.sh
+++ b/.reinguard/scripts/sync-issue-templates.sh
@@ -2,7 +2,8 @@
 # Sync `.github/ISSUE_TEMPLATE/task.yml` Type dropdown from `.reinguard/labels.yaml`
 # via `rgd labels list` (same SSOT). Requires `jq` and mikefarah `yq` v4
 # (https://github.com/mikefarah/yq). If PATH `yq` is not mikefarah v4, a copy is
-# downloaded to `.reinguard/scripts/.bin/yq` on first run.
+# downloaded to `.reinguard/scripts/.bin/yq` on first run (Linux or macOS), with
+# SHA-256 verification against the release checksums file.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -25,6 +26,39 @@ is_mikefarah_yq() {
   return 0
 }
 
+# Download mikefarah yq for os (linux|darwin) and arch (amd64|arm64); verify SHA-256
+# using the release checksums and upstream extract-checksum.sh.
+download_mikefarah_yq_verified() {
+  local ver="$1"
+  local dest="$2"
+  local os="$3"
+  local arch="$4"
+  local asset="yq_${os}_${arch}"
+  local tmp base
+  tmp=$(mktemp -d)
+  base="https://github.com/mikefarah/yq/releases/download/v${ver}"
+  curl -fsSL "$base/checksums" -o "$tmp/checksums"
+  curl -fsSL "$base/checksums_hashes_order" -o "$tmp/checksums_hashes_order"
+  curl -fsSL "$base/extract-checksum.sh" -o "$tmp/extract-checksum.sh"
+  chmod +x "$tmp/extract-checksum.sh"
+  curl -fsSL "$base/$asset" -o "$dest"
+  (
+    cd "$tmp"
+    line=$(./extract-checksum.sh SHA-256 "$asset")
+    exp=$(echo "$line" | awk '{print $2}')
+    if command -v sha256sum >/dev/null 2>&1; then
+      echo "$exp  $dest" | sha256sum -c -
+    elif command -v shasum >/dev/null 2>&1; then
+      echo "$exp  $dest" | shasum -a 256 -c -
+    else
+      echo "ERROR: need sha256sum or shasum to verify yq download" >&2
+      exit 1
+    fi
+  )
+  rm -rf "$tmp"
+  chmod +x "$dest"
+}
+
 ensure_yq() {
   if is_mikefarah_yq; then
     YQ_CMD=(yq)
@@ -34,7 +68,8 @@ ensure_yq() {
   if [[ ! -x "$YQ_CACHED" ]]; then
     echo "Installing mikefarah yq to $YQ_CACHED (one-time)..." >&2
     local ver=4.45.1
-    local arch
+    local arch kernel
+    kernel=$(uname -s)
     arch=$(uname -m)
     case "$arch" in
       x86_64) arch=amd64 ;;
@@ -44,9 +79,16 @@ ensure_yq() {
         exit 1
         ;;
     esac
-    local url="https://github.com/mikefarah/yq/releases/download/v${ver}/yq_linux_${arch}"
-    curl -sSL "$url" -o "$YQ_CACHED"
-    chmod +x "$YQ_CACHED"
+    local os
+    case "$kernel" in
+      Linux) os=linux ;;
+      Darwin) os=darwin ;;
+      *)
+        echo "ERROR: unsupported OS for bundled yq: $kernel (install mikefarah yq v4 and ensure it is on PATH)" >&2
+        exit 1
+        ;;
+    esac
+    download_mikefarah_yq_verified "$ver" "$YQ_CACHED" "$os" "$arch"
   fi
   YQ_CMD=("$YQ_CACHED")
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Verify **mikefarah/yq** downloads in GitHub Actions using the upstream release **`checksums`** file and **`extract-checksum.sh`** (SHA-256) before `sudo install`, reducing supply-chain risk (Issue #85 follow-up from PR #84).
- Add **`.github/scripts/install-mikefarah-yq.sh`** and use it from **`gate-policy`**, **`test-go`**, **`pr-policy`**, and **`issue-label`** workflows (Linux **amd64** / **arm64**).
- **`sync-issue-templates.sh`** now bundles **darwin** or **linux** `yq` with the same verification when PATH lacks mikefarah v4; uses **`shasum -a 256`** on macOS when **`sha256sum`** is unavailable.
- Document CI and local behavior in **`.github/CONTRIBUTING.md`**.

## Traceability

Closes #85

Refs: #58 #83

## Definition of Done

- [x] Tests added or updated (`go test ./...`) — no Go behavior change; shell paths exercised by CI jobs that install `yq`
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed (CONTRIBUTING)

## Test plan

1. `bash -n .github/scripts/install-mikefarah-yq.sh` and `bash -n .reinguard/scripts/sync-issue-templates.sh` (syntax OK).
2. `go vet ./...`, `golangci-lint run ./...`, `go test ./... -race -count=1` (local preflight).
3. After merge / on this PR: CI **`gate-policy`** and **`test-go`** run `.github/scripts/install-mikefarah-yq.sh` and should succeed.
4. Optional: on macOS without mikefarah `yq` on PATH, run `bash .reinguard/scripts/sync-issue-templates.sh` once (downloads verified `.reinguard/scripts/.bin/yq`).

## Risk / Impact

- **CI / local sync** could fail if the pinned **yq** release layout changes (missing `checksums`, `checksums_hashes_order`, or `extract-checksum.sh`). Mitigation: pinned **`YQ_VER`** and reuse of upstream **`extract-checksum.sh`**.
- **First-run** `sync-issue-templates.sh` now pulls extra small files (checksums metadata) from GitHub; acceptable for one-time cache.

## Rollback Plan

- Revert this PR; restore prior inline `curl` + `install` steps in workflows if a hotfix is required.

## Exception

- (not applicable)
