### PR TITLE
feat(observe): scoped PR observation and review inbox

### DIFF
--- a/.cursor/commands/rgd-next.md
+++ b/.cursor/commands/rgd-next.md
@@ -4,6 +4,21 @@ Single Cursor entry for workflow procedures: use **substrate** output to pick Se
 
 ## Sense
 
+Before fresh proposal logic, Cursor may inspect the Adapter-local resume
+artifact:
+
+```bash
+bash .reinguard/scripts/adapter-rgd-next-resume.sh status
+```
+
+If that reports `status: "active"` and `resume_eligible: true`, resume the
+recorded approved Execute path instead of starting a new proposal cycle.
+If it reports `status: "pending_approval"`, a proposal artifact exists for the
+recorded unit but the user has not yet approved Execute; continue with **Propose**
+(do not treat as an approved run). This artifact is **Adapter-local only**
+(ADR-0015): do **not** feed it into `rgd` state / route evaluation or treat it
+as substrate workflow position.
+
 1. From repo root (or pass `--cwd` / `--config-dir` consistent with other `rgd` commands):
 
    ```bash
@@ -54,7 +69,13 @@ When `state.kind` is not `resolved`, follow ADR-0007 handoff: gather observation
 
 ## Propose
 
-After **Sense** and **Route**, present the full-path proposal **exactly once** per run, then wait for approval. There is no alternate mode (no proposal-only run and no stopping after a minimal state dump).
+After **Sense** and **Route**, record the Adapter-local **proposal** artifact for the unit (branch / issue / PR as known) **before** the approval gate, then present the full-path proposal **exactly once** per run, then wait for approval. There is no alternate mode (no proposal-only run and no stopping after a minimal state dump).
+
+```bash
+bash .reinguard/scripts/adapter-rgd-next-resume.sh start --branch <branch> [--issue <N>] [--pr <N>] [--summary TEXT]
+```
+
+This writes `status: "pending_approval"` until the user approves Execute (next section).
 
 1. Trace forward from the current `state_id` using [ADR-0013 § 4](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) through **Per-unit Definition of Done** in [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md).
 2. Follow **`next-orchestration.md` § Full-path proposal format** in full: current position, ordered remainder, gaps, completion condition.
@@ -66,11 +87,25 @@ After **Sense** and **Route**, present the full-path proposal **exactly once** p
 
 After approval, **always** follow [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Post-approval execution contract** and § **Loop semantics**: drive to Per-unit DoD **without** user prompts that gate progress between iterations.
 
+On approval, activate the existing proposal artifact (same unit as **Propose** `start`):
+
+```bash
+bash .reinguard/scripts/adapter-rgd-next-resume.sh approve
+```
+
+If no `pending_approval` artifact exists (for example a fresh machine), run `start` then `approve` in one flow after approval.
+
 **No implicit stop:** Do not end the run because a status summary or external wait “feels done.” Only **Per-unit Definition of Done**, or an **allowed stop with evidence** per `next-orchestration.md` § Post-approval execution contract (including **Implicit stop (forbidden)**), counts as completion.
 
 Loop (summary): **Sense** (`rgd context build`) → **Route** (ADR-0013 § 4; same rules as § Route above) → run mapped procedure(s) → **Refresh** context after material changes — per `next-orchestration.md`.
 
-**Output (for agents):** After each `rgd context build` in the loop, **record** the same iteration context **agent-internally** as in [`next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Output** (per-iteration bullet): `state_id` / `route_id` / guard summary and which procedure(s) ran or are next. Do **not** treat per-iteration chat as required user-visible output — follow [`.cursor/rules/reinguard-bridge.mdc`](../../.cursor/rules/reinguard-bridge.mdc) § **rgd-next Execute — Cursor chat transcript** for what may appear in the Cursor chat panel. **Final user-facing output:** DoD satisfied with evidence, or allowed stop with evidence (`next-orchestration.md` § Post-approval execution contract).
+**Output (for agents):** After each `rgd context build` in the loop, **record** the same iteration context **agent-internally** as in [`next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Output** (per-iteration bullet): `state_id` / `route_id` / guard summary and which procedure(s) ran or are next. Refresh the Adapter-local artifact with:
+
+```bash
+bash .reinguard/scripts/adapter-rgd-next-resume.sh update --state-id <state_id> [--route-id <route_id>]
+```
+
+Do **not** treat per-iteration chat as required user-visible output — follow [`.cursor/rules/reinguard-bridge.mdc`](../../.cursor/rules/reinguard-bridge.mdc) § **rgd-next Execute — Cursor chat transcript** for what may appear in the Cursor chat panel. When DoD or an allowed stop is reached, close the artifact with `finish --status ... --reason ...` before returning the final user-facing report.
 
 ## Guard
 

--- a/.cursor/commands/rgd-next.md
+++ b/.cursor/commands/rgd-next.md
@@ -12,6 +12,14 @@ Single Cursor entry for workflow procedures: use **substrate** output to pick Se
 
    If `rgd` is not on `PATH`, from repo root: `go run ./cmd/rgd context build` (same flags).
 
+   When the user names a PR number, prefer scoped observation:
+
+   ```bash
+   rgd context build --pr <N>
+   ```
+
+   (or `go run ./cmd/rgd context build --pr <N>` from repo root).
+
 2. Parse stdout JSON:
    - `state.state_id`, `state.kind`
    - `routes[0].kind`, `routes[0].route_id` (when `routes[0].kind` is `resolved`)

--- a/.cursor/commands/rgd-next.md
+++ b/.cursor/commands/rgd-next.md
@@ -75,6 +75,8 @@ After **Sense** and **Route**, record the Adapter-local **proposal** artifact fo
 bash .reinguard/scripts/adapter-rgd-next-resume.sh start --branch <branch> [--issue <N>] [--pr <N>] [--summary TEXT]
 ```
 
+Persistent JSON defaults to `.reinguard/local/adapter/rgd-next/execute-resume.json` (ADR-0015).
+
 This writes `status: "pending_approval"` until the user approves Execute (next section).
 
 1. Trace forward from the current `state_id` using [ADR-0013 § 4](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) through **Per-unit Definition of Done** in [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md).

--- a/.cursor/rules/reinguard-bridge.mdc
+++ b/.cursor/rules/reinguard-bridge.mdc
@@ -57,6 +57,13 @@ Normative contract: [`.reinguard/procedure/next-orchestration.md`](../../.reingu
 
 After that approval, the agent’s **only** permitted **chat** output is the **final report**: Per-unit Definition of Done satisfied with evidence, or an **allowed stop** with evidence (see `next-orchestration.md` § Post-approval execution contract and § Output). Iteration summaries, guard checks, and procedure progress are **agent-internal** (tool logs, internal notes) and **do not** appear in chat. The agent still follows § Loop semantics and mapped procedures; lack of per-iteration chat is not an excuse to skip Sense → Route → Act → Refresh.
 
+Cursor may persist an Adapter-local resume artifact under repo-local `.tmp/`
+using `.reinguard/scripts/adapter-rgd-next-resume.sh` (ADR-0015): `start`
+before the approval gate (`pending_approval`), then `approve` after the user
+approves Execute. That artifact exists only to decide **resume vs fresh run**
+on a later chat turn; it is **not** substrate state and must not be surfaced
+through `rgd context build`, FSM rules, guards, or `gates.<id>.*`.
+
 ### Evidence targets
 
 - Until `rgd observe` ships, see [`evidence-temporary.mdc`](evidence-temporary.mdc) for GitHub observation (`gh` / `git` read-only).

--- a/.cursor/rules/reinguard-bridge.mdc
+++ b/.cursor/rules/reinguard-bridge.mdc
@@ -57,8 +57,9 @@ Normative contract: [`.reinguard/procedure/next-orchestration.md`](../../.reingu
 
 After that approval, the agent’s **only** permitted **chat** output is the **final report**: Per-unit Definition of Done satisfied with evidence, or an **allowed stop** with evidence (see `next-orchestration.md` § Post-approval execution contract and § Output). Iteration summaries, guard checks, and procedure progress are **agent-internal** (tool logs, internal notes) and **do not** appear in chat. The agent still follows § Loop semantics and mapped procedures; lack of per-iteration chat is not an excuse to skip Sense → Route → Act → Refresh.
 
-Cursor may persist an Adapter-local resume artifact under repo-local `.tmp/`
-using `.reinguard/scripts/adapter-rgd-next-resume.sh` (ADR-0015): `start`
+Cursor may persist an Adapter-local resume artifact under
+`.reinguard/local/adapter/rgd-next/` (gitignored) via
+`.reinguard/scripts/adapter-rgd-next-resume.sh` (ADR-0015): `start`
 before the approval gate (`pending_approval`), then `approve` after the user
 approves Execute. That artifact exists only to decide **resume vs fresh run**
 on a later chat turn; it is **not** substrate state and must not be surfaced

--- a/.cursor/sandbox.json
+++ b/.cursor/sandbox.json
@@ -1,6 +1,6 @@
 {
   "enableSharedBuildCache": true,
-  "additionalReadwritePaths": [".tmp"],
+  "additionalReadwritePaths": [".tmp", ".reinguard/local"],
   "networkPolicy": {
     "allow": [
       "api.github.com",

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,8 @@ vendor/
 # Cached mikefarah yq (sync-issue-templates.sh)
 .reinguard/scripts/.bin/
 
-# Runtime gate artifacts (substrate-owned operational state)
-.reinguard/runtime/
+# Local operational state (substrate gates, adapter resume, scratch; gitignored)
+.reinguard/local/
 
-# Workspace-local temporary caches (pre-commit workaround, etc.)
+# Workspace-local temporary caches (pre-commit, Go/lint caches; not reinguard artifacts)
 /.tmp/

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,3 +13,4 @@ config:
 ignores:
   - "node_modules/**"
   - "vendor/**"
+  - ".reinguard/local/**"

--- a/.reinguard/knowledge/review--github-thread-api.md
+++ b/.reinguard/knowledge/review--github-thread-api.md
@@ -31,6 +31,12 @@ conversation threads.
 To enumerate threads and read `isResolved`, use the **GraphQL** API:
 `repository.pullRequest.reviewThreads`.
 
+When available, prefer `rgd observe github reviews` / `rgd context build`
+for the structured `review_inbox` read model and `rgd review reply-thread` /
+`rgd review resolve-thread` for the covered happy-path transport. Use the raw
+GraphQL flow below as the fallback and truth source for cases not yet surfaced
+by `rgd`.
+
 ## Enumerate threads with resolution state
 
 Use `gh api graphql` and paginate while `pageInfo.hasNextPage` is true:

--- a/.reinguard/knowledge/workflow--state-gate-guard-extension.md
+++ b/.reinguard/knowledge/workflow--state-gate-guard-extension.md
@@ -31,7 +31,7 @@ when:
 
 ## Adding or changing a runtime **gate** (`gate_id`)
 
-1. [ ] Document producer procedure(s) (`rgd gate record <gate-id>` after verification) and consumer(s) (`rgd gate status`, FSM `gates.<gate-id>.*`).
+1. [ ] Document producer procedure(s) (`rgd gate record <gate-id>` after verification) and consumer(s) (`rgd gate status`, FSM `gates.<gate-id>.*`). On-disk files: `.reinguard/local/gates/<gate-id>.json` (gitignored).
 2. [ ] Update ADR-0014 extension contract if semantics are new or changed.
 3. [ ] Update `.reinguard/control/states/*.yaml` / `routes/*.yaml` if FSM rules reference `gates.<gate-id>`.
 4. [ ] Update ADR-0013 § State catalog / Adapter mapping if a new `state_id` or mapping is introduced.

--- a/.reinguard/policy/coding--preflight.md
+++ b/.reinguard/policy/coding--preflight.md
@@ -20,7 +20,7 @@ etc.); details delegated to Knowledge documents where noted.
 
 Run the applicable subset before each push:
 
-- **Go code changed**: `bash .reinguard/scripts/with-repo-local-state.sh -- go test ./... -race`, same wrapper for `go vet ./...` and `golangci-lint run` (keeps caches under repo-local `.tmp/`)
+- **Go code changed**: `bash .reinguard/scripts/with-repo-local-state.sh -- go test ./... -race`, same wrapper for `go vet ./...` and `golangci-lint run` (keeps caches under repo-local `/.tmp/`, not under `.reinguard/local/`)
 - **Markdown changed**: `bash .reinguard/scripts/with-repo-local-state.sh -- pre-commit run markdownlint-cli2 --all-files` (pinned hook version from `.pre-commit-config.yaml`; no ad-hoc `npx @latest` installs)
 - **Config / schemas / knowledge changed**: `rgd config validate` from repo root
 

--- a/.reinguard/policy/cursor-sandbox.md
+++ b/.reinguard/policy/cursor-sandbox.md
@@ -18,7 +18,7 @@ This policy applies to **committed** `.cursor/sandbox.json` at the repository ro
 - Do **not** commit user-specific absolute paths (e.g. `/home/<user>/...`).
 - **`additionalReadwritePaths`:** may include a **workspace-relative** path such as `".tmp"` so the agent sandbox explicitly allows writes under the gitignored local state root (pre-commit, golangci-lint, Go build cache, and CodeRabbit CLI state when routed there via `with-repo-local-state.sh`). Machine-specific home paths belong in user-level `~/.cursor/sandbox.json`, not in the repo.
 - **`networkPolicy.allow`:** may list **portable** hostnames needed for local verification in this repo (for example `api.github.com`, `github.com`, Go module hosts, and CodeRabbit CLI endpoints). WebSocket/proxy limits can still block the CodeRabbit CLI inside the sandbox even when hosts are allowed; see `review--local-coderabbit-cli.md`.
-- Prefer repo-local writable state under `.tmp/` (workspace-relative) for local verification commands (for example via `.reinguard/scripts/with-repo-local-state.sh`) instead of depending on user-home cache paths.
+- Prefer repo-local writable state under `.tmp/` (workspace-relative) for local verification commands (for example via `.reinguard/scripts/with-repo-local-state.sh`) instead of depending on user-home cache paths. The same root may also hold Adapter-local execution continuity artifacts such as the `rgd-next` resume contract (ADR-0015).
 
 ## User-level overrides
 

--- a/.reinguard/policy/cursor-sandbox.md
+++ b/.reinguard/policy/cursor-sandbox.md
@@ -16,9 +16,9 @@ This policy applies to **committed** `.cursor/sandbox.json` at the repository ro
 
 - Keep **only** repository-safe, machine-independent settings.
 - Do **not** commit user-specific absolute paths (e.g. `/home/<user>/...`).
-- **`additionalReadwritePaths`:** may include a **workspace-relative** path such as `".tmp"` so the agent sandbox explicitly allows writes under the gitignored local state root (pre-commit, golangci-lint, Go build cache, and CodeRabbit CLI state when routed there via `with-repo-local-state.sh`). Machine-specific home paths belong in user-level `~/.cursor/sandbox.json`, not in the repo.
+- **`additionalReadwritePaths`:** may include workspace-relative paths such as `".tmp"` (tool caches: pre-commit, golangci-lint, Go build cache, CodeRabbit CLI when routed via `with-repo-local-state.sh`) and `".reinguard/local"` (gitignored substrate gates, Adapter resume, scratch). Machine-specific home paths belong in user-level `~/.cursor/sandbox.json`, not in the repo.
 - **`networkPolicy.allow`:** may list **portable** hostnames needed for local verification in this repo (for example `api.github.com`, `github.com`, Go module hosts, and CodeRabbit CLI endpoints). WebSocket/proxy limits can still block the CodeRabbit CLI inside the sandbox even when hosts are allowed; see `review--local-coderabbit-cli.md`.
-- Prefer repo-local writable state under `.tmp/` (workspace-relative) for local verification commands (for example via `.reinguard/scripts/with-repo-local-state.sh`) instead of depending on user-home cache paths. The same root may also hold Adapter-local execution continuity artifacts such as the `rgd-next` resume contract (ADR-0015).
+- Prefer repo-local writable caches under `/.tmp/` (workspace-relative) for local verification commands (for example via `.reinguard/scripts/with-repo-local-state.sh`) instead of depending on user-home cache paths. Reinguard-owned local state (gates, Adapter resume) lives under `/.reinguard/local/` (see ADR-0011, ADR-0014, ADR-0015).
 
 ## User-level overrides
 

--- a/.reinguard/procedure/change-inspect.md
+++ b/.reinguard/procedure/change-inspect.md
@@ -99,7 +99,8 @@ the script prints **stderr heartbeats** every **30 seconds** and enforces a
 `review--local-coderabbit-cli.md`). Do not kill the subprocess unless you have
 positive evidence of a crash or hang **beyond** that supervisor limit, or that
 the process exited, crashed, or violated the documented retry contract.
-If the branch uses a runtime verification gate such as `local-verification`,
+If the branch uses a runtime verification gate such as `local-verification`
+(artifacts under `.reinguard/local/gates/` per ADR-0014),
 record or refresh it on the reviewed head after the required local checks
 pass, for example:
 
@@ -142,7 +143,7 @@ If review closure is not yet complete for the current local review cycle:
 3. Re-run applicable preflight steps (`go test`, `go vet`, `golangci-lint`, `bash .reinguard/scripts/with-repo-local-state.sh -- pre-commit run markdownlint-cli2 --all-files`)
 4. Commit the stabilized batch with `Refs: #<issue>`
 5. Re-run `bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- bash .reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit` on the stabilized head
-6. Re-record the runtime gate for the stabilized head when this branch uses one (for example `rgd gate record --status pass local-verification`)
+6. Re-record the gate artifact for the stabilized head when this branch uses one (for example `rgd gate record --status pass local-verification`; files under `.reinguard/local/gates/`)
 7. Re-run inspection (go to step 2) until every finding in the current local review cycle is classified and closed per the shared policy
 
 If a finding is dispositioned **Acknowledged**, record the follow-up Issue
@@ -153,7 +154,7 @@ PR handoff is auditable.
 
 When inspection shows review closure complete for the current local review
 cycle, including local CodeRabbit findings on the latest head: record or
-refresh the runtime gate that proves the branch is ready for PR creation on
+refresh the gate artifact (`.reinguard/local/gates/`) that proves the branch is ready for PR creation on
 the inspected HEAD, for example:
 
 ```bash

--- a/.reinguard/procedure/implement.md
+++ b/.reinguard/procedure/implement.md
@@ -80,7 +80,7 @@ rgd observe
 5. Same-kind sweep per coding--standards § Change scope before hand-off.
 6. **Preflight** per `coding--preflight.md` before commit/push.
 7. **Commit organization**: review the commit history (`git log origin/main..HEAD`) and organize into logical, self-contained commits where needed (interactive rebase, amend, or squash). Each commit should represent one coherent change. This step is the primary location for commit restructuring — `change-inspect` may *recommend* restructuring but does not execute it.
-8. When the branch passes local verification, commit organization is final, and the repository defines a runtime gate for it, record the result with `rgd gate record --status <pass|fail> <gate-id>` (for example `rgd gate record --status pass local-verification`) so future state rules can observe the verified handoff. If Step 7 rewrites history afterward, re-run this step on the new HEAD.
+8. When the branch passes local verification, commit organization is final, and the repository defines a runtime gate for it, record the result with `rgd gate record --status <pass|fail> <gate-id>` (for example `rgd gate record --status pass local-verification`) so future state rules can observe the verified handoff; artifacts live under `.reinguard/local/gates/` (ADR-0014). If Step 7 rewrites history afterward, re-run this step on the new HEAD.
 
 ## Output
 

--- a/.reinguard/procedure/next-orchestration.md
+++ b/.reinguard/procedure/next-orchestration.md
@@ -56,6 +56,11 @@ Before the approval gate, present:
 
 ## Approval gate
 
+The Adapter may persist a **`pending_approval`** artifact before this gate and
+transition it to **`active`** after explicit approval (ADR-0015; see
+[`.cursor/commands/rgd-next.md`](../../.cursor/commands/rgd-next.md) § Propose /
+§ Execute).
+
 Present **once**:
 
 - (a) **Unit identity** — Issue #, PR # (if any), branch name.
@@ -79,6 +84,11 @@ After approval, the agent **must** drive toward **Per-unit Definition of Done** 
 - **Hard Stops** (**HS-***) in [`../policy/safety--agent-invariants.md`](../policy/safety--agent-invariants.md).
 - **Genuine cannot proceed** — missing credentials, org enforcement, unrecoverable GitHub block — report with **evidence** and stop.
 - **Tooling / session limits** — chat session ended, tooling unavailable, or context limits make further tool use impossible **in this session**. Long CI or bot duration is **not** an excuse to exit the path; follow the mapped procedure. On tooling/session limits only, **resume the same approved path** on the next turn **without** re-opening the approval gate (unless the user revokes or changes scope).
+
+Adapters may persist this approval continuity locally so the next turn can
+resume the same approved path. Such persistence is **Adapter-local** and must
+not be promoted into substrate workflow state, routes, guards, or
+`gates.<id>.*` signals (ADR-0015).
 
 ## Loop semantics (after approval)
 

--- a/.reinguard/procedure/review-address.md
+++ b/.reinguard/procedure/review-address.md
@@ -58,7 +58,10 @@ rgd observe github reviews
 
 Use aggregate review / CI signals from observation JSON where helpful.
 
-**Thread-level work:** `rgd observe github reviews` does not replace per-thread `isResolved` enumeration — use `gh api` / GraphQL per knowledge from `rgd context build` / `knowledge.entries` (or the optional `knowledge pack --observation-file … --query "review"` pass) (see `review--github-thread-api.md`).
+**Thread-level work:** prefer the structured `signals.github.reviews.review_inbox`
+from `rgd observe github reviews` / `rgd context build` for actionable thread
+records. Use GraphQL enumeration from review knowledge only as a fallback when
+you need evidence outside the surfaced inbox (see `review--github-thread-api.md`).
 
 **When `state_id` is `waiting_ci` (`user-wait-ci`):** no open thread or formal changes-request work is implied by the FSM. Focus on **`gh pr checks`**, **`ci-pass`**, and mergeability (`gh pr view`); fix failing jobs or wait for pending checks. Re-run `rgd context build` after pushes.
 
@@ -66,7 +69,7 @@ Use aggregate review / CI signals from observation JSON where helpful.
 
 - GitHub **Files changed** → each review thread; root comment **CodeRabbit**, **Codex / chatgpt-codex-connector**, or human.
 - `gh pr view <N> --comments` and `gh pr checks <N>` — failing checks vs review findings.
-- Inline threads: `gh api repos/{owner}/{repo}/pulls/<N>/comments` until `rgd observe` covers this workflow.
+- Inline threads: prefer `review_inbox` + `rgd review reply-thread` / `rgd review resolve-thread`; fall back to raw `gh api` only for cases not yet covered.
 - **Outside diff range / non-inline bot findings** — per review knowledge from context / pack: do **not** treat "zero unresolved threads" as "no review work left." Collect summary bodies, PR conversation, Checks text. Classify and disposition like inline threads; without comment id, post a **PR conversation comment** (quote + disposition), then `@coderabbitai review` when budget/rules allow.
 
 ## Act
@@ -123,13 +126,13 @@ never `Tracked in` the PR’s `Closes` target).
 
 ### 3. Reply on every thread and disposition every non-thread finding
 
-For each **pull review comment** (file/line thread), post a disposition reply (**Fixed** / **By design** / **False positive** / **Acknowledged**) as a **threaded reply** (`gh api POST repos/{owner}/{repo}/pulls/<N>/comments` with `in_reply_to=<root_comment_database_id>`).
+For each **pull review comment** (file/line thread), post a disposition reply (**Fixed** / **By design** / **False positive** / **Acknowledged**) as a **threaded reply**. Prefer `rgd review reply-thread --pr <N> --in-reply-to <root_comment_id> --commit-sha <sha> --path <file> --line <line> --body-file <reply.md>` using the anchor fields surfaced in `review_inbox`.
 A generic PR body or issue-style comment **does not** substitute for a thread reply.
 For **outside-diff / summary-only** findings (see Context) with no anchor id, a **targeted PR conversation comment** (quote + disposition) is the correct substitute — not silence. Outside-diff-range findings from the current review cycle MUST be dispositioned even if the code predates this PR (`HS-NO-DISMISS`). See `review--consensus-protocol.md` § **Non-thread findings**.
 
 ### 4. CodeRabbit threads
 
-Follow [`../policy/review--consensus-protocol.md`](../policy/review--consensus-protocol.md) § **CodeRabbit Resolution Gate** (do **not** `resolve` until consensus evidence). After you push fixes, **incremental auto-review** often runs on its own (`.coderabbit.yaml`). If it does not (pause threshold, skip, or you need a guaranteed pass), trigger a new review cycle with a **PR conversation comment**:
+Follow [`../policy/review--consensus-protocol.md`](../policy/review--consensus-protocol.md) § **CodeRabbit Resolution Gate** (do **not** `resolve` until consensus evidence). When consensus is satisfied, prefer `rgd review resolve-thread --thread-id <thread_id>` using the `review_inbox` record. After you push fixes, **incremental auto-review** often runs on its own (`.coderabbit.yaml`). If it does not (pause threshold, skip, or you need a guaranteed pass), trigger a new review cycle with a **PR conversation comment**:
 `gh pr comment <N> --body "@coderabbitai review"`
 (budget and skip rules: paths from `knowledge.entries` after `rgd context build`, or optional `knowledge pack --observation-file … --query "review"`.)
 

--- a/.reinguard/scripts/adapter-rgd-next-resume.sh
+++ b/.reinguard/scripts/adapter-rgd-next-resume.sh
@@ -49,6 +49,14 @@ require_positive_integer() {
   fi
 }
 
+ensure_artifact_branch_matches_current() {
+  local cur
+  cur="$(current_branch)"
+  [[ -n "$cur" ]] || fail_with "current branch is unavailable (detached HEAD)" 2
+  [[ -n "$artifact_branch" ]] || fail_with "artifact has no branch" 2
+  [[ "$artifact_branch" == "$cur" ]] || fail_with "artifact belongs to branch '$artifact_branch' (current: '$cur')" 2
+}
+
 load_artifact() {
   local raw last_iteration terminal
   raw="$(<"$ARTIFACT_PATH")"
@@ -281,6 +289,7 @@ start_cmd() {
 approve_cmd() {
   require_file "$ARTIFACT_PATH" "resume artifact is missing; start must run before approve" 2
   load_artifact
+  ensure_artifact_branch_matches_current
   [[ "$artifact_status" == "pending_approval" ]] || fail_with "approve requires status pending_approval (got $artifact_status)" 2
   local now
   now="$(json_now_utc)"
@@ -314,6 +323,7 @@ update_cmd() {
   [[ -n "$state_id" ]] || fail_with "--state-id is required for update" 2
   require_file "$ARTIFACT_PATH" "resume artifact is missing; start must run before update" 2
   load_artifact
+  ensure_artifact_branch_matches_current
   [[ "$artifact_status" == "active" ]] || fail_with "only an active artifact can be updated" 2
 
   artifact_last_state="$state_id"
@@ -364,6 +374,7 @@ finish_cmd() {
 
   require_file "$ARTIFACT_PATH" "resume artifact is missing; start must run before finish" 2
   load_artifact
+  ensure_artifact_branch_matches_current
   artifact_status="$status"
   artifact_terminal_reason="$reason"
   artifact_terminal_summary="$summary"
@@ -414,9 +425,15 @@ status_cmd() {
     emit_status_json "invalid" "false" "unexpected artifact_type or command"
     return 0
   fi
-  if [[ ( "$artifact_status" == "active" || "$artifact_status" == "pending_approval" ) && -n "$artifact_branch" && -n "$current" && "$artifact_branch" != "$current" ]]; then
-    emit_status_json "stale" "false" "branch mismatch"
-    return 0
+  if [[ ( "$artifact_status" == "active" || "$artifact_status" == "pending_approval" ) && -n "$artifact_branch" ]]; then
+    if [[ -z "$current" ]]; then
+      emit_status_json "stale" "false" "detached HEAD"
+      return 0
+    fi
+    if [[ "$artifact_branch" != "$current" ]]; then
+      emit_status_json "stale" "false" "branch mismatch"
+      return 0
+    fi
   fi
   if [[ "$artifact_status" == "active" ]]; then
     emit_status_json "$artifact_status" "true"

--- a/.reinguard/scripts/adapter-rgd-next-resume.sh
+++ b/.reinguard/scripts/adapter-rgd-next-resume.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.reinguard/scripts/lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source=.reinguard/scripts/lib/json_minimal.sh
+source "$SCRIPT_DIR/lib/json_minimal.sh"
+
+SCRIPT_NAME="adapter-rgd-next-resume.sh"
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  fail_with "$SCRIPT_NAME must run inside a Git repository." 2
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+STATE_ROOT="${REINGUARD_LOCAL_STATE_ROOT:-$REPO_ROOT/.tmp}"
+ARTIFACT_DIR="$STATE_ROOT/adapter/rgd-next"
+ARTIFACT_PATH="$ARTIFACT_DIR/execute-resume.json"
+
+artifact_branch=""
+artifact_created_at=""
+artifact_updated_at=""
+artifact_approval_at=""
+artifact_status=""
+artifact_issue=""
+artifact_pr=""
+artifact_summary=""
+artifact_last_state=""
+artifact_last_route=""
+artifact_last_recorded_at=""
+artifact_terminal_reason=""
+artifact_terminal_summary=""
+artifact_terminal_recorded_at=""
+
+current_branch() {
+  local branch
+  branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  printf '%s' "$branch"
+}
+
+require_positive_integer() {
+  local flag="$1"
+  local value="$2"
+  if [[ ! $value =~ ^[0-9]+$ ]] || (( value <= 0 )); then
+    fail_with "$flag must be a positive integer" 2
+  fi
+}
+
+load_artifact() {
+  local raw last_iteration terminal
+  raw="$(<"$ARTIFACT_PATH")"
+
+  artifact_branch="$(json_get_string "$raw" "branch")"
+  artifact_created_at="$(json_get_string "$raw" "created_at")"
+  artifact_updated_at="$(json_get_string "$raw" "updated_at")"
+  artifact_approval_at="$(json_get_string "$raw" "approval_recorded_at")"
+  artifact_status="$(json_get_string "$raw" "status")"
+  artifact_issue="$(json_get_number "$raw" "issue_number")"
+  artifact_pr="$(json_get_number "$raw" "pr_number")"
+  artifact_summary="$(json_get_string "$raw" "summary")"
+
+  last_iteration="$(json_get_block "$raw" "last_iteration")"
+  artifact_last_state="$(json_get_string "$last_iteration" "state_id")"
+  artifact_last_route="$(json_get_string "$last_iteration" "route_id")"
+  artifact_last_recorded_at="$(json_get_string "$last_iteration" "recorded_at")"
+
+  terminal="$(json_get_block "$raw" "terminal")"
+  artifact_terminal_reason="$(json_get_string "$terminal" "reason")"
+  artifact_terminal_summary="$(json_get_string "$terminal" "summary")"
+  artifact_terminal_recorded_at="$(json_get_string "$terminal" "recorded_at")"
+}
+
+write_artifact_file() {
+  mkdir -p "$ARTIFACT_DIR"
+  {
+    printf '{\n'
+    printf '  "schema_version": "1",\n'
+    printf '  "artifact_type": "adapter_rgd_next_resume",\n'
+    printf '  "command": "rgd-next",\n'
+    printf '  "status": "%s",\n' "$(json_escape "$artifact_status")"
+    printf '  "branch": "%s",\n' "$(json_escape "$artifact_branch")"
+    printf '  "approval_recorded_at": "%s",\n' "$(json_escape "$artifact_approval_at")"
+    printf '  "created_at": "%s",\n' "$(json_escape "$artifact_created_at")"
+    if [[ -n "$artifact_issue" ]]; then
+      printf '  "issue_number": %s,\n' "$artifact_issue"
+    fi
+    if [[ -n "$artifact_pr" ]]; then
+      printf '  "pr_number": %s,\n' "$artifact_pr"
+    fi
+    if [[ -n "$artifact_summary" ]]; then
+      printf '  "summary": "%s",\n' "$(json_escape "$artifact_summary")"
+    fi
+    printf '  "updated_at": "%s"' "$(json_escape "$artifact_updated_at")"
+    if [[ -n "$artifact_last_state" || -n "$artifact_terminal_reason" ]]; then
+      printf ',\n'
+    else
+      printf '\n'
+    fi
+    if [[ -n "$artifact_last_state" ]]; then
+      printf '  "last_iteration": {\n'
+      printf '    "state_id": "%s",\n' "$(json_escape "$artifact_last_state")"
+      if [[ -n "$artifact_last_route" ]]; then
+        printf '    "route_id": "%s",\n' "$(json_escape "$artifact_last_route")"
+      fi
+      printf '    "recorded_at": "%s"\n' "$(json_escape "$artifact_last_recorded_at")"
+      printf '  }'
+      if [[ -n "$artifact_terminal_reason" ]]; then
+        printf ',\n'
+      else
+        printf '\n'
+      fi
+    fi
+    if [[ -n "$artifact_terminal_reason" ]]; then
+      printf '  "terminal": {\n'
+      printf '    "reason": "%s",\n' "$(json_escape "$artifact_terminal_reason")"
+      if [[ -n "$artifact_terminal_summary" ]]; then
+        printf '    "summary": "%s",\n' "$(json_escape "$artifact_terminal_summary")"
+      fi
+      printf '    "recorded_at": "%s"\n' "$(json_escape "$artifact_terminal_recorded_at")"
+      printf '  }\n'
+    fi
+    printf '}\n'
+  } >"$ARTIFACT_PATH"
+}
+
+emit_status_json() {
+  local status="$1"
+  local resume_eligible="$2"
+  local reason="${3:-}"
+  local current
+  current="$(current_branch)"
+
+  {
+    printf '{\n'
+    printf '  "artifact_path": "%s",\n' "$(json_escape "$ARTIFACT_PATH")"
+    printf '  "current_branch": "%s",\n' "$(json_escape "$current")"
+    printf '  "status": "%s",\n' "$(json_escape "$status")"
+    printf '  "resume_eligible": %s' "$resume_eligible"
+    if [[ -n "$reason" || -n "$artifact_branch" || -n "$artifact_issue" || -n "$artifact_pr" || -n "$artifact_summary" || -n "$artifact_approval_at" || -n "$artifact_created_at" || -n "$artifact_updated_at" || -n "$artifact_last_state" || -n "$artifact_terminal_reason" ]]; then
+      printf ',\n'
+    else
+      printf '\n'
+    fi
+    if [[ -n "$reason" ]]; then
+      printf '  "reason": "%s"' "$(json_escape "$reason")"
+      if [[ -n "$artifact_branch" || -n "$artifact_issue" || -n "$artifact_pr" || -n "$artifact_summary" || -n "$artifact_approval_at" || -n "$artifact_created_at" || -n "$artifact_updated_at" || -n "$artifact_last_state" || -n "$artifact_terminal_reason" ]]; then
+        printf ',\n'
+      else
+        printf '\n'
+      fi
+    fi
+    if [[ -n "$artifact_branch" ]]; then
+      printf '  "branch": "%s",\n' "$(json_escape "$artifact_branch")"
+    fi
+    if [[ -n "$artifact_issue" ]]; then
+      printf '  "issue_number": %s,\n' "$artifact_issue"
+    fi
+    if [[ -n "$artifact_pr" ]]; then
+      printf '  "pr_number": %s,\n' "$artifact_pr"
+    fi
+    if [[ -n "$artifact_summary" ]]; then
+      printf '  "summary": "%s",\n' "$(json_escape "$artifact_summary")"
+    fi
+    if [[ -n "$artifact_approval_at" ]]; then
+      printf '  "approval_recorded_at": "%s",\n' "$(json_escape "$artifact_approval_at")"
+    fi
+    if [[ -n "$artifact_created_at" ]]; then
+      printf '  "created_at": "%s",\n' "$(json_escape "$artifact_created_at")"
+    fi
+    if [[ -n "$artifact_updated_at" ]]; then
+      printf '  "updated_at": "%s"' "$(json_escape "$artifact_updated_at")"
+      if [[ -n "$artifact_last_state" || -n "$artifact_terminal_reason" ]]; then
+        printf ',\n'
+      else
+        printf '\n'
+      fi
+    fi
+    if [[ -n "$artifact_last_state" ]]; then
+      printf '  "last_iteration": {\n'
+      printf '    "state_id": "%s",\n' "$(json_escape "$artifact_last_state")"
+      if [[ -n "$artifact_last_route" ]]; then
+        printf '    "route_id": "%s",\n' "$(json_escape "$artifact_last_route")"
+      fi
+      printf '    "recorded_at": "%s"\n' "$(json_escape "$artifact_last_recorded_at")"
+      printf '  }'
+      if [[ -n "$artifact_terminal_reason" ]]; then
+        printf ',\n'
+      else
+        printf '\n'
+      fi
+    fi
+    if [[ -n "$artifact_terminal_reason" ]]; then
+      printf '  "terminal": {\n'
+      printf '    "reason": "%s",\n' "$(json_escape "$artifact_terminal_reason")"
+      if [[ -n "$artifact_terminal_summary" ]]; then
+        printf '    "summary": "%s",\n' "$(json_escape "$artifact_terminal_summary")"
+      fi
+      printf '    "recorded_at": "%s"\n' "$(json_escape "$artifact_terminal_recorded_at")"
+      printf '  }\n'
+    fi
+    printf '}\n'
+  }
+}
+
+usage() {
+  cat <<EOF2
+Usage:
+  $SCRIPT_NAME start --branch BRANCH [--issue N] [--pr N] [--summary TEXT]
+  $SCRIPT_NAME approve
+  $SCRIPT_NAME update --state-id ID [--route-id ID]
+  $SCRIPT_NAME finish --status done|allowed_stop|revoked --reason REASON [--summary TEXT]
+  $SCRIPT_NAME status
+  $SCRIPT_NAME show
+  $SCRIPT_NAME clear
+
+Terminal reason enum:
+  dod_satisfied
+  hard_stop
+  cannot_proceed
+  tooling_session_limit
+  scope_revoked
+EOF2
+}
+
+start_cmd() {
+  local branch="" issue="" pr="" summary="" now
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --branch)
+        require_flag_value "--branch" "${2:-}" "--branch requires a non-empty branch name"
+        branch="$2"
+        shift 2
+        ;;
+      --issue)
+        require_flag_value "--issue" "${2:-}" "--issue requires a positive integer"
+        issue="$2"
+        shift 2
+        ;;
+      --pr)
+        require_flag_value "--pr" "${2:-}" "--pr requires a positive integer"
+        pr="$2"
+        shift 2
+        ;;
+      --summary)
+        require_flag_value "--summary" "${2:-}" "--summary requires a non-empty value"
+        summary="$2"
+        shift 2
+        ;;
+      *)
+        fail_with "unknown flag for start: $1" 2
+        ;;
+    esac
+  done
+
+  [[ -n "$branch" ]] || fail_with "--branch is required for start" 2
+  [[ -z "$issue" ]] || require_positive_integer "--issue" "$issue"
+  [[ -z "$pr" ]] || require_positive_integer "--pr" "$pr"
+
+  now="$(json_now_utc)"
+  artifact_branch="$branch"
+  artifact_status="pending_approval"
+  artifact_issue="$issue"
+  artifact_pr="$pr"
+  artifact_summary="$summary"
+  artifact_approval_at=""
+  artifact_created_at="$now"
+  artifact_updated_at="$now"
+  artifact_last_state=""
+  artifact_last_route=""
+  artifact_last_recorded_at=""
+  artifact_terminal_reason=""
+  artifact_terminal_summary=""
+  artifact_terminal_recorded_at=""
+  write_artifact_file
+  cat "$ARTIFACT_PATH"
+}
+
+approve_cmd() {
+  require_file "$ARTIFACT_PATH" "resume artifact is missing; start must run before approve" 2
+  load_artifact
+  [[ "$artifact_status" == "pending_approval" ]] || fail_with "approve requires status pending_approval (got $artifact_status)" 2
+  local now
+  now="$(json_now_utc)"
+  artifact_status="active"
+  artifact_approval_at="$now"
+  artifact_updated_at="$now"
+  write_artifact_file
+  cat "$ARTIFACT_PATH"
+}
+
+update_cmd() {
+  local state_id="" route_id=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --state-id)
+        require_flag_value "--state-id" "${2:-}" "--state-id requires a non-empty value"
+        state_id="$2"
+        shift 2
+        ;;
+      --route-id)
+        require_flag_value "--route-id" "${2:-}" "--route-id requires a non-empty value"
+        route_id="$2"
+        shift 2
+        ;;
+      *)
+        fail_with "unknown flag for update: $1" 2
+        ;;
+    esac
+  done
+
+  [[ -n "$state_id" ]] || fail_with "--state-id is required for update" 2
+  require_file "$ARTIFACT_PATH" "resume artifact is missing; start must run before update" 2
+  load_artifact
+  [[ "$artifact_status" == "active" ]] || fail_with "only an active artifact can be updated" 2
+
+  artifact_last_state="$state_id"
+  artifact_last_route="$route_id"
+  artifact_last_recorded_at="$(json_now_utc)"
+  artifact_updated_at="$artifact_last_recorded_at"
+  write_artifact_file
+  cat "$ARTIFACT_PATH"
+}
+
+finish_cmd() {
+  local status="" reason="" summary=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --status)
+        require_flag_value "--status" "${2:-}" "--status requires done, allowed_stop, or revoked"
+        status="$2"
+        shift 2
+        ;;
+      --reason)
+        require_flag_value "--reason" "${2:-}" "--reason requires a terminal reason value"
+        reason="$2"
+        shift 2
+        ;;
+      --summary)
+        require_flag_value "--summary" "${2:-}" "--summary requires a non-empty value"
+        summary="$2"
+        shift 2
+        ;;
+      *)
+        fail_with "unknown flag for finish: $1" 2
+        ;;
+    esac
+  done
+
+  [[ -n "$status" && -n "$reason" ]] || fail_with "--status and --reason are required for finish" 2
+  case "$status" in
+    done|allowed_stop|revoked) ;;
+    *) fail_with "--status must be one of done, allowed_stop, revoked" 2 ;;
+  esac
+  case "$reason" in
+    dod_satisfied|hard_stop|cannot_proceed|tooling_session_limit|scope_revoked) ;;
+    *) fail_with "--reason must be one of dod_satisfied, hard_stop, cannot_proceed, tooling_session_limit, scope_revoked" 2 ;;
+  esac
+  [[ "$status" != "done" || "$reason" == "dod_satisfied" ]] || fail_with "done status requires reason dod_satisfied" 2
+  [[ "$status" != "revoked" || "$reason" == "scope_revoked" ]] || fail_with "revoked status requires reason scope_revoked" 2
+  [[ "$status" != "allowed_stop" || ( "$reason" != "dod_satisfied" && "$reason" != "scope_revoked" ) ]] || fail_with "allowed_stop requires hard_stop, cannot_proceed, or tooling_session_limit" 2
+
+  require_file "$ARTIFACT_PATH" "resume artifact is missing; start must run before finish" 2
+  load_artifact
+  artifact_status="$status"
+  artifact_terminal_reason="$reason"
+  artifact_terminal_summary="$summary"
+  artifact_terminal_recorded_at="$(json_now_utc)"
+  artifact_updated_at="$artifact_terminal_recorded_at"
+  write_artifact_file
+  cat "$ARTIFACT_PATH"
+}
+
+status_cmd() {
+  local raw current
+  local -a missing=()
+  current="$(current_branch)"
+
+  artifact_branch=""
+  artifact_created_at=""
+  artifact_updated_at=""
+  artifact_approval_at=""
+  artifact_status=""
+  artifact_issue=""
+  artifact_pr=""
+  artifact_summary=""
+  artifact_last_state=""
+  artifact_last_route=""
+  artifact_last_recorded_at=""
+  artifact_terminal_reason=""
+  artifact_terminal_summary=""
+  artifact_terminal_recorded_at=""
+
+  if [[ ! -f "$ARTIFACT_PATH" ]]; then
+    emit_status_json "missing" "false"
+    return 0
+  fi
+
+  raw="$(<"$ARTIFACT_PATH")"
+  for key in schema_version artifact_type command status branch created_at updated_at; do
+    if ! json_has_key "$raw" "$key"; then
+      missing+=("$key")
+    fi
+  done
+  if (( ${#missing[@]} > 0 )); then
+    emit_status_json "invalid" "false" "missing required keys: $(IFS=', '; echo "${missing[*]}")"
+    return 0
+  fi
+
+  load_artifact
+  if [[ "$(json_get_string "$raw" "artifact_type")" != "adapter_rgd_next_resume" || "$(json_get_string "$raw" "command")" != "rgd-next" ]]; then
+    emit_status_json "invalid" "false" "unexpected artifact_type or command"
+    return 0
+  fi
+  if [[ ( "$artifact_status" == "active" || "$artifact_status" == "pending_approval" ) && -n "$artifact_branch" && -n "$current" && "$artifact_branch" != "$current" ]]; then
+    emit_status_json "stale" "false" "branch mismatch"
+    return 0
+  fi
+  if [[ "$artifact_status" == "active" ]]; then
+    emit_status_json "$artifact_status" "true"
+    return 0
+  fi
+  emit_status_json "$artifact_status" "false"
+}
+
+show_cmd() {
+  require_file "$ARTIFACT_PATH" "resume artifact is missing" 2
+  cat "$ARTIFACT_PATH"
+}
+
+clear_cmd() {
+  rm -f "$ARTIFACT_PATH"
+  printf '{\n  "artifact_path": "%s",\n  "status": "cleared"\n}\n' "$ARTIFACT_PATH"
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 2
+fi
+
+subcommand="$1"
+shift
+
+case "$subcommand" in
+  start)
+    start_cmd "$@"
+    ;;
+  approve)
+    approve_cmd "$@"
+    ;;
+  update)
+    update_cmd "$@"
+    ;;
+  finish)
+    finish_cmd "$@"
+    ;;
+  status)
+    status_cmd "$@"
+    ;;
+  show)
+    show_cmd "$@"
+    ;;
+  clear)
+    clear_cmd "$@"
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    fail_with "unknown subcommand: $subcommand" 2
+    ;;
+esac

--- a/.reinguard/scripts/adapter-rgd-next-resume.sh
+++ b/.reinguard/scripts/adapter-rgd-next-resume.sh
@@ -14,8 +14,10 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
 fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-STATE_ROOT="${REINGUARD_LOCAL_STATE_ROOT:-$REPO_ROOT/.tmp}"
-ARTIFACT_DIR="$STATE_ROOT/adapter/rgd-next"
+# Adapter-local state under .reinguard/local (not tool caches in .tmp/).
+# REINGUARD_LOCAL_DIR overrides the root (for tests); default is $REPO_ROOT/.reinguard/local
+LOCAL_ROOT="${REINGUARD_LOCAL_DIR:-$REPO_ROOT/.reinguard/local}"
+ARTIFACT_DIR="$LOCAL_ROOT/adapter/rgd-next"
 ARTIFACT_PATH="$ARTIFACT_DIR/execute-resume.json"
 
 artifact_branch=""

--- a/.reinguard/scripts/lib/json_minimal.sh
+++ b/.reinguard/scripts/lib/json_minimal.sh
@@ -4,8 +4,8 @@
 # Scope: controlled, repo-authored JSON (e.g. adapter resume artifacts).
 # Not a general JSON parser: nested objects in values, arbitrary nesting depth,
 # and non-string scalars beyond simple unsigned integers in known fields are
-# out of scope. json_get_block matches a single-level {...} body (no nested
-# braces inside the block).
+# out of scope. json_get_block matches a {...} object value with balanced braces
+# (strings may contain "}" when properly quoted).
 
 # shellcheck shell=bash
 
@@ -23,21 +23,124 @@ json_escape() {
   printf '%s' "$value"
 }
 
+# Decode a JSON string fragment that still contains JSON escape sequences
+# (e.g. \" \\ \n). Used after json_get_string's regex capture.
+json_unescape_string() {
+  local s="$1"
+  local out=""
+  local i=0
+  local len=${#s}
+  while (( i < len )); do
+    local c="${s:i:1}"
+    if [[ "$c" != '\' ]]; then
+      out+="$c"
+      ((i++))
+      continue
+    fi
+    if (( i + 1 >= len )); then
+      out+='\'
+      break
+    fi
+    local n="${s:i+1:1}"
+    case "$n" in
+      '"') out+='"'; ((i += 2));;
+      '\') out+='\'; ((i += 2));;
+      '/') out+='/'; ((i += 2));;
+      'b') out+=$'\b'; ((i += 2));;
+      'f') out+=$'\f'; ((i += 2));;
+      'n') out+=$'\n'; ((i += 2));;
+      'r') ((i += 2));;
+      't') out+=$'\t'; ((i += 2));;
+      'u')
+        # Minimal scope: preserve \uXXXX literally if present (rare in artifacts).
+        if (( i + 5 < len )); then
+          out+="${s:i:6}"
+          ((i += 6))
+        else
+          out+='\'
+          ((i++))
+        fi
+        ;;
+      *)
+        out+="$n"
+        ((i += 2));;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+# Find first occurrence of needle in raw; print start index or empty if missing.
+json_index_of() {
+  local raw="$1"
+  local needle="$2"
+  local nl=${#needle}
+  local i=0
+  local len=${#raw}
+  while (( i + nl <= len )); do
+    if [[ "${raw:i:nl}" == "$needle" ]]; then
+      printf '%d' "$i"
+      return 0
+    fi
+    ((i++))
+  done
+  return 1
+}
+
+# Extract inner content of first "key": { ... } with balanced braces.
 json_get_block() {
   local raw="$1"
   local key="$2"
-  local pattern="\"$key\"[[:space:]]*:[[:space:]]*\\{([^}]*)\\}"
-  if [[ $raw =~ $pattern ]]; then
-    printf '%s' "${BASH_REMATCH[1]}"
+  local needle="\"$key\""
+  local start
+  if ! start="$(json_index_of "$raw" "$needle")"; then
+    return 0
   fi
+  local pos=$((start + ${#needle}))
+  local rest="${raw:pos}"
+  if [[ ! "$rest" =~ ^[[:space:]]*:[[:space:]]*\{ ]]; then
+    return 0
+  fi
+  local matched="${BASH_REMATCH[0]}"
+  local brace_start=$((pos + ${#matched} - 1))
+  local i=$((brace_start + 1))
+  local depth=1
+  local len=${#raw}
+  local in_str=0
+  local esc=0
+  while (( i < len && depth > 0 )); do
+    local ch="${raw:i:1}"
+    if (( in_str )); then
+      if (( esc )); then
+        esc=0
+      elif [[ "$ch" == '\' ]]; then
+        esc=1
+      elif [[ "$ch" == '"' ]]; then
+        in_str=0
+      fi
+    else
+      if [[ "$ch" == '"' ]]; then
+        in_str=1
+      elif [[ "$ch" == '{' ]]; then
+        ((depth++))
+      elif [[ "$ch" == '}' ]]; then
+        ((depth--))
+      fi
+    fi
+    ((i++))
+  done
+  if (( depth != 0 )); then
+    return 0
+  fi
+  printf '%s' "${raw:brace_start+1:i-brace_start-2}"
 }
 
+# Returns the decoded JSON string value for key (JSON string escapes applied).
 json_get_string() {
   local raw="$1"
   local key="$2"
   local pattern="\"$key\"[[:space:]]*:[[:space:]]*\"(([^\"\\\\]|\\\\.)*)\""
   if [[ $raw =~ $pattern ]]; then
-    printf '%s' "${BASH_REMATCH[1]}"
+    json_unescape_string "${BASH_REMATCH[1]}"
   fi
 }
 

--- a/.reinguard/scripts/lib/json_minimal.sh
+++ b/.reinguard/scripts/lib/json_minimal.sh
@@ -19,6 +19,7 @@ json_escape() {
   value=${value//\"/\\\"}
   value=${value//$'\n'/\\n}
   value=${value//$'\r'/}
+  value=${value//$'\t'/\\t}
   printf '%s' "$value"
 }
 

--- a/.reinguard/scripts/lib/json_minimal.sh
+++ b/.reinguard/scripts/lib/json_minimal.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Minimal JSON string helpers for shell scripts.
+#
+# Scope: controlled, repo-authored JSON (e.g. adapter resume artifacts).
+# Not a general JSON parser: nested objects in values, arbitrary nesting depth,
+# and non-string scalars beyond simple unsigned integers in known fields are
+# out of scope. json_get_block matches a single-level {...} body (no nested
+# braces inside the block).
+
+# shellcheck shell=bash
+
+json_now_utc() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+json_escape() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/}
+  printf '%s' "$value"
+}
+
+json_get_block() {
+  local raw="$1"
+  local key="$2"
+  local pattern="\"$key\"[[:space:]]*:[[:space:]]*\\{([^}]*)\\}"
+  if [[ $raw =~ $pattern ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  fi
+}
+
+json_get_string() {
+  local raw="$1"
+  local key="$2"
+  local pattern="\"$key\"[[:space:]]*:[[:space:]]*\"(([^\"\\\\]|\\\\.)*)\""
+  if [[ $raw =~ $pattern ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  fi
+}
+
+json_get_number() {
+  local raw="$1"
+  local key="$2"
+  local pattern="\"$key\"[[:space:]]*:[[:space:]]*([0-9]+)"
+  if [[ $raw =~ $pattern ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  fi
+}
+
+json_has_key() {
+  local raw="$1"
+  local key="$2"
+  local pattern="\"$key\"[[:space:]]*:"
+  [[ $raw =~ $pattern ]]
+}

--- a/.reinguard/scripts/with-repo-local-state.sh
+++ b/.reinguard/scripts/with-repo-local-state.sh
@@ -40,7 +40,6 @@ mkdir -p \
   "$STATE_ROOT/go-build-cache" \
   "$STATE_ROOT/golangci-lint-cache"
 
-export REINGUARD_LOCAL_STATE_ROOT="$STATE_ROOT"
 # Do not set TMPDIR to a path under the repo root: Go's t.TempDir() would then
 # fall inside this git work tree and break tests that expect a non-git directory.
 export XDG_CACHE_HOME="$STATE_ROOT/xdg-cache"

--- a/docs/adr/0009-observation-engine-abstraction.md
+++ b/docs/adr/0009-observation-engine-abstraction.md
@@ -39,6 +39,11 @@ Adopt a **hybrid observation model**:
    state, post comments, or merge PRs. Parallel invocations are independent
    (ADR-0003).
 
+   Review-thread reply / resolve transport, when provided by `rgd`, lives in
+   a **separate explicit command namespace** outside `observe`. Those commands
+   may validate inputs and forward to `gh`, but they do not change the
+   side-effect-free contract of observation itself.
+
 4. **GitHub authentication** — GitHub-backed providers obtain credentials
    only via **`gh auth token`** (or documented equivalent invocation of
    the GitHub CLI), per ADR-0006. No parallel “env-only” token path in

--- a/docs/adr/0011-semantic-control-plane-structure.md
+++ b/docs/adr/0011-semantic-control-plane-structure.md
@@ -36,7 +36,7 @@ Without explicit structure:
      (`.cursor/commands/rgd-next.md`); `cursor-plan` handles deep planning via
      `CreatePlan` only, embedding Issue-creation steps when issue-first
      (`.cursor/commands/cursor-plan.md`).
-   - `runtime/` — **gitignored operational state** written by the Substrate
+   - `local/` — **gitignored operational state** written by the Substrate
      when a bounded runtime contract explicitly allows it (for example runtime
      gate artifacts; see ADR-0014). This directory is **not** Semantics
      content, is not indexed as knowledge, and is not part of control-rule
@@ -58,7 +58,7 @@ Without explicit structure:
    - Must be followed as a norm → `policy/`
    - State / route / guard meaning in match YAML → `control/`
    - Repeatable agent procedure bound to state/route → `procedure/`
-   - Substrate operational state under bounded contract → `runtime/`
+   - Substrate operational state under bounded contract → `local/`
    - Client-specific bridge only (no SSOT prose) → Adapter layer (`.cursor/`)
 
 5. **Adapter layer** — `.cursor/` remains thin: bridge files and commands
@@ -76,7 +76,16 @@ Without explicit structure:
 - **Harder**: Downstream repos that used `.reinguard/rules/` must migrate
   paths (breaking layout change for configuration discovery)
 - **Harder**: `.reinguard/` now contains both Semantics content and an explicit
-  gitignored runtime enclave; tooling and docs must keep that boundary clear
+  gitignored local-state enclave; tooling and docs must keep that boundary clear
+
+## Migration note
+
+The on-disk directory for substrate-owned gate artifacts was renamed from
+`runtime/` to `local/` so that reinguard-owned local state (gates, Adapter
+resume, scratch) lives under one gitignored tree (`.reinguard/local/`) and
+stays distinct from workspace-relative tool caches (`.tmp/`). Existing
+`.reinguard/runtime/gates/*.json` files are not read; re-record with
+`rgd gate record` after updating `rgd`.
 
 ## Refs
 

--- a/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
+++ b/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
@@ -35,7 +35,7 @@ wins** among matching rules (ADR-0004). `state_id` values:
 | `merge_ready` | Coarse merge gate (clean tree, CI, threads, decisions) | Aligns with `merge-readiness` guard signals |
 | `waiting_ci` | PR open; no thread/decision work; CI or mergeability not satisfied | Threads 0, changes 0, working tree clean; `ci_status` != `success` **or** `merge_state_status` != `clean` |
 | `pr_open` | PR exists; residual (e.g. dirty working tree) | `github.pull_requests.pr_exists_for_branch` true |
-| `ready_for_pr` | No PR exists, and `pr-readiness` is fresh and passing | `pr_exists_for_branch` false (or missing) and `gates.pr-readiness.status == pass`; `pr-readiness` is the runtime gate recorded by `.reinguard/procedure/change-inspect.md` per ADR-0014, keeping PR readiness mechanically visible without a dedicated route vocabulary |
+| `ready_for_pr` | No PR exists, and `pr-readiness` is fresh and passing | `pr_exists_for_branch` false (or missing) and `gates.pr-readiness.status == pass`; `pr-readiness` is the runtime gate recorded by `.reinguard/procedure/change-inspect.md` per ADR-0014 (artifact under `.reinguard/local/gates/`), keeping PR readiness mechanically visible without a dedicated route vocabulary |
 | `working_no_pr` | No PR for branch (or PR facet absent); residual before PR readiness is proven | `pr_exists_for_branch` false or path missing, with `ready_for_pr` using a lower numeric `priority` than `working_no_pr` so it wins when the gate condition matches |
 
 **Bot status tiers** (per-element `status` in `bot_reviewer_status`):

--- a/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
+++ b/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
@@ -137,6 +137,11 @@ When adding or changing FSM wiring, keep these touchpoints consistent:
 
 **Guards vs states:** `guard eval` outputs (e.g. built-in `merge-readiness`) are **not** `state_id` values. FSM states may *align* with guard signals (e.g. `merge_ready` with merge-readiness); wiring belongs in `control/states/*.yaml` and this ADR, not by conflating guard JSON with state without explicit rules.
 
+**Adapter-local resume artifacts:** approval continuity for an already approved
+Execute path (ADR-0015) is **not** a workflow state. Do not model it as a new
+`state_id`, `route_id`, guard input, or `gates.<id>` signal. The FSM continues
+to describe repository / platform workflow position only.
+
 Operational checklist (files, validation commands, knowledge surfacing): see `.reinguard/knowledge/workflow--state-gate-guard-extension.md` (ADR-0010 knowledge atom).
 
 ## Consequences

--- a/docs/adr/0014-runtime-gate-artifacts.md
+++ b/docs/adr/0014-runtime-gate-artifacts.md
@@ -18,7 +18,7 @@ but it must not become a workflow brain or execute arbitrary repository scripts.
 
 ## Decision
 
-1. Introduce **runtime gate artifacts** under `.reinguard/runtime/gates/`.
+1. Introduce **runtime gate artifacts** under `.reinguard/local/gates/`.
    These are **gitignored, substrate-owned operational state**, not Semantics
    documents.
 2. Add `rgd gate` commands:
@@ -47,7 +47,7 @@ but it must not become a workflow brain or execute arbitrary repository scripts.
 
 When adding or changing a **runtime gate** (`gate_id`):
 
-1. **Semantics** — Document the gate’s purpose; **producer** procedure(s) that run `rgd gate record <gate-id>` after local verification; **consumer** procedure(s) or FSM rules that read `gates.<gate-id>.*` (e.g. `status`, `head_sha`). Keep recording out of versioned Semantics; artifacts stay under `.reinguard/runtime/gates/` (gitignored).
+1. **Semantics** — Document the gate’s purpose; **producer** procedure(s) that run `rgd gate record <gate-id>` after local verification; **consumer** procedure(s) or FSM rules that read `gates.<gate-id>.*` (e.g. `status`, `head_sha`). Keep recording out of versioned Semantics; artifacts stay under `.reinguard/local/gates/` (gitignored).
 2. **FSM** — If `state eval` or `route select` references `gates.<gate-id>`, update `.reinguard/control/states/*.yaml` and/or `.reinguard/control/routes/*.yaml` and **ADR-0013** (state catalog and Adapter mapping).
 3. **Freshness** — Procedures must treat `rgd gate status` outcomes per Decision §4: `stale` / `missing` / `invalid` are not proof of the current HEAD; consumers return to the producer procedure or re-verify before proceeding.
 4. **Schema** — Artifacts validate against the embedded gate schema; new top-level fields require ADR-0008 / schema versioning, not ad-hoc files.
@@ -56,6 +56,13 @@ When adding or changing a **runtime gate** (`gate_id`):
 `rgd` still does not execute gate verification commands; recording remains procedure-owned.
 
 Operational checklist: `.reinguard/knowledge/workflow--state-gate-guard-extension.md`.
+
+## Migration note
+
+Gate files on disk moved from `.reinguard/runtime/gates/` to
+`.reinguard/local/gates/` (breaking). Rationale: consolidate reinguard-owned
+local state under `.reinguard/local/` and reserve `/.tmp/` for tool caches only.
+Re-run `rgd gate record <gate-id>` on the current HEAD after upgrading `rgd`.
 
 ## Consequences
 

--- a/docs/adr/0015-adapter-local-execute-resume.md
+++ b/docs/adr/0015-adapter-local-execute-resume.md
@@ -29,9 +29,9 @@ orchestration state, not repository workflow position.
 ## Decision
 
 1. Introduce an **Adapter-local execute resume artifact** for `rgd-next`.
-2. The artifact lives under the repo-local temporary state root (`.tmp/`
-   by default, or `REINGUARD_LOCAL_STATE_ROOT` when set by
-   `with-repo-local-state.sh`).
+2. The artifact lives under `.reinguard/local/adapter/rgd-next/` (gitignored).
+   Optional override: set `REINGUARD_LOCAL_DIR` to the desired `.reinguard/local`
+   equivalent root (for example in tests).
 3. The artifact is **Adapter-owned**, not substrate-owned:
    - it must not be merged into `rgd context build`
    - it must not become `gates.<id>.*`
@@ -54,6 +54,13 @@ orchestration state, not repository workflow position.
 6. Terminality remains evidence-based per `next-orchestration.md`. The
    artifact is a durable record of the Adapter contract, not an authority
    that overrides procedure semantics.
+
+## Migration note
+
+Previously the resume file defaulted under `.tmp/adapter/rgd-next/` (and
+`REINGUARD_LOCAL_STATE_ROOT` from `with-repo-local-state.sh`). It now defaults
+to `.reinguard/local/adapter/rgd-next/execute-resume.json` so Adapter state is
+not mixed with workspace tool caches under `/.tmp/`.
 
 ## Consequences
 

--- a/docs/adr/0015-adapter-local-execute-resume.md
+++ b/docs/adr/0015-adapter-local-execute-resume.md
@@ -1,0 +1,77 @@
+# ADR-0015: Adapter-local execute resume artifact
+
+## Status
+
+Accepted.
+
+## Context
+
+`rgd-next` Execute has a single approval gate, then must continue to
+Per-unit Definition of Done unless an allowed stop applies. In practice,
+an Adapter session may still end mid-run because of chat turn boundaries,
+tool/session limits, or an implementation bug that emits a non-terminal
+summary.
+
+The system needs a durable way to recognize "this approved Execute path is
+still active" on the next Adapter turn. At the same time, reinguard must
+preserve the substrate boundary from ADR-0001 and ADR-0003:
+
+- `rgd` computes repository and platform workflow position.
+- `rgd` remains pull-based and stateless across invocations.
+- Client-specific execution continuity must not become a new substrate
+  workflow state, route, or guard signal.
+
+ADR-0014 already permits bounded substrate-owned runtime artifacts for
+verification outcomes such as `pr-readiness`. That mechanism is not a fit
+for Execute continuity itself because approval continuity is Adapter-local
+orchestration state, not repository workflow position.
+
+## Decision
+
+1. Introduce an **Adapter-local execute resume artifact** for `rgd-next`.
+2. The artifact lives under the repo-local temporary state root (`.tmp/`
+   by default, or `REINGUARD_LOCAL_STATE_ROOT` when set by
+   `with-repo-local-state.sh`).
+3. The artifact is **Adapter-owned**, not substrate-owned:
+   - it must not be merged into `rgd context build`
+   - it must not become `gates.<id>.*`
+   - it must not define a new `state_id`, `route_id`, or guard input
+4. The artifact records only the minimum continuity contract needed to
+   resume an already approved Execute path:
+   - unit identity (branch, issue / PR when known)
+   - approval marker and timestamps (after the user approves Execute)
+   - current lifecycle status (`pending_approval`, `active`, `done`,
+     `allowed_stop`, `revoked`)
+   - last observed `state_id` / `route_id`
+   - terminal reason enum for non-active records
+5. An Adapter implementation (for example the Cursor chat Adapter) checks
+   this artifact **before** fresh `rgd-next` proposal logic. The Adapter may
+   create a `pending_approval` record **before** the approval gate so unit
+   identity is durable, then transition to `active` after approval. When the
+   artifact says an approved unit is still `active` and matches the current
+   branch, the Adapter resumes Execute instead of starting a new proposal
+   cycle.
+6. Terminality remains evidence-based per `next-orchestration.md`. The
+   artifact is a durable record of the Adapter contract, not an authority
+   that overrides procedure semantics.
+
+## Consequences
+
+- **Easier**: mid-run chat turns can resume the same approved path without
+  re-opening the approval gate
+- **Easier**: premature final responses become detectable as an
+  Adapter-contract mismatch
+- **Easier**: substrate boundaries stay intact because repo/platform state
+  still comes only from `rgd`
+- **Harder**: Adapter commands must explicitly record start / update /
+  terminal transitions
+- **Harder**: each Adapter must own its own persistence details instead of
+  delegating continuity to `rgd`
+
+## Refs
+
+- ADR-0001 (system positioning)
+- ADR-0003 (pull-based stateless invocation)
+- ADR-0011 (semantic control plane structure)
+- ADR-0013 (FSM workflow states and Adapter mapping)
+- ADR-0014 (runtime gate artifacts)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -118,9 +118,15 @@ Precedence:
 2. Otherwise `--branch` wins over the checked-out branch.
 3. Otherwise live observation uses the local checkout branch.
 
-When `--pr` is set without `--branch`, `signals.github.pull_requests.current_branch`
-tracks the PR head branch, while `observed_scope.local_branch_at_collect`
-preserves the local checkout branch that invoked `rgd`.
+If both `--pr` and `--branch` are set, `--branch` does **not** change PR-scoped
+facets: observation still follows the pull request `N` and its head ref. The
+CLI may still record `requested_branch` in `observed_scope` for visibility;
+effective branch and CI head follow the resolved PR.
+
+Whenever `--pr` is set, `signals.github.pull_requests.current_branch` tracks
+the PR head branch. `observed_scope.local_branch_at_collect` always records
+the local checkout at collect time (independent of `--branch` / `--pr`), so you
+can tell which working tree produced the run.
 
 `--branch` / `--pr` are **live-observe only**. They are rejected when
 `--observation-file` is set on higher-level commands (`state eval`,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -296,7 +296,7 @@ Committed workflow `state_id` priorities for this repository are documented in *
 - **stdin** JSON when `-` is passed as file (optional convention).
 - `--branch BRANCH` / `--pr N` use the same live GitHub scope rules as
   [`rgd observe`](#explicit-github-pr-scope) when `--observation-file` is not set.
-- Runtime gate statuses from `.reinguard/runtime/gates/*.json` are merged into
+- Runtime gate statuses from `.reinguard/local/gates/*.json` are merged into
   the evaluation signal map as `gates.<gate-id>.*` before state resolution.
 
 ### Output
@@ -323,7 +323,7 @@ Evaluates `type: route` rules using:
 - `--state-file` optional prior `state eval` JSON (merged into signals as `state` key)
 - `--branch BRANCH` / `--pr N` for live observation only (same precedence as
   [`rgd observe`](#explicit-github-pr-scope))
-- Runtime gate statuses from `.reinguard/runtime/gates/*.json` (merged as
+- Runtime gate statuses from `.reinguard/local/gates/*.json` (merged as
   `gates.<gate-id>.*` before route evaluation)
 
 ### Output
@@ -352,7 +352,7 @@ signal map as `gates.<gate-id>.*`.
 
 ## `rgd gate`
 
-Runtime gate artifacts live under `.reinguard/runtime/gates/` and are validated
+Runtime gate artifacts live under `.reinguard/local/gates/` and are validated
 against the embedded `gate-artifact.json` schema. These artifacts are
 **gitignored operational state**, not Semantics content.
 
@@ -538,7 +538,7 @@ present, against embedded JSON Schemas. Also **builds enabled observation provid
 errors. **Deprecated** configuration keys (marked in JSON Schema) emit **warnings
 on stderr** but still exit **0** when validation succeeds.
 
-`config validate` does **not** validate `.reinguard/runtime/`; runtime gate
+`config validate` does **not** validate `.reinguard/local/`; runtime gate
 artifacts use the dedicated `rgd gate` schema and commands instead.
 
 **`when` clauses (ADR-0002):** Control rules and knowledge manifest entries are checked with the same static validator: unknown `eval:` names, unknown `op` strings, missing required keys per `op` (e.g. `eq` needs `path` and `value`), `eval: constant` requires `params.value` (boolean), and `path` strings must use allowed roots (`git.`, `github.`, `state.`, `gates.`, or `$` / `$.` for nested quantifier clauses). Named evaluators: `rgd config validate` rejects unknown `eval:` names against the built-in registry. To list built-ins, call `evaluator.DefaultRegistry().ListRegistered()` from Go (sorted names), or see `internal/evaluator/`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -498,8 +498,8 @@ transport fields and shells out to `gh api`.
 | `--commit-sha` | yes | Full 40-character commit SHA |
 | `--path` | yes | Review comment file path |
 | `--line` | yes | Review comment line number |
-| `--body` | one of body/body-file | Inline reply body |
-| `--body-file` | one of body/body-file | File containing the reply body |
+| `--body` | mutually exclusive; one required | Inline reply body |
+| `--body-file` | mutually exclusive; one required | File containing the reply body |
 | `--cwd` | no | Working directory for `gh` |
 
 Payload matches the repository’s PR review transport contract:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -186,8 +186,8 @@ The **pull-requests** facet always includes REST-derived fields for the current 
 |-------|------|-------------|
 | `open_count` | number | Open PR count for the repo (REST search). |
 | `current_branch` | string | Effective branch used for PR observation. Defaults to the checked-out branch; with `--branch` (and no `--pr`), the requested branch; with `--pr` (regardless of `--branch`), the PR head branch. |
-| `pr_exists_for_branch` | boolean | Whether an open PR exists for the effective observed branch / explicit `--pr` target. |
-| `pr_number_for_branch` | number | Resolved PR number for the effective observed branch / explicit `--pr` target, or `0`. |
+| `pr_exists_for_branch` | boolean | Whether an open PR exists for the effective scope (resolved branch or explicit `--pr`). |
+| `pr_number_for_branch` | number | Resolved PR number for the effective scope, or `0`. |
 | `state` | string | GraphQL PR state lowercased: `open`, `closed`, `merged`. |
 | `draft` | boolean | Draft flag. |
 | `title` | string | PR title. |
@@ -224,7 +224,7 @@ Populated when the `reviews` facet runs (see `rgd observe github reviews`). Data
 | Field | Type | Description |
 |-------|------|-------------|
 | `local_branch_at_collect` | string | Checked-out local branch when the command ran (empty if detached). |
-| `selection` | string | Scope selection mode: `current_branch`, `explicit_branch`, `explicit_pr`, or `none`. |
+| `selection` | string | Scope selection mode: `current_branch`, `explicit_branch`, `explicit_pr`, or `none` when neither a local branch nor an explicit scope could drive PR observation. |
 | `requested_branch` | string | Explicit `--branch` value when provided. |
 | `requested_pr_number` | number | Explicit `--pr` value when provided. |
 | `effective_branch` | string | Branch that drove PR observation after precedence rules were applied. |
@@ -240,7 +240,6 @@ Each element of `review_inbox` represents one unresolved GitHub review thread.
 |-------|------|-------------|
 | `thread_id` | string | GraphQL review thread node id (`resolveReviewThread` input). |
 | `root_comment_id` | number | Root review comment database id (`in_reply_to` for REST replies). |
-| `is_resolved` | boolean | Thread resolution state from GraphQL. |
 | `is_outdated` | boolean | Thread outdated state from GraphQL. |
 | `body` | string | Root review comment body when available. |
 | `author` | string | Root review comment author login when available. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,8 @@ rgd guard eval <guard-id> [flags...]
 rgd knowledge index
 rgd knowledge pack [--query STRING] [--observation-file FILE]
 rgd context build [--observation-file FILE]
+rgd review reply-thread --pr N --in-reply-to ID --commit-sha SHA --path FILE --line N (--body TEXT | --body-file FILE)
+rgd review resolve-thread --thread-id ID
 rgd ensure-labels
 rgd labels list [--category TYPE]
 rgd labels sync [--dry-run]
@@ -100,6 +102,30 @@ Subcommands filter which facets run inside the GitHub provider for faster target
 Runs configured providers (from `reinguard.yaml`) unless a subcommand
 narrows scope. Emits one **observation document** JSON object (see schema
 `observation-document.json`).
+
+### Explicit GitHub PR scope
+
+Live observation commands accept optional GitHub scope flags:
+
+| Flag | Description |
+|------|-------------|
+| `--branch BRANCH` | Observe GitHub PR linkage for `BRANCH` instead of the checked-out branch. |
+| `--pr N` | Observe GitHub pull-request / review / CI facets for pull request `N`. |
+
+Precedence:
+
+1. `--pr` wins for PR-scoped GitHub facets.
+2. Otherwise `--branch` wins over the checked-out branch.
+3. Otherwise live observation uses the local checkout branch.
+
+When `--pr` is set without `--branch`, `signals.github.pull_requests.current_branch`
+tracks the PR head branch, while `observed_scope.local_branch_at_collect`
+preserves the local checkout branch that invoked `rgd`.
+
+`--branch` / `--pr` are **live-observe only**. They are rejected when
+`--observation-file` is set on higher-level commands (`state eval`,
+`route select`, `knowledge pack`, `context build`) because the scope is
+already fixed by the saved observation document.
 
 ### Observation document fields (reinguard-native)
 
@@ -159,18 +185,20 @@ The **pull-requests** facet always includes REST-derived fields for the current 
 | Field | Type | Description |
 |-------|------|-------------|
 | `open_count` | number | Open PR count for the repo (REST search). |
-| `current_branch` | string | Current git branch name (empty if detached). |
-| `pr_exists_for_branch` | boolean | Whether an open PR exists whose head matches the current branch. |
-| `pr_number_for_branch` | number | That PR’s number, or `0`. |
+| `current_branch` | string | Effective branch used for PR observation. Defaults to the checked-out branch; with `--branch` (and no `--pr`), the requested branch; with `--pr` (regardless of `--branch`), the PR head branch. |
+| `pr_exists_for_branch` | boolean | Whether an open PR exists for the effective observed branch / explicit `--pr` target. |
+| `pr_number_for_branch` | number | Resolved PR number for the effective observed branch / explicit `--pr` target, or `0`. |
 | `state` | string | GraphQL PR state lowercased: `open`, `closed`, `merged`. |
 | `draft` | boolean | Draft flag. |
 | `title` | string | PR title. |
 | `base_ref` | string | Base branch name (`baseRefName`). |
+| `head_ref` | string | PR head branch name (`headRefName`). |
 | `head_sha` | string | Head commit OID. |
 | `mergeable` | string | `mergeable`, `conflicting`, or `unknown` (from GraphQL `mergeable`). |
 | `merge_state_status` | string | GraphQL `mergeStateStatus` lowercased (e.g. `clean`, `dirty`, `blocked`, `unstable`, `behind`). |
 | `labels` | string array | Label names (first page, up to 20). |
 | `closing_issue_numbers` | number array | Linked issues from `closingIssuesReferences` (first page, up to 20). |
+| `observed_scope` | object | Scope metadata for intent checks. See [Observed scope fields (detail)](#observed-scope-fields-detail) below. |
 
 ### `signals.github.reviews` (GitHub provider, reviews facet)
 
@@ -181,12 +209,48 @@ Populated when the `reviews` facet runs (see `rgd observe github reviews`). Data
 | `review_threads_total` | number | Threads fetched for the current PR after pagination (or up to the engine page cap). |
 | `review_threads_unresolved` | number | Threads where `isResolved` is false. Used by `merge-readiness`. |
 | `pagination_incomplete` | boolean | True if not all thread pages could be read (e.g. pagination capped). |
+| `review_inbox` | array | Unresolved thread records for agent action. See [Review inbox fields (detail)](#review-inbox-fields-detail) below. |
 | `review_decisions_total` | number | Count of nodes returned from `latestReviews` (latest decision per reviewer). |
 | `review_decisions_approved` | number | Count with state `APPROVED`. |
 | `review_decisions_changes_requested` | number | Count with state `CHANGES_REQUESTED`. |
 | `review_decisions_truncated` | boolean | True if `latestReviews` reports `hasNextPage` (more than one page of decisions not fetched). |
 | `bot_reviewer_status` | array | One object per configured `bot_reviewers` entry. See [Bot reviewer fields (detail)](#bot-reviewer-fields-detail) below. |
 | `bot_review_diagnostics` | object | Aggregated booleans over **required** bots only. See [Bot review diagnostics (detail)](#bot-review-diagnostics-detail) below. |
+
+#### Observed scope fields (detail)
+
+`pull_requests.observed_scope` may include:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `local_branch_at_collect` | string | Checked-out local branch when the command ran (empty if detached). |
+| `selection` | string | Scope selection mode: `current_branch`, `explicit_branch`, `explicit_pr`, or `none`. |
+| `requested_branch` | string | Explicit `--branch` value when provided. |
+| `requested_pr_number` | number | Explicit `--pr` value when provided. |
+| `effective_branch` | string | Branch that drove PR observation after precedence rules were applied. |
+| `resolved_pr_number` | number | PR number selected for the effective scope, or `0`. |
+| `pr_head_branch` | string | Head branch returned by the resolved PR, when available. |
+| `pr_head_sha` | string | Head SHA returned by the resolved PR, when available. |
+
+#### Review inbox fields (detail)
+
+Each element of `review_inbox` represents one unresolved GitHub review thread.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `thread_id` | string | GraphQL review thread node id (`resolveReviewThread` input). |
+| `root_comment_id` | number | Root review comment database id (`in_reply_to` for REST replies). |
+| `is_resolved` | boolean | Thread resolution state from GraphQL. |
+| `is_outdated` | boolean | Thread outdated state from GraphQL. |
+| `body` | string | Root review comment body when available. |
+| `author` | string | Root review comment author login when available. |
+| `path` | string | Anchored file path for the root review comment. |
+| `line` | number | Anchored line number when available. |
+| `original_line` | number | Original line number from the root review comment when available. |
+| `start_line` | number | Multi-line start line when available. |
+| `original_start_line` | number | Original multi-line start line when available. |
+| `commit_sha` | string | Commit SHA on the root review comment when available. |
+| `original_commit_sha` | string | Original commit SHA on the root review comment when available. |
 
 #### Bot reviewer fields (detail)
 
@@ -225,6 +289,8 @@ Committed workflow `state_id` priorities for this repository are documented in *
 - **Default:** runs observation inline (same as `rgd observe`) unless:
 - `--observation-file FILE` points to a JSON observation document, or
 - **stdin** JSON when `-` is passed as file (optional convention).
+- `--branch BRANCH` / `--pr N` use the same live GitHub scope rules as
+  [`rgd observe`](#explicit-github-pr-scope) when `--observation-file` is not set.
 - Runtime gate statuses from `.reinguard/runtime/gates/*.json` are merged into
   the evaluation signal map as `gates.<gate-id>.*` before state resolution.
 
@@ -250,6 +316,8 @@ Evaluates `type: route` rules using:
 
 - `--observation-file` (required unless default live observe)
 - `--state-file` optional prior `state eval` JSON (merged into signals as `state` key)
+- `--branch BRANCH` / `--pr N` for live observation only (same precedence as
+  [`rgd observe`](#explicit-github-pr-scope))
 - Runtime gate statuses from `.reinguard/runtime/gates/*.json` (merged as
   `gates.<gate-id>.*` before route evaluation)
 
@@ -382,6 +450,7 @@ Every committed manifest entry includes `when` (schema-required). Repo-relative 
 |------|-------------|
 | `--query` | Optional. Case-insensitive substring match against each entry’s `triggers`. |
 | `--observation-file FILE` | Optional. Observation JSON (same shape as `rgd observe` stdout). When set, the file’s `signals` object is flattened first, and entries are kept only if `when` matches that flat signal map (not state-resolved; use `context build` for `state.*` paths in `when`). |
+| `--branch BRANCH` / `--pr N` | Optional for live observation only; same precedence as [`rgd observe`](#explicit-github-pr-scope). Rejected with `--observation-file`. |
 
 **Selection when `--observation-file` is set:** entries included if `when` matches **or** `--query` matches triggers (OR union by `id`). When `--observation-file` is omitted, `--query` remains the only filter; with an empty query, all entries are returned.
 
@@ -402,6 +471,10 @@ guard steps use that flat map; they do not see route/guard outcomes inside
 - **`--observation-file FILE`**: if set, skips live `observe` and uses the
   given observation document JSON as input (same shape as `rgd observe` stdout).
   Useful for tests and golden fixtures.
+- **`--branch BRANCH` / `--pr N`**: when live observation runs, pass explicit
+  GitHub PR scope into the observe step using the same precedence as
+  [`rgd observe`](#explicit-github-pr-scope). Rejected with
+  `--observation-file`.
 
 The `knowledge` object in the output has **`entries`** (same shape as
 `rgd knowledge pack` stdout), not `paths` (ADR-0010).
@@ -412,6 +485,39 @@ default chain when not using `--observation-file`.
 The `state` field is the state-resolution **Result** (same JSON shape as `rgd state eval` stdout).
 The `routes` array contains one route-resolution **Result** (same shape as `rgd route select` stdout,
 including `route_candidates` when applicable). See `pkg/schema/operational-context.json` (`resolutionResult`).
+
+## `rgd review reply-thread`
+
+Thin transport for one threaded PR review reply. This command does **not**
+classify findings or enforce consensus policy; it only validates required
+transport fields and shells out to `gh api`.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--pr` | yes | Pull request number |
+| `--in-reply-to` | yes | Root review comment database id |
+| `--commit-sha` | yes | Full 40-character commit SHA |
+| `--path` | yes | Review comment file path |
+| `--line` | yes | Review comment line number |
+| `--body` | one of body/body-file | Inline reply body |
+| `--body-file` | one of body/body-file | File containing the reply body |
+| `--cwd` | no | Working directory for `gh` |
+
+Payload matches the repository’s PR review transport contract:
+`POST repos/{owner}/{repo}/pulls/{N}/comments` with `body`, `in_reply_to`,
+`commit_id`, `path`, and `line`.
+
+## `rgd review resolve-thread`
+
+Thin transport for `resolveReviewThread` after consensus.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--thread-id` | yes | GraphQL review thread node id |
+| `--cwd` | no | Working directory for `gh` |
+
+The command shells out to `gh api graphql` with a single
+`resolveReviewThread` mutation.
 
 ### Authors: extending State / Gate / Guard
 

--- a/internal/gate/artifact.go
+++ b/internal/gate/artifact.go
@@ -1,4 +1,4 @@
-// Package gate records and evaluates runtime gate artifacts under .reinguard/runtime/gates.
+// Package gate records and evaluates runtime gate artifacts under .reinguard/local/gates.
 package gate
 
 import (
@@ -68,14 +68,14 @@ type StatusResult struct {
 	RecordedAt string `json:"recorded_at,omitempty"`
 }
 
-// RuntimeDir returns the runtime directory under the resolved config directory.
-func RuntimeDir(cfgDir string) string {
-	return filepath.Join(cfgDir, "runtime")
+// LocalDir returns the local operational state directory under the resolved config directory.
+func LocalDir(cfgDir string) string {
+	return filepath.Join(cfgDir, "local")
 }
 
-// GatesDir returns the runtime gate directory under the resolved config directory.
+// GatesDir returns the gate artifacts directory under the resolved config directory.
 func GatesDir(cfgDir string) string {
-	return filepath.Join(RuntimeDir(cfgDir), "gates")
+	return filepath.Join(LocalDir(cfgDir), "gates")
 }
 
 // ValidateGateID rejects blank or unsafe gate identifiers.

--- a/internal/gate/artifact_test.go
+++ b/internal/gate/artifact_test.go
@@ -241,7 +241,7 @@ func TestLoadSignals_injectsDerivedStatuses(t *testing.T) {
 	}
 	writeFile(t, path, []byte(`{"bad":true}`))
 
-	// When: LoadSignals scans runtime gate artifacts
+	// When: LoadSignals scans local gate artifacts
 	got, err := LoadSignals(context.Background(), cfgDir, repo)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/githubapi/gh.go
+++ b/internal/githubapi/gh.go
@@ -158,9 +158,10 @@ func RepoFromGH(ctx context.Context, wd string) (owner, name string, err error) 
 
 var fullSHARe = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
 
-func validateFullSHA(sha string) error {
-	if !fullSHARe.MatchString(strings.TrimSpace(sha)) {
-		return fmt.Errorf("commit SHA must be a full 40-character hex string")
+func validateFullSHA(sha string) (string, error) {
+	trimmed := strings.TrimSpace(sha)
+	if !fullSHARe.MatchString(trimmed) {
+		return "", fmt.Errorf("commit SHA must be a full 40-character hex string")
 	}
-	return nil
+	return trimmed, nil
 }

--- a/internal/githubapi/gh.go
+++ b/internal/githubapi/gh.go
@@ -161,7 +161,7 @@ var fullSHARe = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
 func validateFullSHA(sha string) (string, error) {
 	trimmed := strings.TrimSpace(sha)
 	if !fullSHARe.MatchString(trimmed) {
-		return "", fmt.Errorf("commit SHA must be a full 40-character hex string")
+		return "", fmt.Errorf("commit SHA must be a full 40-character hex string, got %q", trimmed)
 	}
 	return trimmed, nil
 }

--- a/internal/githubapi/gh.go
+++ b/internal/githubapi/gh.go
@@ -6,17 +6,32 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"regexp"
 	"strings"
 )
 
 // runGHCommand runs the GitHub CLI subprocess. Tests replace it for hermetic runs.
 var runGHCommand = runGHCommandImpl
+var runGHCommandWithInput = runGHCommandWithInputImpl
 
 func runGHCommandImpl(ctx context.Context, wd string, args []string) (stdout, stderr []byte, err error) {
 	cmd := exec.CommandContext(ctx, "gh", args...)
 	if wd != "" {
 		cmd.Dir = wd
 	}
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return outBuf.Bytes(), errBuf.Bytes(), err
+}
+
+func runGHCommandWithInputImpl(ctx context.Context, wd string, stdin []byte, args []string) (stdout, stderr []byte, err error) {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	if wd != "" {
+		cmd.Dir = wd
+	}
+	cmd.Stdin = bytes.NewReader(stdin)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
@@ -139,4 +154,13 @@ func RepoFromGH(ctx context.Context, wd string) (owner, name string, err error) 
 		return "", "", err
 	}
 	return id.Owner, id.Name, nil
+}
+
+var fullSHARe = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
+
+func validateFullSHA(sha string) error {
+	if !fullSHARe.MatchString(strings.TrimSpace(sha)) {
+		return fmt.Errorf("commit SHA must be a full 40-character hex string")
+	}
+	return nil
 }

--- a/internal/githubapi/review_threads.go
+++ b/internal/githubapi/review_threads.go
@@ -1,0 +1,97 @@
+package githubapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// PullRequestThreadReplyInput is the transport payload for one threaded PR review reply.
+type PullRequestThreadReplyInput struct {
+	Body      string
+	CommitSHA string
+	Path      string
+	PRNumber  int
+	InReplyTo int
+	Line      int
+}
+
+// ReplyToPullRequestThread posts a threaded reply on one pull-request review comment.
+func ReplyToPullRequestThread(ctx context.Context, wd string, in PullRequestThreadReplyInput) error {
+	if in.PRNumber <= 0 {
+		return fmt.Errorf("pull request number must be greater than 0")
+	}
+	if in.InReplyTo <= 0 {
+		return fmt.Errorf("in_reply_to must be greater than 0")
+	}
+	if strings.TrimSpace(in.Body) == "" {
+		return fmt.Errorf("reply body must be non-empty")
+	}
+	if err := validateFullSHA(in.CommitSHA); err != nil {
+		return err
+	}
+	in.CommitSHA = strings.TrimSpace(in.CommitSHA)
+	in.Path = strings.TrimSpace(in.Path)
+	if in.Path == "" {
+		return fmt.Errorf("path must be non-empty")
+	}
+	if in.Line <= 0 {
+		return fmt.Errorf("line must be greater than 0")
+	}
+	payload, err := json.Marshal(map[string]any{
+		"body":        in.Body,
+		"in_reply_to": in.InReplyTo,
+		"commit_id":   in.CommitSHA,
+		"path":        in.Path,
+		"line":        in.Line,
+	})
+	if err != nil {
+		return err
+	}
+	_, stderr, err := runGHCommandWithInput(ctx, wd, payload, []string{
+		"api",
+		fmt.Sprintf("repos/{owner}/{repo}/pulls/%d/comments", in.PRNumber),
+		"-X", "POST",
+		"--input", "-",
+	})
+	if err != nil {
+		return fmt.Errorf("gh api reply thread: %w (stderr: %s)", err, strings.TrimSpace(string(stderr)))
+	}
+	return nil
+}
+
+// ResolveReviewThread resolves one GraphQL review thread after consensus.
+func ResolveReviewThread(ctx context.Context, wd, threadID string) error {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return fmt.Errorf("thread id must be non-empty")
+	}
+	query := fmt.Sprintf(`mutation { resolveReviewThread(input: {threadId: %q}) { thread { isResolved } } }`, threadID)
+	stdout, stderr, err := runGHCommand(ctx, wd, []string{"api", "graphql", "-f", "query=" + query})
+	if err != nil {
+		return fmt.Errorf("gh api resolve review thread: %w (stderr: %s)", err, strings.TrimSpace(string(stderr)))
+	}
+	var resp struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+		Data struct {
+			ResolveReviewThread struct {
+				Thread struct {
+					IsResolved bool `json:"isResolved"`
+				} `json:"thread"`
+			} `json:"resolveReviewThread"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout, &resp); err != nil {
+		return fmt.Errorf("parse resolve response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		return fmt.Errorf("graphql error: %s", resp.Errors[0].Message)
+	}
+	if !resp.Data.ResolveReviewThread.Thread.IsResolved {
+		return fmt.Errorf("thread %s was not resolved", threadID)
+	}
+	return nil
+}

--- a/internal/githubapi/review_threads.go
+++ b/internal/githubapi/review_threads.go
@@ -75,22 +75,25 @@ func ResolveReviewThread(ctx context.Context, wd, threadID string) error {
 		return fmt.Errorf("gh api resolve review thread: %w (stderr: %s)", err, strings.TrimSpace(string(stderr)))
 	}
 	var resp struct {
-		Errors []struct {
-			Message string `json:"message"`
-		} `json:"errors"`
 		Data struct {
 			ResolveReviewThread struct {
-				Thread struct {
+				Thread *struct {
 					IsResolved bool `json:"isResolved"`
 				} `json:"thread"`
 			} `json:"resolveReviewThread"`
 		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
 	}
 	if err := json.Unmarshal(stdout, &resp); err != nil {
 		return fmt.Errorf("parse resolve response: %w", err)
 	}
 	if len(resp.Errors) > 0 {
 		return fmt.Errorf("graphql error: %s", resp.Errors[0].Message)
+	}
+	if resp.Data.ResolveReviewThread.Thread == nil {
+		return fmt.Errorf("thread %s not found in response", threadID)
 	}
 	if !resp.Data.ResolveReviewThread.Thread.IsResolved {
 		return fmt.Errorf("thread %s was not resolved", threadID)

--- a/internal/githubapi/review_threads.go
+++ b/internal/githubapi/review_threads.go
@@ -25,13 +25,15 @@ func ReplyToPullRequestThread(ctx context.Context, wd string, in PullRequestThre
 	if in.InReplyTo <= 0 {
 		return fmt.Errorf("in_reply_to must be greater than 0")
 	}
-	if strings.TrimSpace(in.Body) == "" {
+	in.Body = strings.TrimSpace(in.Body)
+	if in.Body == "" {
 		return fmt.Errorf("reply body must be non-empty")
 	}
-	if err := validateFullSHA(in.CommitSHA); err != nil {
+	sha, err := validateFullSHA(in.CommitSHA)
+	if err != nil {
 		return err
 	}
-	in.CommitSHA = strings.TrimSpace(in.CommitSHA)
+	in.CommitSHA = sha
 	in.Path = strings.TrimSpace(in.Path)
 	if in.Path == "" {
 		return fmt.Errorf("path must be non-empty")

--- a/internal/githubapi/review_threads_test.go
+++ b/internal/githubapi/review_threads_test.go
@@ -1,0 +1,114 @@
+package githubapi
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestReplyToPullRequestThread_success(t *testing.T) {
+	// Given: a stubbed gh API transport for threaded replies
+	old := runGHCommandWithInput
+	t.Cleanup(func() { runGHCommandWithInput = old })
+	runGHCommandWithInput = func(ctx context.Context, wd string, stdin []byte, args []string) ([]byte, []byte, error) {
+		if wd != "/tmp/work" {
+			t.Fatalf("unexpected wd: %q", wd)
+		}
+		if !strings.Contains(string(stdin), `"in_reply_to":123`) {
+			t.Fatalf("stdin: %s", stdin)
+		}
+		if !strings.Contains(string(stdin), `"commit_id":"0123456789abcdef0123456789abcdef01234567"`) {
+			t.Fatalf("stdin: %s", stdin)
+		}
+		if !strings.Contains(string(stdin), `"path":"internal/rgdcli/rgdcli.go"`) {
+			t.Fatalf("stdin: %s", stdin)
+		}
+		if len(args) < 2 || args[0] != "api" || args[1] != "repos/{owner}/{repo}/pulls/17/comments" {
+			t.Fatalf("unexpected args: %v", args)
+		}
+		return []byte(`{}`), nil, nil
+	}
+	// When: the helper posts a valid threaded reply
+	err := ReplyToPullRequestThread(context.Background(), "/tmp/work", PullRequestThreadReplyInput{
+		PRNumber:  17,
+		Body:      "Fixed. Updated the scoped observation path.",
+		InReplyTo: 123,
+		CommitSHA: "0123456789abcdef0123456789abcdef01234567",
+		Path:      " internal/rgdcli/rgdcli.go ",
+		Line:      42,
+	})
+	// Then: the transport succeeds and trims payload fields as needed
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReplyToPullRequestThread_rejectsShortSHA(t *testing.T) {
+	// Given: reply input with a short SHA
+	// When: the helper validates the input
+	err := ReplyToPullRequestThread(context.Background(), "", PullRequestThreadReplyInput{
+		PRNumber:  1,
+		Body:      "x",
+		InReplyTo: 2,
+		CommitSHA: "deadbeef",
+		Path:      "a.go",
+		Line:      1,
+	})
+	// Then: the helper rejects the short SHA before any transport call
+	if err == nil || !strings.Contains(err.Error(), "40-character") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestResolveReviewThread_success(t *testing.T) {
+	// Given: a stubbed GraphQL response that confirms resolution
+	old := runGHCommand
+	t.Cleanup(func() { runGHCommand = old })
+	runGHCommand = func(ctx context.Context, wd string, args []string) ([]byte, []byte, error) {
+		if wd != "/tmp/work" {
+			t.Fatalf("unexpected wd: %q", wd)
+		}
+		if len(args) < 4 || args[0] != "api" || args[1] != "graphql" {
+			t.Fatalf("unexpected args: %v", args)
+		}
+		if !strings.Contains(args[3], "THREAD_node_id") {
+			t.Fatalf("query: %v", args)
+		}
+		return []byte(`{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}`), nil, nil
+	}
+	// When: the helper resolves the thread
+	if err := ResolveReviewThread(context.Background(), "/tmp/work", "THREAD_node_id"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveReviewThread_propagatesGHError(t *testing.T) {
+	// Given: gh exits non-zero before GraphQL response parsing
+	old := runGHCommand
+	t.Cleanup(func() { runGHCommand = old })
+	runGHCommand = func(ctx context.Context, wd string, args []string) ([]byte, []byte, error) {
+		return nil, []byte("denied"), errors.New("exit 1")
+	}
+	// When: the helper attempts to resolve the thread
+	err := ResolveReviewThread(context.Background(), "", "THREAD_node_id")
+	// Then: stderr is preserved in the returned error
+	if err == nil || !strings.Contains(err.Error(), "denied") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestResolveReviewThread_rejectsGraphQLErrors(t *testing.T) {
+	// Given: gh succeeds but GraphQL returns an errors array
+	old := runGHCommand
+	t.Cleanup(func() { runGHCommand = old })
+	runGHCommand = func(ctx context.Context, wd string, args []string) ([]byte, []byte, error) {
+		return []byte(`{"errors":[{"message":"permission denied"}]}`), nil, nil
+	}
+	// When: the helper parses the mutation response
+	err := ResolveReviewThread(context.Background(), "", "THREAD_node_id")
+	// Then: GraphQL errors fail closed
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("got %v", err)
+	}
+}

--- a/internal/githubapi/review_threads_test.go
+++ b/internal/githubapi/review_threads_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestReplyToPullRequestThread(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		stub    func(ctx context.Context, wd string, stdin []byte, args []string) ([]byte, []byte, error)
 		name    string
@@ -118,6 +119,14 @@ func TestResolveReviewThread(t *testing.T) {
 			},
 		},
 		{
+			name:    "given null thread when resolving then explicit error",
+			thread:  "THREAD_node_id",
+			wantErr: "not found in response",
+			stub: func(ctx context.Context, wd string, args []string) ([]byte, []byte, error) {
+				return []byte(`{"data":{"resolveReviewThread":{"thread":null}}}`), nil, nil
+			},
+		},
+		{
 			name:    "given graphql errors when resolving then fail closed",
 			thread:  "THREAD_node_id",
 			wantErr: "permission denied",
@@ -129,9 +138,11 @@ func TestResolveReviewThread(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Given: a stubbed gh GraphQL transport
-			old := runGHCommand
-			t.Cleanup(func() { runGHCommand = old })
-			runGHCommand = tt.stub
+			if tt.stub != nil {
+				old := runGHCommand
+				t.Cleanup(func() { runGHCommand = old })
+				runGHCommand = tt.stub
+			}
 
 			// When: the helper resolves the requested thread
 			err := ResolveReviewThread(context.Background(), tt.wd, tt.thread)

--- a/internal/githubapi/review_threads_test.go
+++ b/internal/githubapi/review_threads_test.go
@@ -86,6 +86,7 @@ func TestReplyToPullRequestThread(t *testing.T) {
 }
 
 func TestResolveReviewThread(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		stub    func(ctx context.Context, wd string, args []string) ([]byte, []byte, error)
 		name    string

--- a/internal/githubapi/review_threads_test.go
+++ b/internal/githubapi/review_threads_test.go
@@ -7,108 +7,145 @@ import (
 	"testing"
 )
 
-func TestReplyToPullRequestThread_success(t *testing.T) {
-	// Given: a stubbed gh API transport for threaded replies
-	old := runGHCommandWithInput
-	t.Cleanup(func() { runGHCommandWithInput = old })
-	runGHCommandWithInput = func(ctx context.Context, wd string, stdin []byte, args []string) ([]byte, []byte, error) {
-		if wd != "/tmp/work" {
-			t.Fatalf("unexpected wd: %q", wd)
-		}
-		if !strings.Contains(string(stdin), `"in_reply_to":123`) {
-			t.Fatalf("stdin: %s", stdin)
-		}
-		if !strings.Contains(string(stdin), `"commit_id":"0123456789abcdef0123456789abcdef01234567"`) {
-			t.Fatalf("stdin: %s", stdin)
-		}
-		if !strings.Contains(string(stdin), `"path":"internal/rgdcli/rgdcli.go"`) {
-			t.Fatalf("stdin: %s", stdin)
-		}
-		if len(args) < 2 || args[0] != "api" || args[1] != "repos/{owner}/{repo}/pulls/17/comments" {
-			t.Fatalf("unexpected args: %v", args)
-		}
-		return []byte(`{}`), nil, nil
+func TestReplyToPullRequestThread(t *testing.T) {
+	tests := []struct {
+		stub    func(ctx context.Context, wd string, stdin []byte, args []string) ([]byte, []byte, error)
+		name    string
+		wd      string
+		wantErr string
+		input   PullRequestThreadReplyInput
+	}{
+		{
+			name: "given valid input when replying then request is posted",
+			wd:   "/tmp/work",
+			input: PullRequestThreadReplyInput{
+				PRNumber:  17,
+				Body:      "Fixed. Updated the scoped observation path.",
+				InReplyTo: 123,
+				CommitSHA: "0123456789abcdef0123456789abcdef01234567",
+				Path:      " internal/rgdcli/rgdcli.go ",
+				Line:      42,
+			},
+			stub: func(ctx context.Context, wd string, stdin []byte, args []string) ([]byte, []byte, error) {
+				if wd != "/tmp/work" {
+					t.Fatalf("unexpected wd: %q", wd)
+				}
+				if !strings.Contains(string(stdin), `"in_reply_to":123`) {
+					t.Fatalf("stdin: %s", stdin)
+				}
+				if !strings.Contains(string(stdin), `"commit_id":"0123456789abcdef0123456789abcdef01234567"`) {
+					t.Fatalf("stdin: %s", stdin)
+				}
+				if !strings.Contains(string(stdin), `"path":"internal/rgdcli/rgdcli.go"`) {
+					t.Fatalf("stdin: %s", stdin)
+				}
+				if len(args) < 2 || args[0] != "api" || args[1] != "repos/{owner}/{repo}/pulls/17/comments" {
+					t.Fatalf("unexpected args: %v", args)
+				}
+				return []byte(`{}`), nil, nil
+			},
+		},
+		{
+			name: "given short sha when replying then validation fails",
+			input: PullRequestThreadReplyInput{
+				PRNumber:  1,
+				Body:      "x",
+				InReplyTo: 2,
+				CommitSHA: "deadbeef",
+				Path:      "a.go",
+				Line:      1,
+			},
+			wantErr: "40-character",
+		},
 	}
-	// When: the helper posts a valid threaded reply
-	err := ReplyToPullRequestThread(context.Background(), "/tmp/work", PullRequestThreadReplyInput{
-		PRNumber:  17,
-		Body:      "Fixed. Updated the scoped observation path.",
-		InReplyTo: 123,
-		CommitSHA: "0123456789abcdef0123456789abcdef01234567",
-		Path:      " internal/rgdcli/rgdcli.go ",
-		Line:      42,
-	})
-	// Then: the transport succeeds and trims payload fields as needed
-	if err != nil {
-		t.Fatal(err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: an optional stubbed gh transport
+			if tt.stub != nil {
+				old := runGHCommandWithInput
+				t.Cleanup(func() { runGHCommandWithInput = old })
+				runGHCommandWithInput = tt.stub
+			}
+
+			// When: the helper posts a threaded reply
+			err := ReplyToPullRequestThread(context.Background(), tt.wd, tt.input)
+
+			// Then: the error state matches the expected transport outcome
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("got %v, want error containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 
-func TestReplyToPullRequestThread_rejectsShortSHA(t *testing.T) {
-	// Given: reply input with a short SHA
-	// When: the helper validates the input
-	err := ReplyToPullRequestThread(context.Background(), "", PullRequestThreadReplyInput{
-		PRNumber:  1,
-		Body:      "x",
-		InReplyTo: 2,
-		CommitSHA: "deadbeef",
-		Path:      "a.go",
-		Line:      1,
-	})
-	// Then: the helper rejects the short SHA before any transport call
-	if err == nil || !strings.Contains(err.Error(), "40-character") {
-		t.Fatalf("got %v", err)
+func TestResolveReviewThread(t *testing.T) {
+	tests := []struct {
+		stub    func(ctx context.Context, wd string, args []string) ([]byte, []byte, error)
+		name    string
+		wd      string
+		thread  string
+		wantErr string
+	}{
+		{
+			name:   "given resolved response when resolving then success",
+			wd:     "/tmp/work",
+			thread: "THREAD_node_id",
+			stub: func(ctx context.Context, wd string, args []string) ([]byte, []byte, error) {
+				if wd != "/tmp/work" {
+					t.Fatalf("unexpected wd: %q", wd)
+				}
+				if len(args) < 4 || args[0] != "api" || args[1] != "graphql" {
+					t.Fatalf("unexpected args: %v", args)
+				}
+				if !strings.Contains(args[3], "THREAD_node_id") {
+					t.Fatalf("query: %v", args)
+				}
+				return []byte(`{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}`), nil, nil
+			},
+		},
+		{
+			name:    "given gh stderr when resolving then error preserved",
+			thread:  "THREAD_node_id",
+			wantErr: "denied",
+			stub: func(ctx context.Context, wd string, args []string) ([]byte, []byte, error) {
+				return nil, []byte("denied"), errors.New("exit 1")
+			},
+		},
+		{
+			name:    "given graphql errors when resolving then fail closed",
+			thread:  "THREAD_node_id",
+			wantErr: "permission denied",
+			stub: func(ctx context.Context, wd string, args []string) ([]byte, []byte, error) {
+				return []byte(`{"errors":[{"message":"permission denied"}]}`), nil, nil
+			},
+		},
 	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given: a stubbed gh GraphQL transport
+			old := runGHCommand
+			t.Cleanup(func() { runGHCommand = old })
+			runGHCommand = tt.stub
 
-func TestResolveReviewThread_success(t *testing.T) {
-	// Given: a stubbed GraphQL response that confirms resolution
-	old := runGHCommand
-	t.Cleanup(func() { runGHCommand = old })
-	runGHCommand = func(ctx context.Context, wd string, args []string) ([]byte, []byte, error) {
-		if wd != "/tmp/work" {
-			t.Fatalf("unexpected wd: %q", wd)
-		}
-		if len(args) < 4 || args[0] != "api" || args[1] != "graphql" {
-			t.Fatalf("unexpected args: %v", args)
-		}
-		if !strings.Contains(args[3], "THREAD_node_id") {
-			t.Fatalf("query: %v", args)
-		}
-		return []byte(`{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}`), nil, nil
-	}
-	// When: the helper resolves the thread
-	if err := ResolveReviewThread(context.Background(), "/tmp/work", "THREAD_node_id"); err != nil {
-		t.Fatal(err)
-	}
-}
+			// When: the helper resolves the requested thread
+			err := ResolveReviewThread(context.Background(), tt.wd, tt.thread)
 
-func TestResolveReviewThread_propagatesGHError(t *testing.T) {
-	// Given: gh exits non-zero before GraphQL response parsing
-	old := runGHCommand
-	t.Cleanup(func() { runGHCommand = old })
-	runGHCommand = func(ctx context.Context, wd string, args []string) ([]byte, []byte, error) {
-		return nil, []byte("denied"), errors.New("exit 1")
-	}
-	// When: the helper attempts to resolve the thread
-	err := ResolveReviewThread(context.Background(), "", "THREAD_node_id")
-	// Then: stderr is preserved in the returned error
-	if err == nil || !strings.Contains(err.Error(), "denied") {
-		t.Fatalf("got %v", err)
-	}
-}
-
-func TestResolveReviewThread_rejectsGraphQLErrors(t *testing.T) {
-	// Given: gh succeeds but GraphQL returns an errors array
-	old := runGHCommand
-	t.Cleanup(func() { runGHCommand = old })
-	runGHCommand = func(ctx context.Context, wd string, args []string) ([]byte, []byte, error) {
-		return []byte(`{"errors":[{"message":"permission denied"}]}`), nil, nil
-	}
-	// When: the helper parses the mutation response
-	err := ResolveReviewThread(context.Background(), "", "THREAD_node_id")
-	// Then: GraphQL errors fail closed
-	if err == nil || !strings.Contains(err.Error(), "permission denied") {
-		t.Fatalf("got %v", err)
+			// Then: the parsed result matches the expected success or failure mode
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("got %v, want error containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }

--- a/internal/knowledge/filter.go
+++ b/internal/knowledge/filter.go
@@ -51,7 +51,7 @@ func FilterBySignals(entries []config.KnowledgeManifestEntry, signals map[string
 }
 
 // FilterUnion applies signal-based filtering when useSignalFilter is true, then combines with query filtering using OR (union by entry id).
-// When useSignalFilter is false (no --observation-file for pack), all entries pass the signal branch (D3).
+// When useSignalFilter is false (no observation signals for pack: no file and no live scope flags), all entries pass the signal branch (D3).
 // Empty query skips the query branch for union purposes.
 func FilterUnion(entries []config.KnowledgeManifestEntry, signals map[string]any, useSignalFilter bool, query string) (result []config.KnowledgeManifestEntry, warnings []string) {
 	q := strings.TrimSpace(query)

--- a/internal/observe/github/ci/ci.go
+++ b/internal/observe/github/ci/ci.go
@@ -19,13 +19,19 @@ type combinedStatus struct {
 	State string `json:"state"`
 }
 
-// Collect returns a coarse CI rollup for HEAD of the current branch.
-func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir string) (map[string]any, []string, error) {
+// Collect returns a coarse CI rollup for the observed head SHA.
+// If headSHAOverride is non-empty after trimming, it is used directly; otherwise the
+// SHA is determined via git rev-parse HEAD in workDir.
+func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir, headSHAOverride string) (map[string]any, []string, error) {
 	if c == nil {
 		return nil, nil, fmt.Errorf("nil client")
 	}
 	var warnings []string
-	sha, err := headSHA(ctx, workDir)
+	sha := strings.TrimSpace(headSHAOverride)
+	var err error
+	if sha == "" {
+		sha, err = headSHA(ctx, workDir)
+	}
 	if err != nil {
 		warnings = append(warnings, err.Error())
 		return map[string]any{

--- a/internal/observe/github/ci/ci.go
+++ b/internal/observe/github/ci/ci.go
@@ -22,6 +22,9 @@ type combinedStatus struct {
 // Collect returns a coarse CI rollup for the observed head SHA.
 // If headSHAOverride is non-empty after trimming, it is used directly; otherwise the
 // SHA is determined via git rev-parse HEAD in workDir.
+// owner and repo identify the repository for GET .../commits/{sha}/status. For a pull
+// request from a fork, CI statuses are posted to the head repository; pass the head
+// owner and name from the pull request (not the base repo).
 func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir, headSHAOverride string) (map[string]any, []string, error) {
 	if c == nil {
 		return nil, nil, fmt.Errorf("nil client")

--- a/internal/observe/github/ci/ci_test.go
+++ b/internal/observe/github/ci/ci_test.go
@@ -129,6 +129,36 @@ func TestCollect_usesHeadSHAOverride(t *testing.T) {
 	}
 }
 
+func TestCollect_whitespaceHeadSHAOverrideFallsBackToHEAD(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gitInit(t, dir)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"state":"success"}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "t", BaseURL: srv.URL}
+
+	m, warns, err := Collect(context.Background(), c, "o", "r", dir, "   ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("%v", warns)
+	}
+	cimap, ok := m["ci"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected ci map, got %T", m["ci"])
+	}
+	head, err := headSHA(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cimap["head_sha"] != head {
+		t.Fatalf("want head_sha %q from git HEAD, got %+v", head, cimap)
+	}
+}
+
 func gitInit(t *testing.T, dir string) {
 	t.Helper()
 	cmd := exec.Command("git", "init")

--- a/internal/observe/github/ci/ci_test.go
+++ b/internal/observe/github/ci/ci_test.go
@@ -23,7 +23,7 @@ func TestCollect_status(t *testing.T) {
 	t.Cleanup(srv.Close)
 	c := &githubapi.Client{HTTP: srv.Client(), Token: "t", BaseURL: srv.URL}
 	// When: Collect runs
-	m, warns, err := Collect(context.Background(), c, "o", "r", dir)
+	m, warns, err := Collect(context.Background(), c, "o", "r", dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestCollect_http500(t *testing.T) {
 	t.Cleanup(srv.Close)
 	c := &githubapi.Client{HTTP: srv.Client(), Token: "t", BaseURL: srv.URL}
 	// When: Collect runs
-	_, _, err := Collect(context.Background(), c, "o", "r", dir)
+	_, _, err := Collect(context.Background(), c, "o", "r", dir, "")
 	// Then: error mentions 500
 	if err == nil || !strings.Contains(err.Error(), "500") {
 		t.Fatalf("got %v", err)
@@ -68,7 +68,7 @@ func TestCollect_nonGitWorkDir(t *testing.T) {
 	dir := t.TempDir()
 	c := &githubapi.Client{HTTP: http.DefaultClient, Token: "t", BaseURL: "http://unused.invalid"}
 	// When: Collect runs
-	m, warns, err := Collect(context.Background(), c, "o", "r", dir)
+	m, warns, err := Collect(context.Background(), c, "o", "r", dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,6 +83,40 @@ func TestCollect_nonGitWorkDir(t *testing.T) {
 	// Then: warning and ci_status unknown
 	if !ok || st != "unknown" {
 		t.Fatalf("ci_status=%v (%T)", cimap["ci_status"], cimap["ci_status"])
+	}
+}
+
+func TestCollect_usesHeadSHAOverride(t *testing.T) {
+	t.Parallel()
+	// Given: git repo with HEAD and an explicit override SHA
+	dir := t.TempDir()
+	gitInit(t, dir)
+	var requestedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"state":"pending"}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "t", BaseURL: srv.URL}
+	override := "0123456789abcdef0123456789abcdef01234567"
+	// When: Collect runs with the override
+	m, warns, err := Collect(context.Background(), c, "o", "r", dir, override)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("%v", warns)
+	}
+	if !strings.Contains(requestedPath, override) {
+		t.Fatalf("path=%q want override %q", requestedPath, override)
+	}
+	// Then: the API request and emitted signal both use the override SHA
+	cimap, ok := m["ci"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected ci map, got %T", m["ci"])
+	}
+	if cimap["head_sha"] != override {
+		t.Fatalf("ci=%+v", cimap)
 	}
 }
 

--- a/internal/observe/github/ci/ci_test.go
+++ b/internal/observe/github/ci/ci_test.go
@@ -87,6 +87,40 @@ func TestCollect_nonGitWorkDir(t *testing.T) {
 	}
 }
 
+func TestCollect_statusEndpointUsesOwnerRepoArguments(t *testing.T) {
+	t.Parallel()
+	// Given: a fork PR scenario — CI statuses live on the head repository
+	dir := t.TempDir()
+	gitInit(t, dir)
+	var sawPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"state":"success"}`))
+	}))
+	t.Cleanup(srv.Close)
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "t", BaseURL: srv.URL}
+	head := "abcd0123456789abcdef0123456789abcdef01"
+	// When: Collect is called with head repo owner/name (not the base repo)
+	m, warns, err := Collect(context.Background(), c, "fork-owner", "fork-repo", dir, head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("%v", warns)
+	}
+	// Then: the status request targets /repos/fork-owner/fork-repo/commits/{sha}/status
+	if !strings.Contains(sawPath, "/repos/fork-owner/fork-repo/commits/"+head+"/status") {
+		t.Fatalf("path=%q", sawPath)
+	}
+	cimap, ok := m["ci"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected ci map, got %T", m["ci"])
+	}
+	if cimap["head_sha"] != head {
+		t.Fatalf("ci=%+v", cimap)
+	}
+}
+
 func TestCollect_usesHeadSHAOverride(t *testing.T) {
 	t.Parallel()
 	// Given: git repo with HEAD and an explicit override SHA

--- a/internal/observe/github/ci/ci_test.go
+++ b/internal/observe/github/ci/ci_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/k-shibuki/reinguard/internal/githubapi"
@@ -91,9 +92,14 @@ func TestCollect_usesHeadSHAOverride(t *testing.T) {
 	// Given: git repo with HEAD and an explicit override SHA
 	dir := t.TempDir()
 	gitInit(t, dir)
-	var requestedPath string
+	var (
+		mu            sync.Mutex
+		requestedPath string
+	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		requestedPath = r.URL.Path
+		mu.Unlock()
 		_, _ = w.Write([]byte(`{"state":"pending"}`))
 	}))
 	t.Cleanup(srv.Close)
@@ -107,8 +113,11 @@ func TestCollect_usesHeadSHAOverride(t *testing.T) {
 	if len(warns) != 0 {
 		t.Fatalf("%v", warns)
 	}
-	if !strings.Contains(requestedPath, override) {
-		t.Fatalf("path=%q want override %q", requestedPath, override)
+	mu.Lock()
+	path := requestedPath
+	mu.Unlock()
+	if !strings.Contains(path, override) {
+		t.Fatalf("path=%q want override %q", path, override)
 	}
 	// Then: the API request and emitted signal both use the override SHA
 	cimap, ok := m["ci"].(map[string]any)

--- a/internal/observe/github/ci/ci_test.go
+++ b/internal/observe/github/ci/ci_test.go
@@ -131,6 +131,7 @@ func TestCollect_usesHeadSHAOverride(t *testing.T) {
 
 func TestCollect_whitespaceHeadSHAOverrideFallsBackToHEAD(t *testing.T) {
 	t.Parallel()
+	// Given: a git repo with HEAD and a whitespace-only override (treated as empty)
 	dir := t.TempDir()
 	gitInit(t, dir)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -138,7 +139,7 @@ func TestCollect_whitespaceHeadSHAOverrideFallsBackToHEAD(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 	c := &githubapi.Client{HTTP: srv.Client(), Token: "t", BaseURL: srv.URL}
-
+	// When: Collect runs with whitespace-only override
 	m, warns, err := Collect(context.Background(), c, "o", "r", dir, "   ")
 	if err != nil {
 		t.Fatal(err)
@@ -157,6 +158,7 @@ func TestCollect_whitespaceHeadSHAOverrideFallsBackToHEAD(t *testing.T) {
 	if cimap["head_sha"] != head {
 		t.Fatalf("want head_sha %q from git HEAD, got %+v", head, cimap)
 	}
+	// Then: CI signals use the local HEAD SHA, not a remote override
 }
 
 func gitInit(t *testing.T, dir string) {

--- a/internal/observe/github/prquery/prquery.go
+++ b/internal/observe/github/prquery/prquery.go
@@ -471,16 +471,28 @@ func buildReviewInboxEntry(thread reviewThreadNode) map[string]any {
 	putReviewInboxInt(entry, "root_comment_id", root.DatabaseID)
 	putReviewInboxString(entry, "body", root.Body)
 	putReviewInboxString(entry, "path", root.Path)
-	putReviewInboxOptionalInt(entry, "line", root.Line)
+	linePtr := root.Line
+	if linePtr == nil {
+		linePtr = root.OriginalLine
+	}
+	putReviewInboxOptionalInt(entry, "line", linePtr)
 	putReviewInboxOptionalInt(entry, "original_line", root.OriginalLine)
-	putReviewInboxOptionalInt(entry, "start_line", root.StartLine)
+	startPtr := root.StartLine
+	if startPtr == nil {
+		startPtr = root.OriginalStartLine
+	}
+	putReviewInboxOptionalInt(entry, "start_line", startPtr)
 	putReviewInboxOptionalInt(entry, "original_start_line", root.OriginalStartLine)
 	if root.Author != nil {
 		putReviewInboxString(entry, "author", root.Author.Login)
 	}
-	if root.Commit != nil {
-		putReviewInboxString(entry, "commit_sha", root.Commit.Oid)
+	var commitOid string
+	if root.Commit != nil && strings.TrimSpace(root.Commit.Oid) != "" {
+		commitOid = root.Commit.Oid
+	} else if root.OriginalCommit != nil {
+		commitOid = root.OriginalCommit.Oid
 	}
+	putReviewInboxString(entry, "commit_sha", commitOid)
 	if root.OriginalCommit != nil {
 		putReviewInboxString(entry, "original_commit_sha", root.OriginalCommit.Oid)
 	}

--- a/internal/observe/github/prquery/prquery.go
+++ b/internal/observe/github/prquery/prquery.go
@@ -458,7 +458,6 @@ func buildReviewInboxEntry(thread reviewThreadNode) map[string]any {
 	}
 	entry := map[string]any{
 		"thread_id":   strings.TrimSpace(thread.ID),
-		"is_resolved": thread.IsResolved,
 		"is_outdated": thread.IsOutdated,
 	}
 	if thread.Comments == nil || len(thread.Comments.Nodes) == 0 {
@@ -484,6 +483,7 @@ func buildReviewInboxEntry(thread reviewThreadNode) map[string]any {
 	return entry
 }
 
+// putReviewInboxInt adds key only for positive values, which matches GitHub database IDs.
 func putReviewInboxInt(entry map[string]any, key string, value int) {
 	if value > 0 {
 		entry[key] = value

--- a/internal/observe/github/prquery/prquery.go
+++ b/internal/observe/github/prquery/prquery.go
@@ -29,6 +29,7 @@ const prContextQuery = `query PRContext($owner: String!, $name: String!, $number
       mergeable @include(if: $includeDetail)
       mergeStateStatus @include(if: $includeDetail)
       baseRefName @include(if: $includeDetail)
+      headRefName @include(if: $includeDetail)
       headRefOid @include(if: $includeDetail)
       labels(first: 20) @include(if: $includeDetail) {
         nodes { name }
@@ -64,7 +65,23 @@ const prContextQuery = `query PRContext($owner: String!, $name: String!, $number
           endCursor
         }
         nodes {
+          id
           isResolved
+          isOutdated
+          comments(first: 1) {
+            nodes {
+              databaseId
+              body
+              path
+              line
+              originalLine
+              startLine
+              originalStartLine
+              author { login }
+              commit { oid }
+              originalCommit { oid }
+            }
+          }
         }
       }
     }
@@ -110,6 +127,7 @@ type prPullRequestNode struct {
 	Mergeable               *string            `json:"mergeable"`
 	MergeStateStatus        *string            `json:"mergeStateStatus"`
 	BaseRefName             *string            `json:"baseRefName"`
+	HeadRefName             *string            `json:"headRefName"`
 	HeadRefOid              *string            `json:"headRefOid"`
 	Labels                  *labelsConn        `json:"labels"`
 	ClosingIssuesReferences *closingIssuesConn `json:"closingIssuesReferences"`
@@ -178,13 +196,43 @@ type prCommentsPageResponse struct {
 
 //nolint:govet // fieldalignment: keep aligned with GraphQL response shape
 type reviewThreadsConn struct {
-	Nodes []struct {
-		IsResolved bool `json:"isResolved"`
-	} `json:"nodes"`
+	Nodes    []reviewThreadNode `json:"nodes"`
 	PageInfo struct {
 		HasNextPage bool   `json:"hasNextPage"`
 		EndCursor   string `json:"endCursor"`
 	} `json:"pageInfo"`
+}
+
+//nolint:govet // fieldalignment: GraphQL response shape
+type reviewThreadNode struct {
+	ID         string                    `json:"id"`
+	IsResolved bool                      `json:"isResolved"`
+	IsOutdated bool                      `json:"isOutdated"`
+	Comments   *reviewThreadCommentsConn `json:"comments"`
+}
+
+type reviewThreadCommentsConn struct {
+	Nodes []reviewThreadCommentNode `json:"nodes"`
+}
+
+//nolint:govet // fieldalignment: GraphQL response shape
+type reviewThreadCommentNode struct {
+	DatabaseID        int    `json:"databaseId"`
+	Body              string `json:"body"`
+	Path              string `json:"path"`
+	Line              *int   `json:"line"`
+	OriginalLine      *int   `json:"originalLine"`
+	StartLine         *int   `json:"startLine"`
+	OriginalStartLine *int   `json:"originalStartLine"`
+	Author            *struct {
+		Login string `json:"login"`
+	} `json:"author"`
+	Commit *struct {
+		Oid string `json:"oid"`
+	} `json:"commit"`
+	OriginalCommit *struct {
+		Oid string `json:"oid"`
+	} `json:"originalCommit"`
 }
 
 // CollectOptions configures optional behavior for CollectWithOptions.
@@ -210,7 +258,7 @@ func CollectWithOptions(ctx context.Context, c *githubapi.Client, owner, repo st
 	if prNumber <= 0 {
 		return nil, reviewsInner, nil
 	}
-	firstPR, total, unresolved, incomplete, err := paginatePRContext(ctx, c, owner, repo, prNumber)
+	firstPR, inbox, total, unresolved, incomplete, err := paginatePRContext(ctx, c, owner, repo, prNumber)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -229,6 +277,10 @@ func CollectWithOptions(ctx context.Context, c *githubapi.Client, owner, repo st
 	reviewsInner["review_threads_total"] = total
 	reviewsInner["review_threads_unresolved"] = unresolved
 	reviewsInner["pagination_incomplete"] = incomplete
+	if inbox == nil {
+		inbox = []any{}
+	}
+	reviewsInner["review_inbox"] = inbox
 	commentNodes, err := mergeCommentNodesForBots(ctx, c, owner, repo, prNumber, firstPR.Comments, bots)
 	if err != nil {
 		return nil, nil, err
@@ -243,7 +295,7 @@ func CollectWithOptions(ctx context.Context, c *githubapi.Client, owner, repo st
 	return pullDetail, reviewsInner, nil
 }
 
-func paginatePRContext(ctx context.Context, c *githubapi.Client, owner, repo string, prNumber int) (firstPR *prPullRequestNode, total, unresolved int, incomplete bool, err error) {
+func paginatePRContext(ctx context.Context, c *githubapi.Client, owner, repo string, prNumber int) (firstPR *prPullRequestNode, inbox []any, total, unresolved int, incomplete bool, err error) {
 	var cursor any
 	for page := 0; page < maxReviewThreadPages; page++ {
 		includeDetail := page == 0
@@ -256,10 +308,10 @@ func paginatePRContext(ctx context.Context, c *githubapi.Client, owner, repo str
 		}
 		var data prContextResponse
 		if err := c.PostGraphQL(ctx, prContextQuery, vars, &data); err != nil {
-			return nil, 0, 0, false, err
+			return nil, nil, 0, 0, false, err
 		}
 		if data.Repository == nil || data.Repository.PullRequest == nil {
-			return nil, 0, 0, false, nil
+			return nil, nil, 0, 0, false, nil
 		}
 		pr := data.Repository.PullRequest
 		if includeDetail {
@@ -273,6 +325,9 @@ func paginatePRContext(ctx context.Context, c *githubapi.Client, owner, repo str
 			total++
 			if !n.IsResolved {
 				unresolved++
+			}
+			if entry := buildReviewInboxEntry(n); entry != nil {
+				inbox = append(inbox, entry)
 			}
 		}
 		if !rt.PageInfo.HasNextPage {
@@ -289,7 +344,7 @@ func paginatePRContext(ctx context.Context, c *githubapi.Client, owner, repo str
 		}
 		cursor = end
 	}
-	return firstPR, total, unresolved, incomplete, nil
+	return firstPR, inbox, total, unresolved, incomplete, nil
 }
 
 func emptyReviewsInner() map[string]any {
@@ -297,6 +352,7 @@ func emptyReviewsInner() map[string]any {
 		"review_threads_total":               0,
 		"review_threads_unresolved":          0,
 		"pagination_incomplete":              false,
+		"review_inbox":                       []any{},
 		"review_decisions_total":             0,
 		"review_decisions_approved":          0,
 		"review_decisions_changes_requested": 0,
@@ -325,6 +381,9 @@ func buildPullDetail(pr *prPullRequestNode) map[string]any {
 	}
 	if pr.BaseRefName != nil {
 		m["base_ref"] = *pr.BaseRefName
+	}
+	if pr.HeadRefName != nil {
+		m["head_ref"] = *pr.HeadRefName
 	}
 	if pr.HeadRefOid != nil {
 		m["head_sha"] = *pr.HeadRefOid
@@ -391,6 +450,56 @@ func buildReviewDecisions(lr *latestReviewsConn) map[string]any {
 	out["review_decisions_changes_requested"] = changes
 	out["review_decisions_truncated"] = lr.PageInfo.HasNextPage
 	return out
+}
+
+func buildReviewInboxEntry(thread reviewThreadNode) map[string]any {
+	if thread.IsResolved {
+		return nil
+	}
+	entry := map[string]any{
+		"thread_id":   strings.TrimSpace(thread.ID),
+		"is_resolved": thread.IsResolved,
+		"is_outdated": thread.IsOutdated,
+	}
+	if thread.Comments == nil || len(thread.Comments.Nodes) == 0 {
+		return entry
+	}
+	root := thread.Comments.Nodes[0]
+	putReviewInboxInt(entry, "root_comment_id", root.DatabaseID)
+	putReviewInboxString(entry, "body", root.Body)
+	putReviewInboxString(entry, "path", root.Path)
+	putReviewInboxOptionalInt(entry, "line", root.Line)
+	putReviewInboxOptionalInt(entry, "original_line", root.OriginalLine)
+	putReviewInboxOptionalInt(entry, "start_line", root.StartLine)
+	putReviewInboxOptionalInt(entry, "original_start_line", root.OriginalStartLine)
+	if root.Author != nil {
+		putReviewInboxString(entry, "author", root.Author.Login)
+	}
+	if root.Commit != nil {
+		putReviewInboxString(entry, "commit_sha", root.Commit.Oid)
+	}
+	if root.OriginalCommit != nil {
+		putReviewInboxString(entry, "original_commit_sha", root.OriginalCommit.Oid)
+	}
+	return entry
+}
+
+func putReviewInboxInt(entry map[string]any, key string, value int) {
+	if value > 0 {
+		entry[key] = value
+	}
+}
+
+func putReviewInboxOptionalInt(entry map[string]any, key string, value *int) {
+	if value != nil {
+		entry[key] = *value
+	}
+}
+
+func putReviewInboxString(entry map[string]any, key, value string) {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		entry[key] = trimmed
+	}
 }
 
 // normalizeGitHubActorLogin maps login variants to one comparison key. GitHub App bots

--- a/internal/observe/github/prquery/prquery.go
+++ b/internal/observe/github/prquery/prquery.go
@@ -456,8 +456,12 @@ func buildReviewInboxEntry(thread reviewThreadNode) map[string]any {
 	if thread.IsResolved {
 		return nil
 	}
+	threadID := strings.TrimSpace(thread.ID)
+	if threadID == "" {
+		return nil
+	}
 	entry := map[string]any{
-		"thread_id":   strings.TrimSpace(thread.ID),
+		"thread_id":   threadID,
 		"is_outdated": thread.IsOutdated,
 	}
 	if thread.Comments == nil || len(thread.Comments.Nodes) == 0 {

--- a/internal/observe/github/prquery/prquery.go
+++ b/internal/observe/github/prquery/prquery.go
@@ -31,6 +31,10 @@ const prContextQuery = `query PRContext($owner: String!, $name: String!, $number
       baseRefName @include(if: $includeDetail)
       headRefName @include(if: $includeDetail)
       headRefOid @include(if: $includeDetail)
+      headRepository @include(if: $includeDetail) {
+        name
+        owner { login }
+      }
       labels(first: 20) @include(if: $includeDetail) {
         nodes { name }
       }
@@ -119,21 +123,30 @@ type prContextResponse struct {
 	} `json:"repository"`
 }
 
+//nolint:govet // fieldalignment: GraphQL response shape
+type headRepositoryNode struct {
+	Name  string `json:"name"`
+	Owner *struct {
+		Login string `json:"login"`
+	} `json:"owner"`
+}
+
 type prPullRequestNode struct {
 	State *string `json:"state"`
 	// IsDraft is returned as JSON boolean when @include detail.
-	IsDraft                 *bool              `json:"isDraft"`
-	Title                   *string            `json:"title"`
-	Mergeable               *string            `json:"mergeable"`
-	MergeStateStatus        *string            `json:"mergeStateStatus"`
-	BaseRefName             *string            `json:"baseRefName"`
-	HeadRefName             *string            `json:"headRefName"`
-	HeadRefOid              *string            `json:"headRefOid"`
-	Labels                  *labelsConn        `json:"labels"`
-	ClosingIssuesReferences *closingIssuesConn `json:"closingIssuesReferences"`
-	LatestReviews           *latestReviewsConn `json:"latestReviews"`
-	Comments                *commentsConn      `json:"comments"`
-	ReviewThreads           *reviewThreadsConn `json:"reviewThreads"`
+	IsDraft                 *bool               `json:"isDraft"`
+	Title                   *string             `json:"title"`
+	Mergeable               *string             `json:"mergeable"`
+	MergeStateStatus        *string             `json:"mergeStateStatus"`
+	BaseRefName             *string             `json:"baseRefName"`
+	HeadRefName             *string             `json:"headRefName"`
+	HeadRefOid              *string             `json:"headRefOid"`
+	HeadRepository          *headRepositoryNode `json:"headRepository"`
+	Labels                  *labelsConn         `json:"labels"`
+	ClosingIssuesReferences *closingIssuesConn  `json:"closingIssuesReferences"`
+	LatestReviews           *latestReviewsConn  `json:"latestReviews"`
+	Comments                *commentsConn       `json:"comments"`
+	ReviewThreads           *reviewThreadsConn  `json:"reviewThreads"`
 }
 
 type labelsConn struct {
@@ -368,6 +381,18 @@ func emptyReviewsInner() map[string]any {
 	}
 }
 
+func applyHeadRepositorySignals(pr *prPullRequestNode, m map[string]any) {
+	if pr == nil || pr.HeadRepository == nil {
+		return
+	}
+	if pr.HeadRepository.Owner != nil && strings.TrimSpace(pr.HeadRepository.Owner.Login) != "" {
+		m["head_repo_owner"] = strings.TrimSpace(pr.HeadRepository.Owner.Login)
+	}
+	if strings.TrimSpace(pr.HeadRepository.Name) != "" {
+		m["head_repo_name"] = strings.TrimSpace(pr.HeadRepository.Name)
+	}
+}
+
 func buildPullDetail(pr *prPullRequestNode) map[string]any {
 	m := make(map[string]any)
 	if pr.State != nil {
@@ -388,6 +413,7 @@ func buildPullDetail(pr *prPullRequestNode) map[string]any {
 	if pr.HeadRefOid != nil {
 		m["head_sha"] = *pr.HeadRefOid
 	}
+	applyHeadRepositorySignals(pr, m)
 	if pr.Mergeable != nil {
 		m["mergeable"] = mergeableToSignal(*pr.Mergeable)
 	}

--- a/internal/observe/github/prquery/prquery_inbox_test.go
+++ b/internal/observe/github/prquery/prquery_inbox_test.go
@@ -1,0 +1,57 @@
+package prquery
+
+import (
+	"testing"
+)
+
+func TestBuildReviewInboxEntry_fallbackOriginalAnchors(t *testing.T) {
+	t.Parallel()
+	// Given: GitHub may omit current line/commit on outdated threads while original* remains.
+	ln := 40
+	start := 38
+	origCommit := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	thread := reviewThreadNode{
+		ID:         "THREAD_FALLBACK",
+		IsResolved: false,
+		IsOutdated: true,
+		Comments: &reviewThreadCommentsConn{
+			Nodes: []reviewThreadCommentNode{{
+				DatabaseID:        9001,
+				Body:              "fix scope",
+				Path:              "internal/x.go",
+				Line:              nil,
+				OriginalLine:      &ln,
+				StartLine:         nil,
+				OriginalStartLine: &start,
+				Author: &struct {
+					Login string `json:"login"`
+				}{Login: "coderabbitai[bot]"},
+				Commit: nil,
+				OriginalCommit: &struct {
+					Oid string `json:"oid"`
+				}{Oid: origCommit},
+			}},
+		},
+	}
+	// When
+	entry := buildReviewInboxEntry(thread)
+	// Then: canonical anchors match original* for reply-thread use
+	if entry == nil {
+		t.Fatal("expected entry")
+	}
+	if got := entry["line"]; got != ln {
+		t.Fatalf("line: got %v want %d", got, ln)
+	}
+	if got := entry["start_line"]; got != start {
+		t.Fatalf("start_line: got %v want %d", got, start)
+	}
+	if got := entry["commit_sha"]; got != origCommit {
+		t.Fatalf("commit_sha: got %v want %q", got, origCommit)
+	}
+	if _, ok := entry["original_line"]; !ok {
+		t.Fatal("expected original_line preserved")
+	}
+	if _, ok := entry["original_commit_sha"]; !ok {
+		t.Fatal("expected original_commit_sha preserved")
+	}
+}

--- a/internal/observe/github/prquery/prquery_test.go
+++ b/internal/observe/github/prquery/prquery_test.go
@@ -225,7 +225,19 @@ func TestCollect_onePage_threadsAndDetail(t *testing.T) {
 		t.Fatalf("review_inbox: %+v", rev)
 	}
 	thread := inbox[0].(map[string]any)
-	if thread["thread_id"] != "THREAD_2" || thread["root_comment_id"].(int) != 202 {
+	if thread["thread_id"] != "THREAD_2" {
+		t.Fatalf("thread: %+v", thread)
+	}
+	switch id := thread["root_comment_id"].(type) {
+	case int:
+		if id != 202 {
+			t.Fatalf("want root_comment_id 202, got %d", id)
+		}
+	case float64:
+		if int(id) != 202 {
+			t.Fatalf("want root_comment_id 202, got %v", id)
+		}
+	default:
 		t.Fatalf("thread: %+v", thread)
 	}
 }

--- a/internal/observe/github/prquery/prquery_test.go
+++ b/internal/observe/github/prquery/prquery_test.go
@@ -113,6 +113,10 @@ func TestCollect_onePage_threadsAndDetail(t *testing.T) {
 						"baseRefName":      "main",
 						"headRefName":      "feat/scoped",
 						"headRefOid":       "abc123",
+						"headRepository": map[string]any{
+							"name":  "reinguard",
+							"owner": map[string]any{"login": "forkowner"},
+						},
 						"labels": map[string]any{
 							"nodes": []map[string]any{{"name": "feat"}},
 						},
@@ -193,6 +197,9 @@ func TestCollect_onePage_threadsAndDetail(t *testing.T) {
 	}
 	if pull["head_ref"].(string) != "feat/scoped" {
 		t.Fatalf("pull: %+v", pull)
+	}
+	if pull["head_repo_owner"].(string) != "forkowner" || pull["head_repo_name"].(string) != "reinguard" {
+		t.Fatalf("head repository: %+v", pull)
 	}
 	labels := pull["labels"].([]any)
 	if len(labels) != 1 || labels[0].(string) != "feat" {

--- a/internal/observe/github/prquery/prquery_test.go
+++ b/internal/observe/github/prquery/prquery_test.go
@@ -240,6 +240,50 @@ func TestCollect_onePage_threadsAndDetail(t *testing.T) {
 	default:
 		t.Fatalf("thread: %+v", thread)
 	}
+	if thread["is_outdated"] != true {
+		t.Fatalf("is_outdated: %+v", thread)
+	}
+	if thread["path"] != "internal/rgdcli/rgdcli.go" {
+		t.Fatalf("path: %+v", thread)
+	}
+	if thread["body"] != "please update scope" {
+		t.Fatalf("body: %+v", thread)
+	}
+	if thread["author"] != "coderabbitai[bot]" {
+		t.Fatalf("author: %+v", thread)
+	}
+	wantSHA := "0123456789abcdef0123456789abcdef01234567"
+	origSHA := "89abcdef0123456789abcdef0123456789abcdef"
+	if got := thread["commit_sha"]; got != wantSHA {
+		t.Fatalf("commit_sha: got %v want %q", got, wantSHA)
+	}
+	if got := thread["original_commit_sha"]; got != origSHA {
+		t.Fatalf("original_commit_sha: got %v want %q", got, origSHA)
+	}
+	switch ln := thread["line"].(type) {
+	case int:
+		if ln != 42 {
+			t.Fatalf("line: %d", ln)
+		}
+	case float64:
+		if int(ln) != 42 {
+			t.Fatalf("line: %v", ln)
+		}
+	default:
+		t.Fatalf("line type: %T", thread["line"])
+	}
+	switch oln := thread["original_line"].(type) {
+	case int:
+		if oln != 40 {
+			t.Fatalf("original_line: %d", oln)
+		}
+	case float64:
+		if int(oln) != 40 {
+			t.Fatalf("original_line: %v", oln)
+		}
+	default:
+		t.Fatalf("original_line type: %T", thread["original_line"])
+	}
 }
 
 func TestCollect_reviewThreadsPaginationIncomplete(t *testing.T) {

--- a/internal/observe/github/prquery/prquery_test.go
+++ b/internal/observe/github/prquery/prquery_test.go
@@ -111,6 +111,7 @@ func TestCollect_onePage_threadsAndDetail(t *testing.T) {
 						"mergeable":        "MERGEABLE",
 						"mergeStateStatus": "CLEAN",
 						"baseRefName":      "main",
+						"headRefName":      "feat/scoped",
 						"headRefOid":       "abc123",
 						"labels": map[string]any{
 							"nodes": []map[string]any{{"name": "feat"}},
@@ -131,8 +132,42 @@ func TestCollect_onePage_threadsAndDetail(t *testing.T) {
 						"reviewThreads": map[string]any{
 							"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
 							"nodes": []map[string]any{
-								{"isResolved": true},
-								{"isResolved": false},
+								{
+									"id":         "THREAD_1",
+									"isResolved": true,
+									"isOutdated": false,
+									"comments": map[string]any{
+										"nodes": []map[string]any{
+											{
+												"databaseId": 101,
+												"body":       "resolved",
+												"path":       "a.go",
+												"line":       1,
+											},
+										},
+									},
+								},
+								{
+									"id":         "THREAD_2",
+									"isResolved": false,
+									"isOutdated": true,
+									"comments": map[string]any{
+										"nodes": []map[string]any{
+											{
+												"databaseId":   202,
+												"body":         "please update scope",
+												"path":         "internal/rgdcli/rgdcli.go",
+												"line":         42,
+												"originalLine": 40,
+												"author":       map[string]any{"login": "coderabbitai[bot]"},
+												"commit":       map[string]any{"oid": "0123456789abcdef0123456789abcdef01234567"},
+												"originalCommit": map[string]any{
+													"oid": "89abcdef0123456789abcdef0123456789abcdef",
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -155,6 +190,9 @@ func TestCollect_onePage_threadsAndDetail(t *testing.T) {
 	}
 	if pull["mergeable"].(string) != "mergeable" {
 		t.Fatalf("mergeable: %+v", pull)
+	}
+	if pull["head_ref"].(string) != "feat/scoped" {
+		t.Fatalf("pull: %+v", pull)
 	}
 	labels := pull["labels"].([]any)
 	if len(labels) != 1 || labels[0].(string) != "feat" {
@@ -181,6 +219,14 @@ func TestCollect_onePage_threadsAndDetail(t *testing.T) {
 	}
 	if rev["review_decisions_total"].(int) != 2 || rev["review_decisions_approved"].(int) != 1 || rev["review_decisions_changes_requested"].(int) != 1 {
 		t.Fatalf("decisions: %+v", rev)
+	}
+	inbox := rev["review_inbox"].([]any)
+	if len(inbox) != 1 {
+		t.Fatalf("review_inbox: %+v", rev)
+	}
+	thread := inbox[0].(map[string]any)
+	if thread["thread_id"] != "THREAD_2" || thread["root_comment_id"].(int) != 202 {
+		t.Fatalf("thread: %+v", thread)
 	}
 }
 

--- a/internal/observe/github/pullrequests/pullrequests.go
+++ b/internal/observe/github/pullrequests/pullrequests.go
@@ -56,6 +56,14 @@ type Scope struct {
 	ResolvedPRNumber  int
 }
 
+// Selection values for Scope.Selection.
+const (
+	SelectionExplicitPR     = "explicit_pr"
+	SelectionExplicitBranch = "explicit_branch"
+	SelectionCurrentBranch  = "current_branch"
+	SelectionNone           = "none"
+)
+
 // Collect returns pull request signals for the effective observed branch / PR.
 func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir string, opts ScopeOptions) (map[string]any, Scope, []string, error) {
 	if c == nil {
@@ -86,7 +94,7 @@ func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir stri
 	prNum := 0
 	switch {
 	case scope.RequestedPRNumber > 0:
-		scope.Selection = "explicit_pr"
+		scope.Selection = SelectionExplicitPR
 		pull, err := fetchPullRequest(ctx, c, owner, repo, scope.RequestedPRNumber)
 		if err != nil {
 			return nil, scope, warnings, err
@@ -101,9 +109,9 @@ func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir stri
 		}
 	case branch != "":
 		if scope.RequestedBranch != "" {
-			scope.Selection = "explicit_branch"
+			scope.Selection = SelectionExplicitBranch
 		} else {
-			scope.Selection = "current_branch"
+			scope.Selection = SelectionCurrentBranch
 		}
 		// Issue search `head:<branch>` matches by prefix; use List Pulls with
 		// head=owner:branch for an exact head ref (GitHub REST).
@@ -128,7 +136,7 @@ func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir stri
 			}
 		}
 	default:
-		scope.Selection = "none"
+		scope.Selection = SelectionNone
 	}
 	scope.ResolvedPRNumber = prNum
 

--- a/internal/observe/github/pullrequests/pullrequests.go
+++ b/internal/observe/github/pullrequests/pullrequests.go
@@ -28,31 +28,83 @@ type pullHead struct {
 	Ref string `json:"ref"`
 }
 
+type pullGet struct {
+	Head   pullHead `json:"head"`
+	State  string   `json:"state"`
+	Number int      `json:"number"`
+}
+
 // pullListItem is one element from GET /repos/{owner}/{repo}/pulls for branch matching.
 type pullListItem struct {
 	Head   pullHead `json:"head"`
 	Number int      `json:"number"`
 }
 
-// Collect returns pull request signals for the current branch.
-func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir string) (map[string]any, []string, error) {
+// ScopeOptions configures explicit PR or branch selection for pull-request observation.
+type ScopeOptions struct {
+	Branch   string
+	PRNumber int
+}
+
+// Scope describes which branch / PR the pull-request facet observed.
+type Scope struct {
+	LocalBranch       string
+	RequestedBranch   string
+	EffectiveBranch   string
+	Selection         string
+	RequestedPRNumber int
+	ResolvedPRNumber  int
+}
+
+// Collect returns pull request signals for the effective observed branch / PR.
+func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir string, opts ScopeOptions) (map[string]any, Scope, []string, error) {
 	if c == nil {
-		return nil, nil, fmt.Errorf("nil client")
+		return nil, Scope{}, nil, fmt.Errorf("nil client")
 	}
 	var warnings []string
-	branch, w := resolveBranch(ctx, workDir)
+	localBranch, w := resolveBranch(ctx, workDir)
 	warnings = append(warnings, w...)
+	scope := Scope{
+		LocalBranch:       localBranch,
+		RequestedBranch:   strings.TrimSpace(opts.Branch),
+		RequestedPRNumber: opts.PRNumber,
+	}
 
 	qOpen := fmt.Sprintf("repo:%s/%s is:pr is:open", owner, repo)
 	uOpen := c.APIBase() + "/search/issues?q=" + url.QueryEscape(qOpen)
 	var openOut searchResponse
 	if err := c.GetJSON(ctx, uOpen, &openOut); err != nil {
-		return nil, warnings, err
+		return nil, scope, warnings, err
 	}
 
+	branch := scope.RequestedBranch
+	if branch == "" {
+		branch = localBranch
+	}
+	scope.EffectiveBranch = branch
 	prForBranch := false
 	prNum := 0
-	if branch != "" {
+	switch {
+	case scope.RequestedPRNumber > 0:
+		scope.Selection = "explicit_pr"
+		pull, err := fetchPullRequest(ctx, c, owner, repo, scope.RequestedPRNumber)
+		if err != nil {
+			return nil, scope, warnings, err
+		}
+		if !strings.EqualFold(strings.TrimSpace(pull.State), "open") {
+			return nil, scope, warnings, fmt.Errorf("pull request #%d is not open", scope.RequestedPRNumber)
+		}
+		prForBranch = true
+		prNum = pull.Number
+		if scope.RequestedBranch == "" {
+			scope.EffectiveBranch = strings.TrimSpace(pull.Head.Ref)
+		}
+	case branch != "":
+		if scope.RequestedBranch != "" {
+			scope.Selection = "explicit_branch"
+		} else {
+			scope.Selection = "current_branch"
+		}
 		// Issue search `head:<branch>` matches by prefix; use List Pulls with
 		// head=owner:branch for an exact head ref (GitHub REST).
 		q := url.Values{}
@@ -66,7 +118,7 @@ func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir stri
 		)
 		var pulls []pullListItem
 		if err := c.GetJSON(ctx, uPulls, &pulls); err != nil {
-			return nil, warnings, err
+			return nil, scope, warnings, err
 		}
 		for _, p := range pulls {
 			if strings.EqualFold(p.Head.Ref, branch) {
@@ -75,16 +127,20 @@ func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir stri
 				break
 			}
 		}
+	default:
+		scope.Selection = "none"
 	}
+	scope.ResolvedPRNumber = prNum
 
 	return map[string]any{
 		"pull_requests": map[string]any{
 			"open_count":           openOut.TotalCount,
-			"current_branch":       branch,
+			"current_branch":       scope.EffectiveBranch,
 			"pr_exists_for_branch": prForBranch,
 			"pr_number_for_branch": prNum,
+			"observed_scope":       scope.signalMap(),
 		},
-	}, warnings, nil
+	}, scope, warnings, nil
 }
 
 // resolveBranch returns the current branch name or warnings for detached HEAD / errors.
@@ -97,4 +153,36 @@ func resolveBranch(ctx context.Context, workDir string) (branch string, warnings
 		return "", []string{"detached HEAD"}
 	}
 	return b, nil
+}
+
+func fetchPullRequest(ctx context.Context, c *githubapi.Client, owner, repo string, number int) (pullGet, error) {
+	u := fmt.Sprintf("%s/repos/%s/%s/pulls/%d",
+		c.APIBase(),
+		url.PathEscape(owner),
+		url.PathEscape(repo),
+		number,
+	)
+	var pull pullGet
+	if err := c.GetJSON(ctx, u, &pull); err != nil {
+		return pullGet{}, err
+	}
+	return pull, nil
+}
+
+func (s Scope) signalMap() map[string]any {
+	out := map[string]any{
+		"local_branch_at_collect": s.LocalBranch,
+		"selection":               s.Selection,
+		"resolved_pr_number":      s.ResolvedPRNumber,
+	}
+	if s.RequestedBranch != "" {
+		out["requested_branch"] = s.RequestedBranch
+	}
+	if s.RequestedPRNumber > 0 {
+		out["requested_pr_number"] = s.RequestedPRNumber
+	}
+	if s.EffectiveBranch != "" {
+		out["effective_branch"] = s.EffectiveBranch
+	}
+	return out
 }

--- a/internal/observe/github/pullrequests/pullrequests.go
+++ b/internal/observe/github/pullrequests/pullrequests.go
@@ -104,9 +104,7 @@ func Collect(ctx context.Context, c *githubapi.Client, owner, repo, workDir stri
 		}
 		prForBranch = true
 		prNum = pull.Number
-		if scope.RequestedBranch == "" {
-			scope.EffectiveBranch = strings.TrimSpace(pull.Head.Ref)
-		}
+		scope.EffectiveBranch = strings.TrimSpace(pull.Head.Ref)
 	case branch != "":
 		if scope.RequestedBranch != "" {
 			scope.Selection = SelectionExplicitBranch

--- a/internal/observe/github/pullrequests/pullrequests_test.go
+++ b/internal/observe/github/pullrequests/pullrequests_test.go
@@ -55,7 +55,7 @@ func TestCollect_prForBranch_usesPullsListExactHead(t *testing.T) {
 	if pr["pr_number_for_branch"].(int) != 99 {
 		t.Fatalf("want pr number 99, got %v", pr["pr_number_for_branch"])
 	}
-	if scope.Selection != "current_branch" {
+	if scope.Selection != SelectionCurrentBranch {
 		t.Fatalf("scope=%+v", scope)
 	}
 }
@@ -195,7 +195,7 @@ func TestCollect_explicitBranchOverridesLocalBranch(t *testing.T) {
 	if observed["local_branch_at_collect"] != "main" || observed["requested_branch"] != "feature/review" {
 		t.Fatalf("observed_scope=%+v", observed)
 	}
-	if scope.Selection != "explicit_branch" {
+	if scope.Selection != SelectionExplicitBranch {
 		t.Fatalf("scope=%+v", scope)
 	}
 }
@@ -245,7 +245,117 @@ func TestCollect_explicitPROpensRequestedPR(t *testing.T) {
 	if !ok || reqPR != 18 || observed["effective_branch"] != "feature/scoped" {
 		t.Fatalf("observed_scope=%+v", observed)
 	}
-	if scope.Selection != "explicit_pr" || scope.EffectiveBranch != "feature/scoped" {
+	if scope.Selection != SelectionExplicitPR || scope.EffectiveBranch != "feature/scoped" {
+		t.Fatalf("scope=%+v", scope)
+	}
+}
+
+func TestCollect_explicitPRNotFoundReturnsError(t *testing.T) {
+	t.Parallel()
+	// Given: local repo on main and an explicit PR target that the API cannot find
+	dir := t.TempDir()
+	run(t, "git", dir, "init")
+	run(t, "git", dir, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
+	run(t, "git", dir, "branch", "-M", "main")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+		case "/repos/o/r/pulls/99":
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "tok", BaseURL: srv.URL}
+	// When: Collect runs with an unknown explicit PR number
+	_, _, _, err := Collect(context.Background(), c, "o", "r", dir, ScopeOptions{PRNumber: 99})
+
+	// Then: the missing PR surfaces as an error
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestCollect_explicitPRClosedReturnsError(t *testing.T) {
+	t.Parallel()
+	// Given: local repo on main and an explicit PR target that is closed
+	dir := t.TempDir()
+	run(t, "git", dir, "init")
+	run(t, "git", dir, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
+	run(t, "git", dir, "branch", "-M", "main")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count":1,"items":[{"number":18}]}`))
+		case "/repos/o/r/pulls/18":
+			_, _ = w.Write([]byte(`{"number":18,"state":"closed","head":{"ref":"feature/scoped"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "tok", BaseURL: srv.URL}
+	// When: Collect runs with a closed explicit PR number
+	_, _, _, err := Collect(context.Background(), c, "o", "r", dir, ScopeOptions{PRNumber: 18})
+
+	// Then: the helper rejects the non-open PR
+	if err == nil || !strings.Contains(err.Error(), "not open") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestCollect_explicitBranchWithoutMatchingPROmitsResolution(t *testing.T) {
+	t.Parallel()
+	// Given: local repo on main and an explicit branch with no matching open PR
+	dir := t.TempDir()
+	run(t, "git", dir, "init")
+	run(t, "git", dir, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
+	run(t, "git", dir, "branch", "-M", "main")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count":1,"items":[{"number":17}]}`))
+		case "/repos/o/r/pulls":
+			if r.URL.Query().Get("head") != "o:feature/missing" {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "tok", BaseURL: srv.URL}
+	// When: Collect runs with an explicit branch that has no matching PR
+	m, scope, warns, err := Collect(context.Background(), c, "o", "r", dir, ScopeOptions{Branch: "feature/missing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("%v", warns)
+	}
+
+	// Then: the branch remains observed without resolving a PR number
+	pr, ok := m["pull_requests"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pull_requests map, got %T", m["pull_requests"])
+	}
+	if pr["current_branch"] != "feature/missing" || pr["pr_exists_for_branch"].(bool) {
+		t.Fatalf("pull_requests=%+v", pr)
+	}
+	if pr["pr_number_for_branch"].(int) != 0 {
+		t.Fatalf("pull_requests=%+v", pr)
+	}
+	if scope.Selection != SelectionExplicitBranch || scope.ResolvedPRNumber != 0 {
 		t.Fatalf("scope=%+v", scope)
 	}
 }

--- a/internal/observe/github/pullrequests/pullrequests_test.go
+++ b/internal/observe/github/pullrequests/pullrequests_test.go
@@ -37,7 +37,7 @@ func TestCollect_prForBranch_usesPullsListExactHead(t *testing.T) {
 
 	c := &githubapi.Client{HTTP: srv.Client(), Token: "tok", BaseURL: srv.URL}
 	// When: Collect runs
-	m, warns, err := Collect(context.Background(), c, "o", "r", dir)
+	m, scope, warns, err := Collect(context.Background(), c, "o", "r", dir, ScopeOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,6 +54,9 @@ func TestCollect_prForBranch_usesPullsListExactHead(t *testing.T) {
 	}
 	if pr["pr_number_for_branch"].(int) != 99 {
 		t.Fatalf("want pr number 99, got %v", pr["pr_number_for_branch"])
+	}
+	if scope.Selection != "current_branch" {
+		t.Fatalf("scope=%+v", scope)
 	}
 }
 
@@ -84,7 +87,7 @@ func TestCollect_withGitRepo(t *testing.T) {
 
 	c := &githubapi.Client{HTTP: srv.Client(), Token: "tok", BaseURL: srv.URL}
 	// When: Collect runs
-	m, warns, err := Collect(context.Background(), c, "o", "r", dir)
+	m, scope, warns, err := Collect(context.Background(), c, "o", "r", dir, ScopeOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,6 +104,9 @@ func TestCollect_withGitRepo(t *testing.T) {
 	}
 	if oc, ok := pr["open_count"].(int); !ok || oc != 0 {
 		t.Fatalf("open_count want 0 got %v (%T)", pr["open_count"], pr["open_count"])
+	}
+	if scope.LocalBranch != "main" {
+		t.Fatalf("scope=%+v", scope)
 	}
 }
 
@@ -131,12 +137,115 @@ func TestCollect_detachedHeadWarning(t *testing.T) {
 	t.Cleanup(srv.Close)
 	c := &githubapi.Client{HTTP: srv.Client(), Token: "tok", BaseURL: srv.URL}
 	// When: Collect runs
-	_, warns, err := Collect(context.Background(), c, "o", "r", dir)
+	_, _, warns, err := Collect(context.Background(), c, "o", "r", dir, ScopeOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Then: non-empty warnings (detached head)
 	if len(warns) == 0 {
 		t.Fatal("expected warning")
+	}
+}
+
+func TestCollect_explicitBranchOverridesLocalBranch(t *testing.T) {
+	t.Parallel()
+	// Given: local repo on main and an API response for feature/review
+	dir := t.TempDir()
+	run(t, "git", dir, "init")
+	run(t, "git", dir, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
+	run(t, "git", dir, "branch", "-M", "main")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count":1,"items":[{"number":17}]}`))
+		case "/repos/o/r/pulls":
+			if r.URL.Query().Get("head") != "o:feature/review" {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write([]byte(`[{"number":17,"head":{"ref":"feature/review"}}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "tok", BaseURL: srv.URL}
+	// When: Collect runs with an explicit branch override
+	m, scope, warns, err := Collect(context.Background(), c, "o", "r", dir, ScopeOptions{Branch: "feature/review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("%v", warns)
+	}
+	// Then: the resolved PR and observed scope follow the requested branch
+	pr, ok := m["pull_requests"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pull_requests map, got %T", m["pull_requests"])
+	}
+	if pr["current_branch"] != "feature/review" || pr["pr_number_for_branch"].(int) != 17 {
+		t.Fatalf("pull_requests=%+v", pr)
+	}
+	observed, ok := pr["observed_scope"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected observed_scope map, got %T", pr["observed_scope"])
+	}
+	if observed["local_branch_at_collect"] != "main" || observed["requested_branch"] != "feature/review" {
+		t.Fatalf("observed_scope=%+v", observed)
+	}
+	if scope.Selection != "explicit_branch" {
+		t.Fatalf("scope=%+v", scope)
+	}
+}
+
+func TestCollect_explicitPROpensRequestedPR(t *testing.T) {
+	t.Parallel()
+	// Given: local repo on main and an explicit open PR target
+	dir := t.TempDir()
+	run(t, "git", dir, "init")
+	run(t, "git", dir, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
+	run(t, "git", dir, "branch", "-M", "main")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count":2,"items":[{"number":17},{"number":18}]}`))
+		case "/repos/o/r/pulls/18":
+			_, _ = w.Write([]byte(`{"number":18,"state":"open","head":{"ref":"feature/scoped"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "tok", BaseURL: srv.URL}
+	// When: Collect runs with an explicit PR number
+	m, scope, warns, err := Collect(context.Background(), c, "o", "r", dir, ScopeOptions{PRNumber: 18})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("%v", warns)
+	}
+	// Then: the observed scope resolves to PR #18 and its head branch
+	pr, ok := m["pull_requests"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pull_requests map, got %T", m["pull_requests"])
+	}
+	if !pr["pr_exists_for_branch"].(bool) || pr["pr_number_for_branch"].(int) != 18 {
+		t.Fatalf("pull_requests=%+v", pr)
+	}
+	observed, ok := pr["observed_scope"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected observed_scope map, got %T", pr["observed_scope"])
+	}
+	reqPR, ok := observed["requested_pr_number"].(int)
+	if !ok || reqPR != 18 || observed["effective_branch"] != "feature/scoped" {
+		t.Fatalf("observed_scope=%+v", observed)
+	}
+	if scope.Selection != "explicit_pr" || scope.EffectiveBranch != "feature/scoped" {
+		t.Fatalf("scope=%+v", scope)
 	}
 }

--- a/internal/observe/github/pullrequests/pullrequests_test.go
+++ b/internal/observe/github/pullrequests/pullrequests_test.go
@@ -359,3 +359,56 @@ func TestCollect_explicitBranchWithoutMatchingPROmitsResolution(t *testing.T) {
 		t.Fatalf("scope=%+v", scope)
 	}
 }
+
+func TestCollect_explicitPRWinsOverRequestedBranchForEffectiveBranch(t *testing.T) {
+	t.Parallel()
+	// Given: local repo on main, explicit PR number, and a different explicit branch override
+	dir := t.TempDir()
+	run(t, "git", dir, "init")
+	run(t, "git", dir, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
+	run(t, "git", dir, "branch", "-M", "main")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count":1,"items":[{"number":18}]}`))
+		case "/repos/o/r/pulls/18":
+			_, _ = w.Write([]byte(`{"number":18,"state":"open","head":{"ref":"feature/scoped"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "tok", BaseURL: srv.URL}
+	// When: Collect runs with both explicit selectors
+	m, scope, warns, err := Collect(context.Background(), c, "o", "r", dir, ScopeOptions{
+		Branch:   "feature/ignored",
+		PRNumber: 18,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("%v", warns)
+	}
+
+	// Then: explicit PR selection wins and current_branch follows the PR head ref
+	pr, ok := m["pull_requests"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pull_requests map, got %T", m["pull_requests"])
+	}
+	if pr["current_branch"] != "feature/scoped" || pr["pr_number_for_branch"].(int) != 18 {
+		t.Fatalf("pull_requests=%+v", pr)
+	}
+	observed, ok := pr["observed_scope"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected observed_scope map, got %T", pr["observed_scope"])
+	}
+	if observed["requested_branch"] != "feature/ignored" || observed["effective_branch"] != "feature/scoped" {
+		t.Fatalf("observed_scope=%+v", observed)
+	}
+	if scope.Selection != SelectionExplicitPR || scope.EffectiveBranch != "feature/scoped" {
+		t.Fatalf("scope=%+v", scope)
+	}
+}

--- a/internal/observe/pipeline.go
+++ b/internal/observe/pipeline.go
@@ -15,7 +15,13 @@ type LoadSignalsOptions struct {
 	// When empty, Collect runs against the repository.
 	ObservationPath string
 	WorkDir         string
-	Serial          bool
+	// Branch observes GitHub PR linkage for a specific branch.
+	// When empty, live collection uses the checked-out branch.
+	Branch string
+	// PRNumber observes GitHub PR-scoped facets for a specific pull request.
+	// When zero, live collection does not force a PR number.
+	PRNumber int
+	Serial   bool
 }
 
 // LoadSignalsFileOrCollect reads observation JSON from ObservationPath when set (signals,
@@ -38,7 +44,11 @@ func LoadSignalsFileOrCollect(ctx context.Context, root *config.Root, opts LoadS
 	if err != nil {
 		return nil, nil, false, err
 	}
-	return engine.Collect(ctx, root, Options{WorkDir: opts.WorkDir, Serial: opts.Serial})
+	return engine.Collect(ctx, root, Options{
+		WorkDir: opts.WorkDir,
+		Scope:   Scope{Branch: opts.Branch, PRNumber: opts.PRNumber},
+		Serial:  opts.Serial,
+	})
 }
 
 // ParseObservationJSON decodes a saved observation document (signals, diagnostics, degraded).

--- a/internal/observe/provider_github.go
+++ b/internal/observe/provider_github.go
@@ -220,7 +220,7 @@ func (p *GitHubProvider) Collect(ctx context.Context, opts Options) (Fragment, e
 	needScopedCIHead := wantFacet("ci") && explicitScope
 	p.githubCollectIssues(ctx, client, owner, repo, wantFacet("issues"), signals, &diags, &degraded)
 	p.githubCollectPullRequestsAndPRNum(ctx, client, owner, repo, opts, wantFacet, signals, appendWarnings, &diags, &degraded, &prNum, &prLookupOK)
-	prHeadSHA = p.githubCollectPRGraph(ctx, client, owner, repo, prNum, wantFacet("pull-requests"), wantFacet("reviews"), needScopedCIHead, prLookupOK, signals, &diags, &degraded, opts)
+	prHeadSHA, ciStatusOwner, ciStatusRepo := p.githubCollectPRGraph(ctx, client, owner, repo, prNum, wantFacet("pull-requests"), wantFacet("reviews"), needScopedCIHead, prLookupOK, signals, &diags, &degraded, opts)
 	if wantFacet("ci") && explicitScope && strings.TrimSpace(prHeadSHA) == "" {
 		degraded = true
 		diags = append(diags, Diagnostic{
@@ -236,7 +236,7 @@ func (p *GitHubProvider) Collect(ctx context.Context, opts Options) (Fragment, e
 			},
 		})
 	} else {
-		p.githubCollectCI(ctx, client, owner, repo, opts.WorkDir, prHeadSHA, wantFacet("ci"), signals, appendWarnings, &diags, &degraded)
+		p.githubCollectCI(ctx, client, owner, repo, opts.WorkDir, prHeadSHA, ciStatusOwner, ciStatusRepo, wantFacet("ci"), signals, appendWarnings, &diags, &degraded)
 	}
 
 	return Fragment{Signals: signals, Diagnostics: diags, Degraded: degraded}, nil
@@ -281,11 +281,15 @@ func (*GitHubProvider) githubCollectPullRequestsAndPRNum(ctx context.Context, cl
 	}
 }
 
-func (*GitHubProvider) githubCollectCI(ctx context.Context, client *githubapi.Client, owner, repo, workDir, headSHA string, want bool, signals map[string]any, appendWarnings func(string, []string), diags *[]Diagnostic, degraded *bool) {
+func (*GitHubProvider) githubCollectCI(ctx context.Context, client *githubapi.Client, baseOwner, baseRepo, workDir, headSHA string, statusOwner, statusRepo string, want bool, signals map[string]any, appendWarnings func(string, []string), diags *[]Diagnostic, degraded *bool) {
 	if !want {
 		return
 	}
-	m, warns, err := ci.Collect(ctx, client, owner, repo, workDir, headSHA)
+	repoOwner, repoName := strings.TrimSpace(statusOwner), strings.TrimSpace(statusRepo)
+	if repoOwner == "" || repoName == "" {
+		repoOwner, repoName = baseOwner, baseRepo
+	}
+	m, warns, err := ci.Collect(ctx, client, repoOwner, repoName, workDir, headSHA)
 	if err != nil {
 		*degraded = true
 		*diags = append(*diags, Diagnostic{Severity: "error", Message: err.Error(), Provider: "github.ci"})
@@ -295,21 +299,34 @@ func (*GitHubProvider) githubCollectCI(ctx context.Context, client *githubapi.Cl
 	mergeSignals(signals, m)
 }
 
-func (p *GitHubProvider) githubCollectPRGraph(ctx context.Context, client *githubapi.Client, owner, repo string, prNum int, wantPull, wantRev, wantCI bool, prLookupOK bool, signals map[string]any, diags *[]Diagnostic, degraded *bool, opts Options) string {
+// headRepoForCIStatus returns the owner and repo for GET .../commits/{sha}/status.
+// Fork PRs report statuses on the head repository; same-repo PRs match base owner/repo.
+func headRepoForCIStatus(pullDetail map[string]any, baseOwner, baseRepo string) (string, string) {
+	statusOwner, statusRepo := baseOwner, baseRepo
+	if ho, ok := pullDetail["head_repo_owner"].(string); ok && strings.TrimSpace(ho) != "" {
+		if hn, ok := pullDetail["head_repo_name"].(string); ok && strings.TrimSpace(hn) != "" {
+			return strings.TrimSpace(ho), strings.TrimSpace(hn)
+		}
+	}
+	return statusOwner, statusRepo
+}
+
+func (p *GitHubProvider) githubCollectPRGraph(ctx context.Context, client *githubapi.Client, owner, repo string, prNum int, wantPull, wantRev, wantCI bool, prLookupOK bool, signals map[string]any, diags *[]Diagnostic, degraded *bool, opts Options) (headSHA string, statusOwner string, statusRepo string) {
 	if !wantPull && !wantRev && !wantCI {
-		return ""
+		return "", "", ""
 	}
 	if !prLookupOK || prNum <= 0 {
-		return ""
+		return "", "", ""
 	}
 	pullDetail, revInner, err := prquery.Collect(ctx, client, owner, repo, prNum, p.BotReviewers)
 	if err != nil {
 		*degraded = true
 		*diags = append(*diags, Diagnostic{Severity: "error", Message: err.Error(), Provider: "github.pr-query"})
-		return ""
+		return "", "", ""
 	}
-	headSHA, _ := pullDetail["head_sha"].(string)
+	headSHA, _ = pullDetail["head_sha"].(string)
 	headRef, _ := pullDetail["head_ref"].(string)
+	statusOwner, statusRepo = headRepoForCIStatus(pullDetail, owner, repo)
 	if wantPull && len(pullDetail) > 0 {
 		if existing, ok := signals["pull_requests"].(map[string]any); ok {
 			for k, v := range pullDetail {
@@ -329,9 +346,9 @@ func (p *GitHubProvider) githubCollectPRGraph(ctx context.Context, client *githu
 		mergeSignals(signals, map[string]any{"reviews": revInner})
 	}
 	if wantCI {
-		return headSHA
+		return headSHA, statusOwner, statusRepo
 	}
-	return ""
+	return "", "", ""
 }
 
 func mergeSignals(dst map[string]any, src map[string]any) {

--- a/internal/observe/provider_github.go
+++ b/internal/observe/provider_github.go
@@ -216,10 +216,11 @@ func (p *GitHubProvider) Collect(ctx context.Context, opts Options) (Fragment, e
 	var prNum int
 	prLookupOK := true
 	var prHeadSHA string
+	explicitScope := opts.Scope.PRNumber > 0 || strings.TrimSpace(opts.Scope.Branch) != ""
+	needScopedCIHead := wantFacet("ci") && explicitScope
 	p.githubCollectIssues(ctx, client, owner, repo, wantFacet("issues"), signals, &diags, &degraded)
 	p.githubCollectPullRequestsAndPRNum(ctx, client, owner, repo, opts, wantFacet, signals, appendWarnings, &diags, &degraded, &prNum, &prLookupOK)
-	prHeadSHA = p.githubCollectPRGraph(ctx, client, owner, repo, prNum, wantFacet("pull-requests"), wantFacet("reviews"), wantFacet("ci"), prLookupOK, signals, &diags, &degraded, opts)
-	explicitScope := opts.Scope.PRNumber > 0 || strings.TrimSpace(opts.Scope.Branch) != ""
+	prHeadSHA = p.githubCollectPRGraph(ctx, client, owner, repo, prNum, wantFacet("pull-requests"), wantFacet("reviews"), needScopedCIHead, prLookupOK, signals, &diags, &degraded, opts)
 	if wantFacet("ci") && explicitScope && strings.TrimSpace(prHeadSHA) == "" {
 		degraded = true
 		diags = append(diags, Diagnostic{
@@ -255,7 +256,9 @@ func (*GitHubProvider) githubCollectIssues(ctx context.Context, client *githubap
 }
 
 func (*GitHubProvider) githubCollectPullRequestsAndPRNum(ctx context.Context, client *githubapi.Client, owner, repo string, opts Options, wantFacet func(string) bool, signals map[string]any, appendWarnings func(string, []string), diags *[]Diagnostic, degraded *bool, prNum *int, prLookupOK *bool) {
-	if !wantFacet("pull-requests") && !wantFacet("reviews") && !wantFacet("ci") {
+	explicitScope := opts.Scope.PRNumber > 0 || strings.TrimSpace(opts.Scope.Branch) != ""
+	needPRForCI := wantFacet("ci") && explicitScope
+	if !wantFacet("pull-requests") && !wantFacet("reviews") && !needPRForCI {
 		return
 	}
 	m, _, warns, err := pullrequests.Collect(ctx, client, owner, repo, opts.WorkDir, pullrequests.ScopeOptions{
@@ -325,7 +328,10 @@ func (p *GitHubProvider) githubCollectPRGraph(ctx context.Context, client *githu
 	if wantRev {
 		mergeSignals(signals, map[string]any{"reviews": revInner})
 	}
-	return headSHA
+	if wantCI {
+		return headSHA
+	}
+	return ""
 }
 
 func mergeSignals(dst map[string]any, src map[string]any) {

--- a/internal/observe/provider_github.go
+++ b/internal/observe/provider_github.go
@@ -219,7 +219,24 @@ func (p *GitHubProvider) Collect(ctx context.Context, opts Options) (Fragment, e
 	p.githubCollectIssues(ctx, client, owner, repo, wantFacet("issues"), signals, &diags, &degraded)
 	p.githubCollectPullRequestsAndPRNum(ctx, client, owner, repo, opts, wantFacet, signals, appendWarnings, &diags, &degraded, &prNum, &prLookupOK)
 	prHeadSHA = p.githubCollectPRGraph(ctx, client, owner, repo, prNum, wantFacet("pull-requests"), wantFacet("reviews"), wantFacet("ci"), prLookupOK, signals, &diags, &degraded, opts)
-	p.githubCollectCI(ctx, client, owner, repo, opts.WorkDir, prHeadSHA, wantFacet("ci"), signals, appendWarnings, &diags, &degraded)
+	explicitScope := opts.Scope.PRNumber > 0 || strings.TrimSpace(opts.Scope.Branch) != ""
+	if wantFacet("ci") && explicitScope && strings.TrimSpace(prHeadSHA) == "" {
+		degraded = true
+		diags = append(diags, Diagnostic{
+			Severity: "error",
+			Message:  "scoped CI collection could not resolve the selected head SHA",
+			Provider: "github.ci",
+			Code:     "scoped_head_unresolved",
+		})
+		mergeSignals(signals, map[string]any{
+			"ci": map[string]any{
+				"ci_status": "unknown",
+				"head_sha":  "",
+			},
+		})
+	} else {
+		p.githubCollectCI(ctx, client, owner, repo, opts.WorkDir, prHeadSHA, wantFacet("ci"), signals, appendWarnings, &diags, &degraded)
+	}
 
 	return Fragment{Signals: signals, Diagnostics: diags, Degraded: degraded}, nil
 }

--- a/internal/observe/provider_github.go
+++ b/internal/observe/provider_github.go
@@ -360,7 +360,7 @@ func updateObservedScope(prMap map[string]any, opts Options, prNum int, headRef,
 	raw["resolved_pr_number"] = prNum
 	if headRef != "" {
 		raw["pr_head_branch"] = headRef
-		if opts.Scope.PRNumber > 0 && strings.TrimSpace(opts.Scope.Branch) == "" {
+		if opts.Scope.PRNumber > 0 {
 			prMap["current_branch"] = headRef
 			raw["effective_branch"] = headRef
 		}

--- a/internal/observe/provider_github.go
+++ b/internal/observe/provider_github.go
@@ -215,10 +215,11 @@ func (p *GitHubProvider) Collect(ctx context.Context, opts Options) (Fragment, e
 
 	var prNum int
 	prLookupOK := true
+	var prHeadSHA string
 	p.githubCollectIssues(ctx, client, owner, repo, wantFacet("issues"), signals, &diags, &degraded)
-	p.githubCollectPullRequestsAndPRNum(ctx, client, owner, repo, opts.WorkDir, wantFacet, signals, appendWarnings, &diags, &degraded, &prNum, &prLookupOK)
-	p.githubCollectCI(ctx, client, owner, repo, opts.WorkDir, wantFacet("ci"), signals, appendWarnings, &diags, &degraded)
-	p.githubCollectPRGraph(ctx, client, owner, repo, prNum, wantFacet("pull-requests"), wantFacet("reviews"), prLookupOK, signals, &diags, &degraded)
+	p.githubCollectPullRequestsAndPRNum(ctx, client, owner, repo, opts, wantFacet, signals, appendWarnings, &diags, &degraded, &prNum, &prLookupOK)
+	prHeadSHA = p.githubCollectPRGraph(ctx, client, owner, repo, prNum, wantFacet("pull-requests"), wantFacet("reviews"), wantFacet("ci"), prLookupOK, signals, &diags, &degraded, opts)
+	p.githubCollectCI(ctx, client, owner, repo, opts.WorkDir, prHeadSHA, wantFacet("ci"), signals, appendWarnings, &diags, &degraded)
 
 	return Fragment{Signals: signals, Diagnostics: diags, Degraded: degraded}, nil
 }
@@ -236,11 +237,14 @@ func (*GitHubProvider) githubCollectIssues(ctx context.Context, client *githubap
 	mergeSignals(signals, m)
 }
 
-func (*GitHubProvider) githubCollectPullRequestsAndPRNum(ctx context.Context, client *githubapi.Client, owner, repo, workDir string, wantFacet func(string) bool, signals map[string]any, appendWarnings func(string, []string), diags *[]Diagnostic, degraded *bool, prNum *int, prLookupOK *bool) {
-	if !wantFacet("pull-requests") && !wantFacet("reviews") {
+func (*GitHubProvider) githubCollectPullRequestsAndPRNum(ctx context.Context, client *githubapi.Client, owner, repo string, opts Options, wantFacet func(string) bool, signals map[string]any, appendWarnings func(string, []string), diags *[]Diagnostic, degraded *bool, prNum *int, prLookupOK *bool) {
+	if !wantFacet("pull-requests") && !wantFacet("reviews") && !wantFacet("ci") {
 		return
 	}
-	m, warns, err := pullrequests.Collect(ctx, client, owner, repo, workDir)
+	m, _, warns, err := pullrequests.Collect(ctx, client, owner, repo, opts.WorkDir, pullrequests.ScopeOptions{
+		Branch:   opts.Scope.Branch,
+		PRNumber: opts.Scope.PRNumber,
+	})
 	if err != nil {
 		*prLookupOK = false
 		*degraded = true
@@ -257,11 +261,11 @@ func (*GitHubProvider) githubCollectPullRequestsAndPRNum(ctx context.Context, cl
 	}
 }
 
-func (*GitHubProvider) githubCollectCI(ctx context.Context, client *githubapi.Client, owner, repo, workDir string, want bool, signals map[string]any, appendWarnings func(string, []string), diags *[]Diagnostic, degraded *bool) {
+func (*GitHubProvider) githubCollectCI(ctx context.Context, client *githubapi.Client, owner, repo, workDir, headSHA string, want bool, signals map[string]any, appendWarnings func(string, []string), diags *[]Diagnostic, degraded *bool) {
 	if !want {
 		return
 	}
-	m, warns, err := ci.Collect(ctx, client, owner, repo, workDir)
+	m, warns, err := ci.Collect(ctx, client, owner, repo, workDir, headSHA)
 	if err != nil {
 		*degraded = true
 		*diags = append(*diags, Diagnostic{Severity: "error", Message: err.Error(), Provider: "github.ci"})
@@ -271,35 +275,40 @@ func (*GitHubProvider) githubCollectCI(ctx context.Context, client *githubapi.Cl
 	mergeSignals(signals, m)
 }
 
-func (p *GitHubProvider) githubCollectPRGraph(ctx context.Context, client *githubapi.Client, owner, repo string, prNum int, wantPull, wantRev bool, prLookupOK bool, signals map[string]any, diags *[]Diagnostic, degraded *bool) {
-	if !wantPull && !wantRev {
-		return
+func (p *GitHubProvider) githubCollectPRGraph(ctx context.Context, client *githubapi.Client, owner, repo string, prNum int, wantPull, wantRev, wantCI bool, prLookupOK bool, signals map[string]any, diags *[]Diagnostic, degraded *bool, opts Options) string {
+	if !wantPull && !wantRev && !wantCI {
+		return ""
 	}
 	if !prLookupOK || prNum <= 0 {
-		return
+		return ""
 	}
 	pullDetail, revInner, err := prquery.Collect(ctx, client, owner, repo, prNum, p.BotReviewers)
 	if err != nil {
 		*degraded = true
 		*diags = append(*diags, Diagnostic{Severity: "error", Message: err.Error(), Provider: "github.pr-query"})
-		return
+		return ""
 	}
+	headSHA, _ := pullDetail["head_sha"].(string)
+	headRef, _ := pullDetail["head_ref"].(string)
 	if wantPull && len(pullDetail) > 0 {
 		if existing, ok := signals["pull_requests"].(map[string]any); ok {
 			for k, v := range pullDetail {
 				existing[k] = v
 			}
+			updateObservedScope(existing, opts, prNum, headRef, headSHA)
 		} else {
 			pm := make(map[string]any, len(pullDetail))
 			for k, v := range pullDetail {
 				pm[k] = v
 			}
+			updateObservedScope(pm, opts, prNum, headRef, headSHA)
 			signals["pull_requests"] = pm
 		}
 	}
 	if wantRev {
 		mergeSignals(signals, map[string]any{"reviews": revInner})
 	}
+	return headSHA
 }
 
 func mergeSignals(dst map[string]any, src map[string]any) {
@@ -322,5 +331,24 @@ func intFromMap(m map[string]any, key string) int {
 		return int(x)
 	default:
 		return 0
+	}
+}
+
+func updateObservedScope(prMap map[string]any, opts Options, prNum int, headRef, headSHA string) {
+	raw, ok := prMap["observed_scope"].(map[string]any)
+	if !ok {
+		raw = map[string]any{}
+		prMap["observed_scope"] = raw
+	}
+	raw["resolved_pr_number"] = prNum
+	if headRef != "" {
+		raw["pr_head_branch"] = headRef
+		if opts.Scope.PRNumber > 0 && strings.TrimSpace(opts.Scope.Branch) == "" {
+			prMap["current_branch"] = headRef
+			raw["effective_branch"] = headRef
+		}
+	}
+	if headSHA != "" {
+		raw["pr_head_sha"] = headSHA
 	}
 }

--- a/internal/observe/provider_github_test.go
+++ b/internal/observe/provider_github_test.go
@@ -576,6 +576,27 @@ exit 1
 	}
 }
 
+func TestHeadRepoForCIStatus(t *testing.T) {
+	t.Parallel()
+	t.Run("fork_head_repo", func(t *testing.T) {
+		t.Parallel()
+		o, n := headRepoForCIStatus(map[string]any{
+			"head_repo_owner": "fork-owner",
+			"head_repo_name":  "fork-repo",
+		}, "base-owner", "base-repo")
+		if o != "fork-owner" || n != "fork-repo" {
+			t.Fatalf("got %q %q", o, n)
+		}
+	})
+	t.Run("falls_back_to_base", func(t *testing.T) {
+		t.Parallel()
+		o, n := headRepoForCIStatus(map[string]any{}, "base-owner", "base-repo")
+		if o != "base-owner" || n != "base-repo" {
+			t.Fatalf("got %q %q", o, n)
+		}
+	})
+}
+
 func runGitCmd(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)

--- a/internal/observe/provider_github_test.go
+++ b/internal/observe/provider_github_test.go
@@ -2,6 +2,7 @@ package observe
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -483,6 +484,95 @@ func TestGitHubProviderFactory_botReviewers_blankID(t *testing.T) {
 				t.Fatalf("got %v", err)
 			}
 		})
+	}
+}
+
+//nolint:gocyclo // integration-style stub server + fake gh setup
+func TestGitHubProvider_Collect_explicitBranchNoPR_failClosedCI(t *testing.T) {
+	// Given: explicit --branch scope with no matching open PR (prNum stays 0) and local HEAD sha present.
+	// When:  Collect runs CI facet.
+	// Then:  CI must not fall back to the local checkout SHA; signals report unknown + scoped_head_unresolved.
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh executable is a Unix #!/bin/sh script")
+	}
+	tmp := t.TempDir()
+	ghBin := filepath.Join(tmp, "gh")
+	script := `#!/bin/sh
+if [ "$1" = "auth" ] && [ "$2" = "token" ]; then
+  echo testtoken
+  exit 0
+fi
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  echo "octocat/hello-world"
+  exit 0
+fi
+exit 1
+`
+	if err := os.WriteFile(ghBin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tmp+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	repoDir := t.TempDir()
+	runGitCmd(t, repoDir, "init")
+	runGitCmd(t, repoDir, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
+	shaBytes, err := exec.Command("git", "-C", repoDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	localHead := strings.TrimSpace(string(shaBytes))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+		case r.URL.Path == "/repos/octocat/hello-world/pulls":
+			_, _ = w.Write([]byte(`[]`))
+		case strings.HasPrefix(r.URL.Path, "/repos/octocat/hello-world/commits/") && strings.HasSuffix(r.URL.Path, "/status"):
+			t.Errorf("unexpected CI status fetch for local HEAD %q (fail-closed should skip CI)", r.URL.Path)
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	p := NewGitHubProvider()
+	p.APIBase = srv.URL
+
+	frag, err := p.Collect(context.Background(), Options{
+		WorkDir: repoDir,
+		Scope:   Scope{Branch: "no-matching-pr-branch"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !frag.Degraded {
+		t.Fatalf("expected degraded, got %+v", frag.Diagnostics)
+	}
+	var foundScoped bool
+	for _, d := range frag.Diagnostics {
+		if d.Code == "scoped_head_unresolved" {
+			foundScoped = true
+			break
+		}
+	}
+	if !foundScoped {
+		t.Fatalf("missing scoped_head_unresolved: %+v", frag.Diagnostics)
+	}
+	gitHub := frag.Signals
+	if gitHub == nil {
+		t.Fatal("nil github signals")
+	}
+	ci, _ := gitHub["ci"].(map[string]any)
+	if ci == nil {
+		t.Fatalf("missing ci: %+v", gitHub)
+	}
+	if got := fmt.Sprint(ci["ci_status"]); got != "unknown" {
+		t.Fatalf("ci_status: got %q", got)
+	}
+	if got := fmt.Sprint(ci["head_sha"]); got != "" {
+		t.Fatalf("head_sha: got %q want empty (not local %s)", got, localHead)
 	}
 }
 

--- a/internal/observe/types.go
+++ b/internal/observe/types.go
@@ -25,12 +25,22 @@ type Provider interface {
 	Collect(ctx context.Context, opts Options) (Fragment, error)
 }
 
+// Scope selects an explicit GitHub PR/branch target for one collect run.
+// Zero values mean "infer from the current working directory". When both fields are set,
+// PRNumber takes precedence for PR-scoped GitHub facets.
+type Scope struct {
+	Branch   string
+	PRNumber int
+}
+
 // Options configure a collect run: working directory, optional GitHub facet filter, default
-// branch from config, optional provider ID restriction, and serial vs parallel execution.
+// branch from config, optional provider ID restriction, explicit PR/branch scope, and serial
+// vs parallel execution.
 type Options struct {
+	ProviderIDs   []string
 	WorkDir       string
 	GitHubFacet   string
 	DefaultBranch string
-	ProviderIDs   []string
+	Scope         Scope
 	Serial        bool
 }

--- a/internal/rgdcli/flag_factories.go
+++ b/internal/rgdcli/flag_factories.go
@@ -21,6 +21,14 @@ func newSerialFlag() *cli.BoolFlag {
 	return &cli.BoolFlag{Name: "serial", Usage: "run observation providers sequentially"}
 }
 
+func newBranchFlag() *cli.StringFlag {
+	return &cli.StringFlag{Name: "branch", Usage: "observe GitHub PR scope for this branch instead of the local checkout"}
+}
+
+func newPRNumberFlag() *cli.IntFlag {
+	return &cli.IntFlag{Name: "pr", Usage: "observe GitHub facets for this pull request number"}
+}
+
 func newFailOnNonResolvedFlag() *cli.BoolFlag {
 	return &cli.BoolFlag{
 		Name:  "fail-on-non-resolved",
@@ -58,7 +66,14 @@ func newSchemaExportDirFlag() *cli.StringFlag {
 
 // observeFlags returns flags for any observe-shaped command.
 func observeFlags() []cli.Flag {
-	return []cli.Flag{newSerialFlag(), newCwdFlag(), newConfigDirFlag(), newFailOnNonResolvedFlag()}
+	return []cli.Flag{
+		newSerialFlag(),
+		newCwdFlag(),
+		newConfigDirFlag(),
+		newBranchFlag(),
+		newPRNumberFlag(),
+		newFailOnNonResolvedFlag(),
+	}
 }
 
 // Root-only clones of urfave's default HelpFlag / VersionFlag. The library keeps

--- a/internal/rgdcli/rgdcli.go
+++ b/internal/rgdcli/rgdcli.go
@@ -216,7 +216,7 @@ func RunKnowledgePack(c *cli.Context) error {
 	if !loaded.KnowledgePresent || loaded.Knowledge == nil {
 		return writeJSON(c.App.Writer, map[string]any{"entries": []config.KnowledgeManifestEntry{}})
 	}
-	useSig := c.String("observation-file") != ""
+	useSig := c.String("observation-file") != "" || c.IsSet("branch") || c.IsSet("pr")
 	var flat map[string]any
 	if useSig {
 		loadOpts, lerr := loadSignalsOpts(c, wd)

--- a/internal/rgdcli/rgdcli.go
+++ b/internal/rgdcli/rgdcli.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/k-shibuki/reinguard/internal/config"
@@ -99,6 +100,10 @@ func RunObserve(c *cli.Context, gitHubFacet string, providerOverride []string) e
 		}
 		root = config.Root{SchemaVersion: loaded.Root.SchemaVersion, DefaultBranch: loaded.Root.DefaultBranch, Providers: ps}
 	}
+	branch, prNumber, err := parseObserveScopeFlags(c, false)
+	if err != nil {
+		return err
+	}
 	engine, err := observe.NewEngineFromConfig(root.Providers)
 	if err != nil {
 		return err
@@ -108,6 +113,7 @@ func RunObserve(c *cli.Context, gitHubFacet string, providerOverride []string) e
 		Serial:      c.Bool("serial"),
 		ProviderIDs: providerOverride,
 		GitHubFacet: gitHubFacet,
+		Scope:       observe.Scope{Branch: branch, PRNumber: prNumber},
 	}
 	signals, diags, deg, err := engine.Collect(context.Background(), &root, opts)
 	if err != nil {
@@ -128,7 +134,11 @@ func RunStateEval(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	sig, diags, deg, err := observe.LoadSignalsFileOrCollect(context.Background(), &loaded.Root, loadSignalsOpts(c, wd))
+	loadOpts, err := loadSignalsOpts(c, wd)
+	if err != nil {
+		return err
+	}
+	sig, diags, deg, err := observe.LoadSignalsFileOrCollect(context.Background(), &loaded.Root, loadOpts)
 	if err != nil {
 		return err
 	}
@@ -159,7 +169,11 @@ func RunRouteSelect(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	sig, diags, deg, err := observe.LoadSignalsFileOrCollect(context.Background(), &loaded.Root, loadSignalsOpts(c, wd))
+	loadOpts, err := loadSignalsOpts(c, wd)
+	if err != nil {
+		return err
+	}
+	sig, diags, deg, err := observe.LoadSignalsFileOrCollect(context.Background(), &loaded.Root, loadOpts)
 	if err != nil {
 		return err
 	}
@@ -205,7 +219,11 @@ func RunKnowledgePack(c *cli.Context) error {
 	useSig := c.String("observation-file") != ""
 	var flat map[string]any
 	if useSig {
-		sig, _, _, lerr := observe.LoadSignalsFileOrCollect(context.Background(), &loaded.Root, loadSignalsOpts(c, wd))
+		loadOpts, lerr := loadSignalsOpts(c, wd)
+		if lerr != nil {
+			return lerr
+		}
+		sig, _, _, lerr := observe.LoadSignalsFileOrCollect(context.Background(), &loaded.Root, loadOpts)
 		if lerr != nil {
 			return lerr
 		}
@@ -237,7 +255,11 @@ func RunContextBuild(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	sig, diags, deg, err := observe.LoadSignalsFileOrCollect(context.Background(), &loaded.Root, loadSignalsOpts(c, wd))
+	loadOpts, err := loadSignalsOpts(c, wd)
+	if err != nil {
+		return err
+	}
+	sig, diags, deg, err := observe.LoadSignalsFileOrCollect(context.Background(), &loaded.Root, loadOpts)
 	if err != nil {
 		return err
 	}
@@ -458,12 +480,38 @@ func loadChecksFile(wd, path string) ([]gate.Check, error) {
 	return checks, nil
 }
 
-func loadSignalsOpts(c *cli.Context, wd string) observe.LoadSignalsOptions {
-	opts := observe.LoadSignalsOptions{WorkDir: wd, Serial: c.Bool("serial")}
+func loadSignalsOpts(c *cli.Context, wd string) (observe.LoadSignalsOptions, error) {
+	branch, prNumber, err := parseObserveScopeFlags(c, c.String("observation-file") != "")
+	if err != nil {
+		return observe.LoadSignalsOptions{}, err
+	}
+	opts := observe.LoadSignalsOptions{
+		WorkDir:  wd,
+		Branch:   branch,
+		PRNumber: prNumber,
+		Serial:   c.Bool("serial"),
+	}
 	if p := c.String("observation-file"); p != "" {
 		opts.ObservationPath = resolveInputPath(wd, p)
 	}
-	return opts
+	return opts, nil
+}
+
+func parseObserveScopeFlags(c *cli.Context, observationFileSet bool) (branch string, prNumber int, err error) {
+	branch = strings.TrimSpace(c.String("branch"))
+	if c.IsSet("branch") && branch == "" {
+		return "", 0, fmt.Errorf("--branch must be non-empty")
+	}
+	if c.IsSet("pr") {
+		prNumber = c.Int("pr")
+		if prNumber <= 0 {
+			return "", 0, fmt.Errorf("--pr must be greater than 0")
+		}
+	}
+	if observationFileSet && (branch != "" || prNumber > 0) {
+		return "", 0, fmt.Errorf("--branch/--pr cannot be used with --observation-file")
+	}
+	return branch, prNumber, nil
 }
 
 func writeJSON(w io.Writer, v any) error {
@@ -654,6 +702,8 @@ func NewApp(version string) *cli.App {
 					Usage: "evaluate state rules",
 					Flags: []cli.Flag{
 						newObservationFileFlag(),
+						newBranchFlag(),
+						newPRNumberFlag(),
 						newSerialFlag(),
 						newCwdFlag(),
 						newConfigDirFlag(),
@@ -673,6 +723,8 @@ func NewApp(version string) *cli.App {
 					Flags: []cli.Flag{
 						newObservationFileFlag(),
 						newStateFileFlag(),
+						newBranchFlag(),
+						newPRNumberFlag(),
 						newSerialFlag(),
 						newCwdFlag(),
 						newConfigDirFlag(),
@@ -700,6 +752,8 @@ func NewApp(version string) *cli.App {
 						newConfigDirFlag(),
 						newKnowledgeQueryFlag(),
 						newObservationFileFlag(),
+						newBranchFlag(),
+						newPRNumberFlag(),
 					},
 					Action: RunKnowledgePack,
 				},
@@ -717,6 +771,8 @@ func NewApp(version string) *cli.App {
 						newCwdFlag(),
 						newConfigDirFlag(),
 						newObservationFileFlag(),
+						newBranchFlag(),
+						newPRNumberFlag(),
 					},
 					Action: RunContextBuild,
 				},
@@ -794,6 +850,24 @@ func NewApp(version string) *cli.App {
 						}
 						return RunGuardEval(c, c.Args().First())
 					},
+				},
+			},
+		},
+		{
+			Name:  "review",
+			Usage: "pull request review transport helpers",
+			Subcommands: []*cli.Command{
+				{
+					Name:   "reply-thread",
+					Usage:  "post a threaded pull-request review reply",
+					Flags:  reviewReplyThreadFlags(),
+					Action: runReviewReplyThread,
+				},
+				{
+					Name:   "resolve-thread",
+					Usage:  "resolve a pull-request review thread",
+					Flags:  reviewResolveThreadFlags(),
+					Action: runReviewResolveThread,
 				},
 			},
 		},

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -187,8 +187,11 @@ func TestRunContextBuild_rejectsScopeFlagsWithObservationFile(t *testing.T) {
 			err := app.Run(args)
 
 			// Then: command rejects the scope override because the observation is already fixed
-			if err == nil || !strings.Contains(err.Error(), "--branch/--pr cannot be used with --observation-file") {
-				t.Fatalf("got %v", err)
+			if err == nil {
+				t.Fatal("expected error when using --observation-file with scope flags, got nil")
+			}
+			if !strings.Contains(err.Error(), "--branch/--pr cannot be used with --observation-file") {
+				t.Fatalf("expected error containing '--branch/--pr cannot be used with --observation-file', got: %v", err)
 			}
 		})
 	}

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -156,6 +157,40 @@ exit 1
 	}
 	// Then: observation is degraded, state/route still resolve, and github.repository comes from local_git
 	assertObservationDegradedWithLocalGitHubRepo(t, out)
+}
+
+func TestRunContextBuild_rejectsScopeFlagsWithObservationFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "pr", args: []string{"--pr", "104"}},
+		{name: "branch", args: []string{"--branch", "feat/test"}},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Given: minimal config and a pre-built observation file
+			cfgDir := t.TempDir()
+			writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+			writeFile(t, filepath.Join(cfgDir, "control", "states", "default.yaml"), []byte(testFixtureRulesStateIdle))
+			writeFile(t, filepath.Join(cfgDir, "control", "routes", "default.yaml"), []byte(testFixtureControlRoutesNext))
+			obsPath := filepath.Join(t.TempDir(), "observation.json")
+			writeFile(t, obsPath, []byte(`{"schema_version":"0.6.0","signals":{"git":{"branch":"main"}},"degraded":false}`))
+
+			// When: context build runs with --observation-file and a scope flag
+			app := NewApp("test")
+			args := append([]string{"rgd", "context", "build", "--config-dir", cfgDir, "--observation-file", obsPath}, tc.args...)
+			err := app.Run(args)
+
+			// Then: command rejects the scope override because the observation is already fixed
+			if err == nil || !strings.Contains(err.Error(), "--branch/--pr cannot be used with --observation-file") {
+				t.Fatalf("got %v", err)
+			}
+		})
+	}
 }
 
 func assertObservationDegradedWithLocalGitHubRepo(t *testing.T, out map[string]any) {

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -167,6 +167,7 @@ func TestRunContextBuild_rejectsScopeFlagsWithObservationFile(t *testing.T) {
 	}{
 		{name: "pr", args: []string{"--pr", "104"}},
 		{name: "branch", args: []string{"--branch", "feat/test"}},
+		{name: "branch and pr", args: []string{"--branch", "feat/test", "--pr", "104"}},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/internal/rgdcli/rgdcli_knowledge_test.go
+++ b/internal/rgdcli/rgdcli_knowledge_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -147,6 +148,29 @@ func TestRunKnowledgePack_observationFileAndQueryUnion(t *testing.T) {
 	// Then: both entries returned (OR union of when match and trigger match)
 	if len(out.Entries) != 2 {
 		t.Fatalf("want OR union, got %s", buf.String())
+	}
+}
+
+func TestRunKnowledgePack_rejectsInvalidScopePR(t *testing.T) {
+	t.Parallel()
+	// Given: knowledge pack with --pr 0 (invalid) — scope validation must run without --observation-file.
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+	if err := os.Mkdir(filepath.Join(cfgDir, "knowledge"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cfgDir, "knowledge", "manifest.json"), []byte(`{
+  "schema_version": "0.6.0",
+  "entries": []
+}`))
+	app := NewApp("t")
+	app.Writer = &bytes.Buffer{}
+	err := app.Run([]string{"rgd", "knowledge", "pack", "--config-dir", cfgDir, "--pr", "0"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--pr must be greater than 0") {
+		t.Fatalf("got %v", err)
 	}
 }
 

--- a/internal/rgdcli/rgdcli_review.go
+++ b/internal/rgdcli/rgdcli_review.go
@@ -1,0 +1,88 @@
+package rgdcli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/k-shibuki/reinguard/internal/configdir"
+	"github.com/k-shibuki/reinguard/internal/githubapi"
+	"github.com/urfave/cli/v2"
+)
+
+func runReviewReplyThread(c *cli.Context) error {
+	wd, err := reviewWorkDir(c)
+	if err != nil {
+		return err
+	}
+	body, err := reviewBodyFromFlags(wd, c)
+	if err != nil {
+		return err
+	}
+	return githubapi.ReplyToPullRequestThread(c.Context, wd, githubapi.PullRequestThreadReplyInput{
+		PRNumber:  c.Int("pr"),
+		Body:      body,
+		InReplyTo: c.Int("in-reply-to"),
+		CommitSHA: c.String("commit-sha"),
+		Path:      c.String("path"),
+		Line:      c.Int("line"),
+	})
+}
+
+func runReviewResolveThread(c *cli.Context) error {
+	wd, err := reviewWorkDir(c)
+	if err != nil {
+		return err
+	}
+	return githubapi.ResolveReviewThread(c.Context, wd, c.String("thread-id"))
+}
+
+func reviewWorkDir(c *cli.Context) (string, error) {
+	if wd := strings.TrimSpace(c.String("cwd")); wd != "" {
+		return wd, nil
+	}
+	return configdir.WorkingDir()
+}
+
+func reviewBodyFromFlags(wd string, c *cli.Context) (string, error) {
+	inline := c.String("body")
+	path := c.String("body-file")
+	switch {
+	case strings.TrimSpace(inline) != "" && strings.TrimSpace(path) != "":
+		return "", fmt.Errorf("--body and --body-file are mutually exclusive")
+	case strings.TrimSpace(inline) != "":
+		return inline, nil
+	case strings.TrimSpace(path) != "":
+		data, err := os.ReadFile(resolveInputPath(wd, path))
+		if err != nil {
+			return "", err
+		}
+		body := string(data)
+		if strings.TrimSpace(body) == "" {
+			return "", fmt.Errorf("body file must be non-empty")
+		}
+		return body, nil
+	default:
+		return "", fmt.Errorf("either --body or --body-file is required")
+	}
+}
+
+func reviewReplyThreadFlags() []cli.Flag {
+	return []cli.Flag{
+		newCwdFlag(),
+		&cli.IntFlag{Name: "pr", Required: true, Usage: "pull request number"},
+		&cli.IntFlag{Name: "in-reply-to", Required: true, Usage: "root review comment database id"},
+		&cli.StringFlag{Name: "commit-sha", Required: true, Usage: "full 40-character commit SHA"},
+		&cli.StringFlag{Name: "path", Required: true, Usage: "review comment file path"},
+		&cli.IntFlag{Name: "line", Required: true, Usage: "review comment line number"},
+		&cli.StringFlag{Name: "body", Usage: "reply body text"},
+		&cli.StringFlag{Name: "body-file", Usage: "path to a file containing the reply body"},
+	}
+}
+
+func reviewResolveThreadFlags() []cli.Flag {
+	return []cli.Flag{
+		newCwdFlag(),
+		&cli.StringFlag{Name: "thread-id", Required: true, Usage: "GraphQL review thread node id"},
+	}
+}

--- a/internal/rgdcli/rgdcli_review.go
+++ b/internal/rgdcli/rgdcli_review.go
@@ -47,19 +47,24 @@ func reviewWorkDir(c *cli.Context) (string, error) {
 func reviewBodyFromFlags(wd string, c *cli.Context) (string, error) {
 	inline := c.String("body")
 	path := c.String("body-file")
+	hasInline := inline != ""
+	hasPath := path != ""
 	switch {
-	case strings.TrimSpace(inline) != "" && strings.TrimSpace(path) != "":
+	case hasInline && hasPath:
 		return "", fmt.Errorf("--body and --body-file are mutually exclusive")
-	case strings.TrimSpace(inline) != "":
+	case hasInline:
+		if strings.TrimSpace(inline) == "" {
+			return "", fmt.Errorf("--body must be non-empty")
+		}
 		return inline, nil
-	case strings.TrimSpace(path) != "":
+	case hasPath:
 		data, err := os.ReadFile(resolveInputPath(wd, path))
 		if err != nil {
 			return "", err
 		}
 		body := string(data)
 		if strings.TrimSpace(body) == "" {
-			return "", fmt.Errorf("body file must be non-empty")
+			return "", fmt.Errorf("--body-file must be non-empty")
 		}
 		return body, nil
 	default:

--- a/internal/rgdcli/rgdcli_review_test.go
+++ b/internal/rgdcli/rgdcli_review_test.go
@@ -1,0 +1,122 @@
+package rgdcli
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestReviewBodyFromFlags(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		body          string
+		fileBody      string
+		wantBody      string
+		wantErrSubstr string
+		useBodyFile   bool
+	}{
+		{
+			name:     "given body when parsing then inline body returned",
+			body:     "Fixed in latest commit.",
+			wantBody: "Fixed in latest commit.",
+		},
+		{
+			name:        "given body file when parsing then file body returned",
+			fileBody:    "By design. Scoped CI follows the observed PR head.\n",
+			wantBody:    "By design. Scoped CI follows the observed PR head.\n",
+			useBodyFile: true,
+		},
+		{
+			name:          "given body and file when parsing then error",
+			body:          "x",
+			fileBody:      "x",
+			wantErrSubstr: "mutually exclusive",
+			useBodyFile:   true,
+		},
+		{
+			name:          "given empty body file when parsing then error",
+			fileBody:      "   \n",
+			wantErrSubstr: "non-empty",
+			useBodyFile:   true,
+		},
+		{
+			name:          "given no body flags when parsing then error",
+			wantErrSubstr: "required",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runReviewBodyCase(t, tc)
+		})
+	}
+}
+
+func runReviewBodyCase(t *testing.T, tc struct {
+	name          string
+	body          string
+	fileBody      string
+	wantBody      string
+	wantErrSubstr string
+	useBodyFile   bool
+}) {
+	t.Helper()
+	// Given: a CLI context and optional reply body file
+	wd := t.TempDir()
+	if tc.useBodyFile {
+		if err := os.WriteFile(filepath.Join(wd, "reply.md"), []byte(tc.fileBody), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ctx := newReviewBodyContext(t, tc.body, tc.useBodyFile)
+
+	// When: reviewBodyFromFlags reads and validates the selected input
+	got, err := reviewBodyFromFlags(wd, ctx)
+
+	// Then: the resulting body or validation error matches the command contract
+	if tc.wantErrSubstr != "" {
+		if err == nil || !strings.Contains(err.Error(), tc.wantErrSubstr) {
+			t.Fatalf("expected error containing %q, got %v", tc.wantErrSubstr, err)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != tc.wantBody {
+		t.Fatalf("got %q want %q", got, tc.wantBody)
+	}
+}
+
+func newReviewBodyContext(t *testing.T, body string, useBodyFile bool) *cli.Context {
+	t.Helper()
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	for _, fl := range []cli.Flag{
+		&cli.StringFlag{Name: "body"},
+		&cli.StringFlag{Name: "body-file"},
+	} {
+		if err := fl.Apply(set); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := set.Parse(nil); err != nil {
+		t.Fatal(err)
+	}
+	if body != "" {
+		if err := set.Set("body", body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if useBodyFile {
+		if err := set.Set("body-file", "reply.md"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return cli.NewContext(cli.NewApp(), set, nil)
+}

--- a/internal/rgdcli/rgdcli_review_test.go
+++ b/internal/rgdcli/rgdcli_review_test.go
@@ -26,6 +26,11 @@ func TestReviewBodyFromFlags(t *testing.T) {
 			wantBody: "Fixed in latest commit.",
 		},
 		{
+			name:          "given whitespace body when parsing then required error",
+			body:          "   ",
+			wantErrSubstr: "required",
+		},
+		{
 			name:        "given body file when parsing then file body returned",
 			fileBody:    "By design. Scoped CI follows the observed PR head.\n",
 			wantBody:    "By design. Scoped CI follows the observed PR head.\n",

--- a/internal/rgdcli/rgdcli_review_test.go
+++ b/internal/rgdcli/rgdcli_review_test.go
@@ -26,9 +26,9 @@ func TestReviewBodyFromFlags(t *testing.T) {
 			wantBody: "Fixed in latest commit.",
 		},
 		{
-			name:          "given whitespace body when parsing then required error",
+			name:          "given whitespace body when parsing then non-empty error",
 			body:          "   ",
-			wantErrSubstr: "required",
+			wantErrSubstr: "--body must be non-empty",
 		},
 		{
 			name:        "given body file when parsing then file body returned",

--- a/internal/rgdcli/rgdcli_scope_test.go
+++ b/internal/rgdcli/rgdcli_scope_test.go
@@ -76,6 +76,11 @@ func TestParseObserveScopeFlags(t *testing.T) {
 			pr:            -1,
 			wantErrSubstr: "--pr must be greater than 0",
 		},
+		{
+			name:          "given whitespace branch then error",
+			branch:        "   ",
+			wantErrSubstr: "--branch must be non-empty",
+		},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/internal/rgdcli/rgdcli_scope_test.go
+++ b/internal/rgdcli/rgdcli_scope_test.go
@@ -22,6 +22,12 @@ func TestParseObserveScopeFlags(t *testing.T) {
 		wantPR             int
 	}{
 		{
+			name:          "given no scope flags when live observe then zero values returned",
+			wantBranch:    "",
+			wantPR:        0,
+			wantErrSubstr: "",
+		},
+		{
 			name:          "given branch when live observe then branch returned",
 			branch:        "main",
 			wantBranch:    "main",
@@ -50,9 +56,24 @@ func TestParseObserveScopeFlags(t *testing.T) {
 			wantErrSubstr:      "--branch/--pr cannot be used with --observation-file",
 		},
 		{
+			name:          "given branch and pr when live observe then both values preserved",
+			branch:        "topic",
+			setPR:         true,
+			pr:            9,
+			wantBranch:    "topic",
+			wantPR:        9,
+			wantErrSubstr: "",
+		},
+		{
 			name:          "given zero pr then error",
 			setPR:         true,
 			pr:            0,
+			wantErrSubstr: "--pr must be greater than 0",
+		},
+		{
+			name:          "given negative pr then error",
+			setPR:         true,
+			pr:            -1,
 			wantErrSubstr: "--pr must be greater than 0",
 		},
 	}

--- a/internal/rgdcli/rgdcli_scope_test.go
+++ b/internal/rgdcli/rgdcli_scope_test.go
@@ -1,0 +1,103 @@
+package rgdcli
+
+import (
+	"flag"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestParseObserveScopeFlags(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name               string
+		branch             string
+		wantBranch         string
+		wantErrSubstr      string
+		observationFileSet bool
+		setPR              bool
+		pr                 int
+		wantPR             int
+	}{
+		{
+			name:          "given branch when live observe then branch returned",
+			branch:        "main",
+			wantBranch:    "main",
+			wantPR:        0,
+			wantErrSubstr: "",
+		},
+		{
+			name:          "given pr when live observe then pr returned",
+			setPR:         true,
+			pr:            5,
+			wantBranch:    "",
+			wantPR:        5,
+			wantErrSubstr: "",
+		},
+		{
+			name:               "given branch with observation file then error",
+			branch:             "main",
+			observationFileSet: true,
+			wantErrSubstr:      "--branch/--pr cannot be used with --observation-file",
+		},
+		{
+			name:               "given pr with observation file then error",
+			setPR:              true,
+			pr:                 5,
+			observationFileSet: true,
+			wantErrSubstr:      "--branch/--pr cannot be used with --observation-file",
+		},
+		{
+			name:          "given zero pr then error",
+			setPR:         true,
+			pr:            0,
+			wantErrSubstr: "--pr must be greater than 0",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Given: a CLI context with the scope flags registered
+			set := flag.NewFlagSet("test", flag.ContinueOnError)
+			for _, fl := range []cli.Flag{newBranchFlag(), newPRNumberFlag()} {
+				if err := fl.Apply(set); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := set.Parse(nil); err != nil {
+				t.Fatal(err)
+			}
+			if tc.branch != "" {
+				if err := set.Set("branch", tc.branch); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.setPR {
+				if err := set.Set("pr", strconv.Itoa(tc.pr)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			ctx := cli.NewContext(cli.NewApp(), set, nil)
+
+			// When: parseObserveScopeFlags validates the selected flags
+			gotBranch, gotPR, err := parseObserveScopeFlags(ctx, tc.observationFileSet)
+
+			// Then: the parsed values or validation error match the contract
+			if tc.wantErrSubstr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrSubstr) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErrSubstr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotBranch != tc.wantBranch || gotPR != tc.wantPR {
+				t.Fatalf("got branch=%q pr=%d want branch=%q pr=%d", gotBranch, gotPR, tc.wantBranch, tc.wantPR)
+			}
+		})
+	}
+}

--- a/internal/rgdcli/workflow_fsm_test.go
+++ b/internal/rgdcli/workflow_fsm_test.go
@@ -22,8 +22,8 @@ func reinguardConfigDir(t *testing.T) string {
 	if err := copyTree(t, src, dst); err != nil {
 		t.Fatalf("copy .reinguard: %v", err)
 	}
-	// Isolate FSM scenario tests from developer-local pr-readiness artifacts (pass would force ready_for_pr).
-	_ = os.Remove(filepath.Join(dst, "local", "gates", "pr-readiness.json"))
+	// Isolate FSM scenario tests from developer-local .reinguard/local artifacts (hermetic fixtures).
+	_ = os.RemoveAll(filepath.Join(dst, "local"))
 	return dst
 }
 

--- a/internal/rgdcli/workflow_fsm_test.go
+++ b/internal/rgdcli/workflow_fsm_test.go
@@ -23,7 +23,7 @@ func reinguardConfigDir(t *testing.T) string {
 		t.Fatalf("copy .reinguard: %v", err)
 	}
 	// Isolate FSM scenario tests from developer-local pr-readiness artifacts (pass would force ready_for_pr).
-	_ = os.Remove(filepath.Join(dst, "runtime", "gates", "pr-readiness.json"))
+	_ = os.Remove(filepath.Join(dst, "local", "gates", "pr-readiness.json"))
 	return dst
 }
 

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -113,7 +113,7 @@ func TestAdapterRgdNextResumeScript_Lifecycle(t *testing.T) {
 	// When: the adapter records progress and then a terminal allowed stop
 	got := runResumeLifecycleStatus(t, repo, script)
 
-	// Then: the artifact is stored under repo-local .tmp and remains auditable
+	// Then: the artifact is stored under repo-local .reinguard/local and remains auditable
 	if got.Status != "allowed_stop" || got.ResumeEligible {
 		t.Fatalf("status = %+v", got)
 	}
@@ -126,7 +126,7 @@ func TestAdapterRgdNextResumeScript_Lifecycle(t *testing.T) {
 	if got.Terminal.Reason != "tooling_session_limit" || got.Terminal.Summary != "context limit reached" {
 		t.Fatalf("terminal = %+v", got.Terminal)
 	}
-	wantPath := filepath.Join(repo, ".tmp", "adapter", "rgd-next", "execute-resume.json")
+	wantPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
 	if got.ArtifactPath != wantPath {
 		t.Fatalf("artifact_path = %q, want %q", got.ArtifactPath, wantPath)
 	}
@@ -175,7 +175,7 @@ func TestAdapterRgdNextResumeScript_StatusInvalidForMalformedArtifact(t *testing
 	script := scriptPath(t, "adapter-rgd-next-resume.sh")
 	repo := setupLocalReviewRepo(t)
 	renameBranch(t, repo, "feature/104")
-	artifactPath := filepath.Join(repo, ".tmp", "adapter", "rgd-next", "execute-resume.json")
+	artifactPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
 	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -1,0 +1,310 @@
+package scripttest
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type resumeScriptStatus struct {
+	LastIteration struct {
+		StateID    string `json:"state_id"`
+		RouteID    string `json:"route_id"`
+		RecordedAt string `json:"recorded_at"`
+	} `json:"last_iteration"`
+	Terminal struct {
+		Reason     string `json:"reason"`
+		Summary    string `json:"summary"`
+		RecordedAt string `json:"recorded_at"`
+	} `json:"terminal"`
+	ArtifactPath   string `json:"artifact_path"`
+	Status         string `json:"status"`
+	Reason         string `json:"reason"`
+	Branch         string `json:"branch"`
+	CurrentBranch  string `json:"current_branch"`
+	ApprovalAt     string `json:"approval_recorded_at"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+	IssueNumber    int    `json:"issue_number"`
+	ResumeEligible bool   `json:"resume_eligible"`
+}
+
+func TestAdapterRgdNextResumeScript_ShellSyntax(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	paths := []string{
+		filepath.Join(root, ".reinguard", "scripts", "adapter-rgd-next-resume.sh"),
+		filepath.Join(root, ".reinguard", "scripts", "lib", "json_minimal.sh"),
+	}
+	for _, path := range paths {
+		path := path
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			t.Parallel()
+			out, err := exec.Command("bash", "-n", path).CombinedOutput()
+			if err != nil {
+				t.Fatalf("bash -n %s: %v\n%s", path, err, out)
+			}
+		})
+	}
+}
+
+func TestAdapterRgdNextResumeScript_ProposalThenApprove(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	pendingOut, err := runBashScript(t, repo, script, nil, "status")
+	if err != nil {
+		t.Fatalf("status after start: %v\n%s", err, pendingOut)
+	}
+	var pending resumeScriptStatus
+	unmarshalJSON(t, pendingOut, &pending)
+	if pending.Status != "pending_approval" || pending.ResumeEligible || pending.ApprovalAt != "" {
+		t.Fatalf("expected pending_approval before approve, got %+v", pending)
+	}
+
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+	activeOut, err := runBashScript(t, repo, script, nil, "status")
+	if err != nil {
+		t.Fatalf("status after approve: %v\n%s", err, activeOut)
+	}
+	var active resumeScriptStatus
+	unmarshalJSON(t, activeOut, &active)
+	if active.Status != "active" || !active.ResumeEligible || active.ApprovalAt == "" {
+		t.Fatalf("expected active after approve, got %+v", active)
+	}
+}
+
+func TestAdapterRgdNextResumeScript_Lifecycle(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	// Given: proposal artifact created before the approval gate, then approved Execute
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--summary", "approved execute path",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+
+	// When: the adapter records progress and then a terminal allowed stop
+	got := runResumeLifecycleStatus(t, repo, script)
+
+	// Then: the artifact is stored under repo-local .tmp and remains auditable
+	if got.Status != "allowed_stop" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Branch != "feature/104" || got.IssueNumber != 104 {
+		t.Fatalf("identity = %+v", got)
+	}
+	if got.LastIteration.StateID != "waiting_ci" || got.LastIteration.RouteID != "user-wait-ci" {
+		t.Fatalf("last_iteration = %+v", got.LastIteration)
+	}
+	if got.Terminal.Reason != "tooling_session_limit" || got.Terminal.Summary != "context limit reached" {
+		t.Fatalf("terminal = %+v", got.Terminal)
+	}
+	wantPath := filepath.Join(repo, ".tmp", "adapter", "rgd-next", "execute-resume.json")
+	if got.ArtifactPath != wantPath {
+		t.Fatalf("artifact_path = %q, want %q", got.ArtifactPath, wantPath)
+	}
+	if fi, statErr := os.Stat(wantPath); statErr != nil || fi.IsDir() {
+		t.Fatalf("expected artifact file %q, stat err=%v", wantPath, statErr)
+	}
+}
+
+func TestAdapterRgdNextResumeScript_StatusStaleOnBranchMismatch(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "main")
+
+	// Given: a resume artifact recorded for a different branch
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+
+	// When: the adapter checks status from the current branch
+	statusOut, err := runBashScript(t, repo, script, nil, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	// Then: resume is blocked as stale rather than silently reused
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "stale" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Reason != "branch mismatch" || got.CurrentBranch != "main" {
+		t.Fatalf("stale metadata = %+v", got)
+	}
+}
+
+func TestAdapterRgdNextResumeScript_StatusInvalidForMalformedArtifact(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+	artifactPath := filepath.Join(repo, ".tmp", "adapter", "rgd-next", "execute-resume.json")
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(artifactPath, []byte(`{"status":"active"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Given: a malformed adapter-local artifact
+	// When: the status command validates it
+	statusOut, err := runBashScript(t, repo, script, nil, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	// Then: the script fails closed with invalid status details
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "invalid" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if !strings.Contains(got.Reason, "missing required keys") {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+}
+
+func TestAdapterRgdNextResumeScript_FinishValidatesTerminalReason(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	// Given/When/Then: invalid finish combinations are rejected by the adapter-local contract.
+	tests := []struct {
+		name       string
+		argsLine   string
+		wantSubstr string
+	}{
+		{
+			name:       "doneRequiresDodSatisfied",
+			argsLine:   "finish --status done --reason tooling_session_limit",
+			wantSubstr: "done status requires reason dod_satisfied",
+		},
+		{
+			name:       "revokedRequiresScopeRevoked",
+			argsLine:   "finish --status revoked --reason hard_stop",
+			wantSubstr: "revoked status requires reason scope_revoked",
+		},
+		{
+			name:       "allowedStopRejectsDodSatisfied",
+			argsLine:   "finish --status allowed_stop --reason dod_satisfied",
+			wantSubstr: "allowed_stop requires hard_stop, cannot_proceed, or tooling_session_limit",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			startOut, err := runBashScript(t, repo, script, nil,
+				"start",
+				"--branch", "feature/104",
+			)
+			if err != nil {
+				t.Fatalf("start: %v\n%s", err, startOut)
+			}
+
+			out, err := runBashScript(t, repo, script, nil, strings.Fields(tt.argsLine)...)
+			if err == nil {
+				t.Fatalf("expected failure, got success:\n%s", out)
+			}
+			if !strings.Contains(out, tt.wantSubstr) {
+				t.Fatalf("expected output to contain %q, got:\n%s", tt.wantSubstr, out)
+			}
+
+			clearOut, clearErr := runBashScript(t, repo, script, nil, "clear")
+			if clearErr != nil {
+				t.Fatalf("clear: %v\n%s", clearErr, clearOut)
+			}
+		})
+	}
+}
+
+func runResumeLifecycleStatus(t *testing.T, repo, script string) resumeScriptStatus {
+	t.Helper()
+
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	updateOut, err := runBashScript(t, repo, script, nil,
+		"update",
+		"--state-id", "waiting_ci",
+		"--route-id", "user-wait-ci",
+	)
+	if err != nil {
+		t.Fatalf("update: %v\n%s", err, updateOut)
+	}
+	finishOut, err := runBashScript(t, repo, script, nil,
+		"finish",
+		"--status", "allowed_stop",
+		"--reason", "tooling_session_limit",
+		"--summary", "context limit reached",
+	)
+	if err != nil {
+		t.Fatalf("finish: %v\n%s", err, finishOut)
+	}
+	statusOut, err := runBashScript(t, repo, script, nil, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	return got
+}
+
+func renameBranch(t *testing.T, repo, branch string) {
+	t.Helper()
+	cmd := exec.Command("git", "branch", "-M", branch)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git branch -M: %v\n%s", err, out)
+	}
+}
+
+func unmarshalJSON(t *testing.T, raw string, target any) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(raw), target); err != nil {
+		t.Fatalf("unmarshal JSON: %v\n%s", err, raw)
+	}
+}

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -135,6 +135,75 @@ func TestAdapterRgdNextResumeScript_Lifecycle(t *testing.T) {
 	}
 }
 
+func TestAdapterRgdNextResumeScript_StatusStaleOnDetachedHead(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+	gitEmptyCommit(t, repo)
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+
+	detachOut, err := exec.Command("git", "-C", repo, "checkout", "--detach").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git checkout --detach: %v\n%s", err, detachOut)
+	}
+
+	statusOut, err := runBashScript(t, repo, script, nil, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "stale" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Reason != "detached HEAD" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+}
+
+func TestAdapterRgdNextResumeScript_SummaryRoundTripWithQuotes(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+	summary := `say "hi" and \n`
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--summary", summary,
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+	showOut, err := runBashScript(t, repo, script, nil, "show")
+	if err != nil {
+		t.Fatalf("show: %v\n%s", err, showOut)
+	}
+	var artifact map[string]any
+	unmarshalJSON(t, showOut, &artifact)
+	got, _ := artifact["summary"].(string)
+	if got != summary {
+		t.Fatalf("summary round-trip: got %q want %q", got, summary)
+	}
+}
+
 func TestAdapterRgdNextResumeScript_StatusStaleOnBranchMismatch(t *testing.T) {
 	t.Parallel()
 
@@ -234,6 +303,13 @@ func TestAdapterRgdNextResumeScript_FinishValidatesTerminalReason(t *testing.T) 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				clearOut, clearErr := runBashScript(t, repo, script, nil, "clear")
+				if clearErr != nil {
+					t.Errorf("clear: %v\n%s", clearErr, clearOut)
+				}
+			})
+
 			startOut, err := runBashScript(t, repo, script, nil,
 				"start",
 				"--branch", "feature/104",
@@ -249,11 +325,6 @@ func TestAdapterRgdNextResumeScript_FinishValidatesTerminalReason(t *testing.T) 
 			}
 			if !strings.Contains(out, tt.wantSubstr) {
 				t.Fatalf("expected output to contain %q, got:\n%s", tt.wantSubstr, out)
-			}
-
-			clearOut, clearErr := runBashScript(t, repo, script, nil, "clear")
-			if clearErr != nil {
-				t.Fatalf("clear: %v\n%s", clearErr, clearOut)
 			}
 		})
 	}
@@ -300,6 +371,14 @@ func renameBranch(t *testing.T, repo, branch string) {
 	cmd.Dir = repo
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git branch -M: %v\n%s", err, out)
+	}
+}
+
+func gitEmptyCommit(t *testing.T, repo string) {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
 	}
 }
 

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -237,6 +237,7 @@ func TestAdapterRgdNextResumeScript_FinishValidatesTerminalReason(t *testing.T) 
 			startOut, err := runBashScript(t, repo, script, nil,
 				"start",
 				"--branch", "feature/104",
+				"--issue", "104",
 			)
 			if err != nil {
 				t.Fatalf("start: %v\n%s", err, startOut)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Add `--branch` / `--pr` scope for live observation and `rgd context build`, with `observed_scope` and `review_inbox` signals.
- Add `rgd review reply-thread` and `rgd review resolve-thread` as thin `gh api` transports (observation remains side-effect free).
- Document precedence when both `--pr` and `--branch` are set; tighten validation and inbox edge cases.

## Traceability

Closes #104

Refs: #104

## Definition of Done

- [x] Tests added or updated (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. `go test -race ./...` — all packages pass.
2. `go vet ./...` and `golangci-lint run` — clean.
3. `bash .reinguard/scripts/with-repo-local-state.sh -- pre-commit run markdownlint-cli2 --all-files` — clean.
4. `go run ./cmd/rgd config validate` — OK.
5. Local CodeRabbit: `bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- bash .reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit` — completed with exit 0 on latest head; findings dispositioned (docs/tests/validation fixes applied; optional items documented or deferred as nitpicks).

## Risk / Impact

- **Observation / CLI**: New flags and signal shapes; callers using saved observation files are unchanged except documented scope rules.
- **Review transport**: New commands shell out to `gh` only; same auth contract as the rest of `rgd` (ADR-0006).

## Rollback Plan

- Revert this PR on `main` via GitHub revert or `git revert` of the merge commit; no migration of stored data required.

## Exception

- Type:
- Justification:
