### PR TITLE
refactor(control): align Adapter SSOT and schema 0.7.0 contract

### DIFF
--- a/.cursor/commands/cursor-plan.md
+++ b/.cursor/commands/cursor-plan.md
@@ -56,44 +56,12 @@ Do not emit a second parallel artifact (e.g. “I’ll create the Issue now” w
 
 ### Phase 3B — Issue creation (content to embed in `CreatePlan`)
 
-When the plan shape is **Issue-first**, include these steps **inside** the `CreatePlan` todo list (and enough detail in the overview that an executor needs no guesswork):
-
-1. **Choose template**
-   - **Task** — implementation or chore; Conventional Commits title + type label. Starting point: `.github/ISSUE_TEMPLATE/task.yml`.
-   - **Epic** — phased parent work; label `epic`. Starting point: `.github/ISSUE_TEMPLATE/epic.yml`.
-
-2. **Build the body file** — Markdown file for `--body-file` with sections required by the template (see `workflow--pr-discipline.md` § Recommended Issue sections). Use real newlines (same constraints as PR bodies in `workflow--pr-discipline.md` § PR body updates).
-
-3. **Choose labels** — SSOT: `.reinguard/labels.yaml`.
-   - **Task**: exactly one **type** label (`feat`, `fix`, …) from `categories.type`.
-   - **Epic**: label **`epic`** only (no type label).
-
-4. **Pre-flight validation**
-
-   ```bash
-   bash .reinguard/scripts/check-issue-policy.sh \
-     --title "<title>" \
-     --body-file /path/to/issue-body.md \
-     --label <feat|…|epic> \
-     [--template task|epic]
-   ```
-
-   Fix errors until it prints `Issue policy pre-flight OK.`
-
-5. **Create the Issue**
-
-   ```bash
-   gh issue create --title "<title>" --body-file /path/to/issue-body.md --label "<label>"
-   ```
-
-   For multiple labels: repeat `--label` or `gh issue edit` after create.
-
-**Related:** `.reinguard/scripts/check-issue-policy.sh`, `.reinguard/policy/workflow--pr-discipline.md`, `.reinguard/procedure/implement.md` (branch naming shares `labels.yaml` type vocabulary).
+When the plan shape is **Issue-first**, embed end-to-end Issue creation **inside** the `CreatePlan` todos. Required sections, labels, templates, and `check-issue-policy.sh` usage: [`.reinguard/policy/workflow--pr-discipline.md`](../../.reinguard/policy/workflow--pr-discipline.md). Label vocabulary: [`.reinguard/labels.yaml`](../../.reinguard/labels.yaml). Script: [`.reinguard/scripts/check-issue-policy.sh`](../../.reinguard/scripts/check-issue-policy.sh). Branch naming vocabulary aligns with `implement` (same type labels).
 
 ## Guard
 
 - **Plan mode:** Do not modify the workspace until the user accepts **`CreatePlan`**; use read-only exploration tools only while planning.
-- **Execution handoff:** `cursor-plan` is **planning only**. After the user accepts the plan, execution **must** use [`rgd-next`](rgd-next.md) loop semantics ([`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § Loop semantics: Sense → Route → Act → Refresh). Do not execute a plan as a linear checklist without FSM-driven state transitions.
+- **Execution handoff:** After plan acceptance, follow [`.cursor/rules/reinguard-bridge.mdc`](../rules/reinguard-bridge.mdc) § **Agent procedure reference** (`rgd-next` + `next-orchestration.md` loop; not a linear checklist).
 - **`CreatePlan` is mandatory** for this command; Issue creation is **never** the standalone output—only steps **inside** the accepted plan.
 - Prefer **`AskQuestion`** over open-ended “what do you want?” when discrete choices exist.
 - Do not claim design decisions are “complete” while any ledger row is still `open` without user acknowledgment.

--- a/.cursor/commands/rgd-next.md
+++ b/.cursor/commands/rgd-next.md
@@ -44,25 +44,7 @@ as substrate workflow position.
 
 ## Route
 
-**Normative mapping:** [ADR-0013 § 4](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) (*Adapter mapping (durable)*). Use ADR-0013 and `.reinguard/control/` as SSOT for state and route semantics.
-
-The table below is a **Cursor-facing heuristic** (when `state.kind` is `resolved`) with the same procedure targets as ADR-0013 § 4:
-
-| `state_id` | Open procedure |
-|------------|----------------|
-| `working_no_pr` | `.reinguard/procedure/implement.md` |
-| `ready_for_pr` | `.reinguard/procedure/pr-create.md` |
-| `pr_open` | `.reinguard/procedure/review-address.md` (residual monitor) |
-| `waiting_ci` | `.reinguard/procedure/review-address.md` (checks / mergeability) |
-| `unresolved_threads` | `.reinguard/procedure/review-address.md` (thread disposition) |
-| `non_thread_findings_pending` | `.reinguard/procedure/review-address.md` (non-thread findings / inbox) |
-| `changes_requested` | `.reinguard/procedure/review-address.md` (formal “Request changes” on the PR) |
-| `waiting_bot_run` | `.reinguard/procedure/wait-bot-review.md` (+ `review--bot-operations.md` from `knowledge.entries`) |
-| `waiting_bot_rate_limited` | `.reinguard/procedure/wait-bot-review.md` |
-| `waiting_bot_paused` | `.reinguard/procedure/wait-bot-review.md` |
-| `waiting_bot_failed` | `.reinguard/procedure/wait-bot-review.md` |
-| `waiting_bot_stale` | `.reinguard/procedure/wait-bot-review.md` |
-| `merge_ready` | `.reinguard/procedure/pr-merge.md` |
+**Normative mapping:** [ADR-0013 § 4](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) (*Adapter mapping (durable)*). When `state.kind` is `resolved`, use that section’s table to choose the procedure file under `.reinguard/procedure/`. ADR-0013 and `.reinguard/control/` are the SSOT for state and route semantics (do not duplicate the mapping here).
 
 **Dirty working tree + `review-address`:** When `observation.signals.git.working_tree_clean` is `false` and the resolved procedure is `review-address`, run **Step 0** in that procedure first (`change-inspect` → commit → refresh context). See `.reinguard/knowledge/review--incremental-fix-flow.md`.
 
@@ -86,11 +68,9 @@ Persistent JSON defaults to `.reinguard/local/adapter/rgd-next/execute-resume.js
 
 This writes `status: "pending_approval"` and persists the **proposed** contract inputs (`state-id`, `ordered-remainder`, `completion-condition`, fingerprint inputs) so the artifact records **what** the user will approve. The status stays `pending_approval` until the user approves Execute (next section).
 
-1. Trace forward from the current `state_id` using [ADR-0013 § 4](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) through **Per-unit Definition of Done** in [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md).
-2. Follow **`next-orchestration.md` § Full-path proposal format** in full: current position, ordered remainder, gaps, completion condition.
-3. Obtain **single explicit user approval** per **`next-orchestration.md` § Approval gate** (unit identity, ordered remainder, completion condition). **No per-procedure re-approval** after this gate.
+Proposal content, approval gate, and user-visible output requirements: [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Full-path proposal format** and § **Approval gate**. Trace from the current `state_id` ([ADR-0013 § 4](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md)) through **Per-unit Definition of Done** in `next-orchestration.md`. **No per-procedure re-approval** after the single gate.
 
-**Output (for agents):** User-visible text must be the full-path proposal — including unit identity, ordered procedures through DoD, gaps, and completion condition — not merely `state_id` / `route_id` bullets. **Do not** end the turn after only a short status line. Do **not** replace the **Output** sections inside each procedure file; those remain authoritative per procedure front matter.
+**Output (for agents):** Per **`next-orchestration.md`** § **Output** and procedure front matter — not merely `state_id` / `route_id` bullets.
 
 ## Execute
 
@@ -104,11 +84,9 @@ bash .reinguard/scripts/adapter-rgd-next-resume.sh approve
 
 If no `pending_approval` artifact exists (for example a fresh machine), run `start` then `approve` in one flow after approval.
 
-**No implicit stop:** Do not end the run because a status summary or external wait “feels done.” Only **Per-unit Definition of Done**, or an **allowed stop with evidence** per `next-orchestration.md` § Post-approval execution contract (including **Implicit stop (forbidden)**), counts as completion.
+Post-approval behavior, loop semantics, allowed stops, and chat output rules: [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Post-approval execution contract**, § **Loop semantics**, § **Output**.
 
-Loop (summary): **Sense** (`rgd context build`) → **Route** (ADR-0013 § 4; same rules as § Route above) → run mapped procedure(s) → **Refresh** context after material changes — per `next-orchestration.md`.
-
-**Output (for agents):** After each `rgd context build` in the loop, **record** the same iteration context **agent-internally** as in [`next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Output** (per-iteration bullet): `state_id` / `route_id` / guard summary and which procedure(s) ran or are next. Refresh the Adapter-local artifact with:
+Refresh the Adapter-local artifact with:
 
 ```bash
 bash .reinguard/scripts/adapter-rgd-next-resume.sh update --state-id <state_id> [--route-id <route_id>]

--- a/.cursor/rules/reinguard-bridge.mdc
+++ b/.cursor/rules/reinguard-bridge.mdc
@@ -69,6 +69,8 @@ Optional keyword filter (Adapter ops note):
 rgd knowledge pack --observation-file /tmp/rgd-observe.json --query '<keyword>'
 ```
 
+`--query` matches **triggers** only (case-insensitive substring); see `docs/cli.md`.
+
 ## After changing knowledge front matter
 
 Run `rgd knowledge index` and commit `manifest.json`; then `rgd config validate`.

--- a/.cursor/rules/reinguard-bridge.mdc
+++ b/.cursor/rules/reinguard-bridge.mdc
@@ -23,33 +23,14 @@ Use **English for everything except replies in the Cursor chat panel to the user
 
 Follow these policy documents in every interaction:
 
-- [safety--agent-invariants.md](../../.reinguard/policy/safety--agent-invariants.md) — **HARD STOPS (HS-*)**:
-  - **HS-CI-MERGE** — green CI before merge; no `--admin`
-  - **HS-PR-TEMPLATE** — all PR template sections required
-  - **HS-PR-BASE** — PRs target `main` only
-  - **HS-LOCAL-VERIFY** — `go test` / `go vet` / `golangci-lint` before push
-  - **HS-NO-SKIP** — no skipping verification without documented exception
-  - **HS-NO-DISMISS** — never dismiss findings as "pre-existing" or "outside diff range"
-  - **HS-REVIEW-RESOLVE** — disposition reply for all findings (threads and non-thread)
-  - **HS-MERGE-CONSENSUS** — no merge (any method) while required bot review is not terminal, has failed, is stale, review threads are unresolved, or consensus is not reached
+- [safety--agent-invariants.md](../../.reinguard/policy/safety--agent-invariants.md) — **HARD STOPS (HS-*)**: **HS-CI-MERGE**, **HS-PR-TEMPLATE**, **HS-PR-BASE**, **HS-LOCAL-VERIFY**, **HS-NO-SKIP**, **HS-NO-DISMISS**, **HS-REVIEW-RESOLVE**, **HS-MERGE-CONSENSUS** (normative definitions only in that file).
 - [coding--standards.md](../../.reinguard/policy/coding--standards.md) — English artifacts, `gofmt`, `go vet`, **Change scope** (same-kind sweep), ADR/CLI authority
 - [workflow--pr-discipline.md](../../.reinguard/policy/workflow--pr-discipline.md) — Issue-driven work, PR discipline, branch naming, exceptions
 - [commit--format.md](../../.reinguard/policy/commit--format.md) — Conventional Commits, `Refs` in message body, atomic commits, branch naming
 
 ## Workflow
 
-Follow [.reinguard/policy/workflow--pr-discipline.md](../../.reinguard/policy/workflow--pr-discipline.md) for Issue-driven work, PR discipline, branch naming, and exceptions.
-
-### Command separation (implement → change-inspect → pr-create → review-address → pr-merge)
-
-Treat **inspect**, **create**, **address**, and **merge** as distinct steps (supports future `rgd` semantics):
-
-- **After `implement`** → **`change-inspect`** (self-inspection gate, always run): whole-change review against inspection dimensions before PR creation.
-- **After `change-inspect` passes** → **`pr-create`**: push, fill template (dimension 6), create PR, await CI.
-- **External review findings / unresolved threads** → **`review-address`**: classify, fix, disposition reply, resolve threads.
-- **Review done, CI green, policy satisfied** → **`pr-merge`**: execute merge only after checks.
-
-**Orchestration:** After Sense and Route, `rgd-next` **always** applies `.reinguard/procedure/next-orchestration.md` (full-path proposal format, single approval gate, post-approval execution contract; no proposal-only or minimal-dump mode). Adapter flow: `rgd-next.md` § **Propose** (once) then § **Execute**.
+Follow [.reinguard/policy/workflow--pr-discipline.md](../../.reinguard/policy/workflow--pr-discipline.md). Which procedures apply to which FSM `state_id` / `route_id` is defined in each procedure’s YAML front matter (`applies_to`) and in [ADR-0013 § 4](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) (*Adapter mapping*). After Sense and Route, `rgd-next` applies [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) (single full-path proposal, one approval gate, then Execute). Adapter flow: [`rgd-next.md`](../commands/rgd-next.md) § **Propose** then § **Execute**.
 
 ### rgd-next Execute — Cursor chat transcript (Adapter)
 
@@ -80,17 +61,13 @@ Branch protection, labels, and CI gates: [.github/CONTRIBUTING.md](../../.github
 
 ## Knowledge retrieval
 
-- **Primary:** `rgd context build` — use `knowledge.entries` in stdout JSON (each entry’s required `when` is evaluated against observation + merged `state.*` signals to filter inclusion; see `docs/cli.md`).
-- **Catalog only:** triage with `entries` in `manifest.json` when you are not running `rgd` (paths and metadata; `when` shows relevance conditions).
-- Read only the Markdown paths you need.
-- **Tests (when writing or reviewing Go tests):** [.reinguard/knowledge/testing--strategy.md](../../.reinguard/knowledge/testing--strategy.md), [.reinguard/knowledge/testing--assertions.md](../../.reinguard/knowledge/testing--assertions.md), [.reinguard/knowledge/testing--given-when-then.md](../../.reinguard/knowledge/testing--given-when-then.md).
-- **Optional** trigger substring filter (OR-union with observation signals): save observation JSON (`rgd observe > /tmp/rgd-observe.json`), then:
+See [`docs/cli.md`](../../docs/cli.md) (`rgd context build`, `knowledge pack`, manifest `entries`, and `when` evaluation). **Tests (when writing or reviewing Go tests):** [.reinguard/knowledge/testing--strategy.md](../../.reinguard/knowledge/testing--strategy.md), [.reinguard/knowledge/testing--assertions.md](../../.reinguard/knowledge/testing--assertions.md), [.reinguard/knowledge/testing--given-when-then.md](../../.reinguard/knowledge/testing--given-when-then.md).
+
+Optional keyword filter (Adapter ops note):
 
 ```bash
 rgd knowledge pack --observation-file /tmp/rgd-observe.json --query '<keyword>'
 ```
-
-`--query` matches **triggers** only (case-insensitive substring), not `description`.
 
 ## After changing knowledge front matter
 

--- a/.reinguard/control/catalog.yaml
+++ b/.reinguard/control/catalog.yaml
@@ -2,7 +2,7 @@
 # Not read by config.Load or `rgd config validate` today (those load
 # reinguard.yaml and control/{states,routes,guards}/*.yaml only).
 # Maintained manually; future `rgd` may auto-generate or validate this catalog.
-schema_version: "0.6.0"
+schema_version: "0.7.0"
 entries:
   - id: workflow-states
     path: states/workflow.yaml

--- a/.reinguard/control/guards/default.yaml
+++ b/.reinguard/control/guards/default.yaml
@@ -1,5 +1,6 @@
 # Dogfood guard rules: enable merge-readiness (built-in) when not on a detached HEAD.
 # Named evaluator (ADR-0002) wires the match-layer registry alongside scalar op (constant is a no-op true).
+schema_version: "0.7.0"
 rules:
   - type: guard
     id: merge_readiness_when_branch_attached

--- a/.reinguard/control/routes/workflow.yaml
+++ b/.reinguard/control/routes/workflow.yaml
@@ -1,5 +1,6 @@
 # Routes keyed off flattened state.state_id (ADR-0013). One primary route per state.
 # route_id uses the user-* prefix (Adapter-agnostic; not tied to a specific IDE).
+schema_version: "0.7.0"
 rules:
   - type: route
     id: route_implement_pr_ready

--- a/.reinguard/control/states/workflow.yaml
+++ b/.reinguard/control/states/workflow.yaml
@@ -1,6 +1,7 @@
 # FSM workflow states (ADR-0013). Lower priority number wins among matches (ADR-0004).
 # Actionable human review (threads / formal changes) beats bot-wait states;
 # bot-wait states split by reason (state_id); CI/merge gate split as waiting_ci.
+schema_version: "0.7.0"
 rules:
   # Human-actionable review work first (before any bot-wait tier).
   - type: state

--- a/.reinguard/knowledge/manifest.json
+++ b/.reinguard/knowledge/manifest.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "entries": [
     {
       "id": "ci-permissions-and-gates",

--- a/.reinguard/labels.yaml
+++ b/.reinguard/labels.yaml
@@ -1,5 +1,5 @@
 # GitHub label catalog + commit prefix config (ADR-0008). SSOT for rgd ensure-labels, labels sync, CI policy.
-schema_version: "0.3.0"
+schema_version: "0.7.0"
 
 categories:
   type:

--- a/.reinguard/policy/catalog.yaml
+++ b/.reinguard/policy/catalog.yaml
@@ -1,7 +1,7 @@
 # Policy catalog — normative documents referenced by Adapter and AGENTS.md.
 # Not indexed by `rgd knowledge index`. Not read by `rgd config validate`
 # (manual index only). Maintained manually.
-schema_version: "0.6.0"
+schema_version: "0.7.0"
 entries:
   - id: review-disposition-categories
     path: review--disposition-categories.md

--- a/.reinguard/reinguard.yaml
+++ b/.reinguard/reinguard.yaml
@@ -1,5 +1,5 @@
 # Minimal repo-local config (ADR-0008). See pkg/schema/reinguard-config.json.
-schema_version: "0.6.0"
+schema_version: "0.7.0"
 default_branch: main
 workflow:
   runtime_gate_roles:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,23 +47,6 @@ CI: `golangci-lint`, `go vet`, `go test -race`; PRs must pass job **`ci-pass`** 
 
 ### Review threads and merge
 
-Before resolving a review thread (required when **Require conversation resolution** is on), leave a
-short **disposition**: **Fixed** / **By design** / **False positive** / **Acknowledged** — see
-[`.reinguard/policy/review--consensus-protocol.md`](.reinguard/policy/review--consensus-protocol.md)
-for the full consensus model and resolution rules. Non-thread findings (outside-diff-range, PR summary)
-require a PR conversation comment with the same disposition ([**HS-REVIEW-RESOLVE**](.reinguard/policy/safety--agent-invariants.md)).
+Normative: [`.reinguard/policy/review--consensus-protocol.md`](.reinguard/policy/review--consensus-protocol.md) (dispositions, thread and non-thread resolution, [**HS-REVIEW-RESOLVE**](.reinguard/policy/safety--agent-invariants.md)); [`.reinguard/policy/review--disposition-categories.md`](.reinguard/policy/review--disposition-categories.md) (classification for local review, self-inspection, and PR review).
 
-Use the same disposition vocabulary for local review and self-inspection; see
-[`.reinguard/policy/review--disposition-categories.md`](.reinguard/policy/review--disposition-categories.md).
-Classification depends on whether the finding is correct, whether the
-current behavior is intentional by design, or whether the finding is
-incorrect — not on reviewer tone, severity labels, or suggestion wording.
-
-Treat review closure as complete only when every finding in the current
-review cycle is classified and closed through the appropriate channel:
-local inspection ledger before PR creation, or PR thread reply / PR
-conversation comment plus consensus when a PR exists.
-
-Do **not** dismiss any finding as "pre-existing" or "outside diff range" ([**HS-NO-DISMISS**](.reinguard/policy/safety--agent-invariants.md)).
-
-Do **not** merge (any method) while required bot review is not terminal, has failed, is stale, threads are unresolved, or consensus has not been reached ([**HS-MERGE-CONSENSUS**](.reinguard/policy/safety--agent-invariants.md)).
+[**HS-NO-DISMISS**](.reinguard/policy/safety--agent-invariants.md) · [**HS-MERGE-CONSENSUS**](.reinguard/policy/safety--agent-invariants.md)

--- a/docs/adr/0008-schema-versioning.md
+++ b/docs/adr/0008-schema-versioning.md
@@ -55,6 +55,10 @@ as semver for API-shaped artifacts.
    ADR. This ADR references that file as the operational contract for
    machine-readable CLI I/O.
 
+6. **Versioned repository files:** Any repository-owned file whose embedded JSON Schema requires a top-level `schema_version` (including `reinguard.yaml`, optional `labels.yaml`, `knowledge/manifest.json`, policy and control catalogs where present, and each `rules` bundle under `.reinguard/control/{states,routes,guards}/`) participates in the **same** synchronized semver line as `pkg/schema`’s `CurrentSchemaVersion` (ADR-0011 layout). Adding or changing such a file without bumping the shared contract is a schema change.
+
+7. **Per-file enforcement:** `config.Load` / `rgd config validate` reject **major** mismatches for **each** declared `schema_version`. **Same-major** skew (older or newer minor/patch) emits **warnings on stderr** per file, not only for the root `reinguard.yaml`. Control rule YAML documents validate against `rules-document.json`, which requires a top-level `schema_version` alongside `rules`.
+
 ## Consequences
 
 - **Easier**: Progressive adoption; semver communicates breaking vs
@@ -64,3 +68,4 @@ as semver for API-shaped artifacts.
   that config files also declare, even when YAML structure is unchanged
 - **Harder**: Best-effort parsing requires disciplined deprecation and
   thorough tests to avoid silently accepting broken configs
+- **Harder**: Bumping the shared contract (for example to `0.7.0`) touches every versioned Semantics file that declares `schema_version`, not only the root config

--- a/docs/adr/0008-schema-versioning.md
+++ b/docs/adr/0008-schema-versioning.md
@@ -55,9 +55,9 @@ as semver for API-shaped artifacts.
    ADR. This ADR references that file as the operational contract for
    machine-readable CLI I/O.
 
-6. **Versioned repository files:** Any repository-owned file whose embedded JSON Schema requires a top-level `schema_version` (including `reinguard.yaml`, optional `labels.yaml`, `knowledge/manifest.json`, policy and control catalogs where present, and each `rules` bundle under `.reinguard/control/{states,routes,guards}/`) participates in the **same** synchronized semver line as `pkg/schema`’s `CurrentSchemaVersion` (ADR-0011 layout). Adding or changing such a file without bumping the shared contract is a schema change.
+6. **Versioned repository files:** Any repository-owned file whose embedded JSON Schema requires a top-level `schema_version` (including `reinguard.yaml`, optional `labels.yaml`, `knowledge/manifest.json`, and each `rules` bundle under `.reinguard/control/{states,routes,guards}/`) participates in the **same** synchronized semver line as `pkg/schema`’s `CurrentSchemaVersion` (ADR-0011 layout). Policy and control **catalogs** (`policy/catalog.yaml`, `control/catalog.yaml`) also carry `schema_version` by convention for consistency, but `config.Load` does not validate catalogs today — only tests enforce their alignment. Adding or changing a validated versioned file without bumping the shared contract is a schema change.
 
-7. **Per-file enforcement:** `config.Load` / `rgd config validate` reject **major** mismatches for **each** declared `schema_version`. **Same-major** skew (older or newer minor/patch) emits **warnings on stderr** per file, not only for the root `reinguard.yaml`. Control rule YAML documents validate against `rules-document.json`, which requires a top-level `schema_version` alongside `rules`.
+7. **Per-file enforcement:** `config.Load` / `rgd config validate` reject **major** mismatches for **each** declared `schema_version` in the files they load: `reinguard.yaml`, optional `labels.yaml`, optional `knowledge/manifest.json`, and each control rule file under `control/{states,routes,guards}/`. **Same-major** skew (older or newer minor/patch) emits **warnings on stderr** per file, not only for the root. Control rule YAML documents validate against `rules-document.json`, which requires a top-level `schema_version` alongside `rules`.
 
 ## Consequences
 

--- a/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
+++ b/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
@@ -1,9 +1,5 @@
 # ADR-0013: FSM workflow states and Adapter mapping
 
-## Status
-
-Accepted (design note; amend when observation or Adapter contracts change).
-
 ## Context
 
 reinguard needs a **single priority space** (ADR-0004) for declarative workflow
@@ -119,14 +115,7 @@ it prepares `ready_for_pr` by recording the configured pre-PR AI review proof
 itself a state-mapped procedure.
 Post-review learning: `.reinguard/procedure/internalize.md`.
 
-**Cursor entries:** `.cursor/commands/rgd-next.md` - run/read `rgd context build`,
-Route (`state_id` -> procedure) per section 4 above; no per-procedure Adapter stubs.
-Orchestration (mandatory after Sense and Route: single full-path **Propose**, one approval, then **Execute** to DoD):
-`.reinguard/procedure/next-orchestration.md` - contract referenced from `rgd-next.md` section Propose and section Execute;
-not state-mapped.
-`.cursor/commands/cursor-plan.md` - Plan-mode-style interrogation (`AskQuestion` /
-`CreatePlan` only); GitHub Issue creation is expressed inside the plan when
-issue-first (Phase 3B content); not part of the FSM.
+**Cursor entries:** `.cursor/commands/rgd-next.md` — Sense (`rgd context build`), Route per **§ 4** above, then Propose / Execute per `.reinguard/procedure/next-orchestration.md` (no duplicate procedure mapping table in Adapter files). `.cursor/commands/cursor-plan.md` — planning only (`AskQuestion` / `CreatePlan`); not part of the FSM.
 
 ### 5. Extension contract (state / route / Adapter)
 
@@ -135,7 +124,7 @@ When adding or changing FSM wiring, keep these touchpoints consistent:
 1. **State catalog (this ADR)** — Add or update the row in section 1 for every new or changed `state_id`. Residual states must stay documented (observation gaps, missing facets) and their **numeric `priority`** must be explicit relative to refinements (lower wins; ADR-0004).
 2. **Control state rules** — Edit `.reinguard/control/states/*.yaml`. Ensure rules do not accidentally overlap: a more specific condition (e.g. a gate-backed state) must use a **lower** numeric `priority` than its residual fallback.
 3. **Routes** — Edit `.reinguard/control/routes/*.yaml` when a `state_id` needs a different primary `route_id` or when new states share an existing route with different procedure hints (section 2).
-4. **Adapter mapping** — Update section 4 (Primary procedure) and `.cursor/commands/rgd-next.md` when the primary Cursor procedure for a `state_id` changes.
+4. **Adapter mapping** — Update section 4 (Primary procedure) when the primary Cursor procedure for a `state_id` changes. Adapter commands reference this section; do not duplicate the mapping table outside ADR-0013.
 5. **Procedures** — Update `applies_to.state_ids` in affected `.reinguard/procedure/*.md` files. Procedures that are **not** state-mapped (e.g. `change-inspect`) remain documented here and in their body as producers or prerequisites, not as `state_id` values.
 6. **Tests** — Extend scenario tests (e.g. `internal/rgdcli/workflow_fsm_test.go`) when resolution or fallback behavior is non-obvious (residual vs refined state, stale gate fallback).
 

--- a/docs/adr/0014-runtime-gate-artifacts.md
+++ b/docs/adr/0014-runtime-gate-artifacts.md
@@ -1,9 +1,5 @@
 # ADR-0014: Runtime gate artifacts for deterministic local workflow progression
 
-## Status
-
-Accepted.
-
 ## Context
 
 `working_no_pr` currently collapses materially different local situations:

--- a/docs/adr/0015-adapter-local-execute-resume.md
+++ b/docs/adr/0015-adapter-local-execute-resume.md
@@ -1,9 +1,5 @@
 # ADR-0015: Adapter-local execute resume artifact
 
-## Status
-
-Accepted.
-
 ## Context
 
 `rgd-next` Execute has a single approval gate, then must continue to

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -586,15 +586,13 @@ artifacts use the dedicated `rgd gate` schema and commands instead.
 
 **`when` clauses (ADR-0002):** Control rules and knowledge manifest entries are checked with the same static validator: unknown `eval:` names, unknown `op` strings, missing required keys per `op` (e.g. `eq` needs `path` and `value`), `eval: constant` requires `params.value` (boolean), and `path` strings must use allowed roots (`git.`, `github.`, `state.`, `gates.`, or `$` / `$.` for nested quantifier clauses). Named evaluators: `rgd config validate` rejects unknown `eval:` names against the built-in registry. To list built-ins, call `evaluator.DefaultRegistry().ListRegistered()` from Go (sorted names), or see `internal/evaluator/`.
 
-**`schema_version` vs this binary (ADR-0008):** `reinguard.yaml` declares a
-semver `schema_version` synchronized with embedded JSON Schemas. This `rgd`
-build compares it to its contract version (`MAJOR.MINOR.PATCH`):
+**`schema_version` vs this binary (ADR-0008):** Versioned inputs (at minimum `reinguard.yaml`; also optional `labels.yaml`, `knowledge/manifest.json` when present, and each control rule file under `control/{states,routes,guards}/*.yaml`) declare a semver `schema_version` synchronized with embedded JSON Schemas. This `rgd` build compares each to its contract version (`MAJOR.MINOR.PATCH`):
 
 | Relationship | Behavior |
 |----------------|----------|
 | **Major** differs from the binary’s contract | **Error** (exit non-zero); do not load an incompatible major line silently. |
-| **Same major**, **minor or patch** differs | **Warning on stderr**, validation and load **continue** (older or newer skew). |
-| **Exact match** | No schema-skew warning from this rule. |
+| **Same major**, **minor or patch** differs | **Warning on stderr** naming the declaring file, validation and load **continue** (older or newer skew). |
+| **Exact match** | No schema-skew warning from this rule for that file. |
 
 Skew and deprecation messages go to **stderr**; success messages go to **stdout**.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -586,7 +586,7 @@ artifacts use the dedicated `rgd gate` schema and commands instead.
 
 **`when` clauses (ADR-0002):** Control rules and knowledge manifest entries are checked with the same static validator: unknown `eval:` names, unknown `op` strings, missing required keys per `op` (e.g. `eq` needs `path` and `value`), `eval: constant` requires `params.value` (boolean), and `path` strings must use allowed roots (`git.`, `github.`, `state.`, `gates.`, or `$` / `$.` for nested quantifier clauses). Named evaluators: `rgd config validate` rejects unknown `eval:` names against the built-in registry. To list built-ins, call `evaluator.DefaultRegistry().ListRegistered()` from Go (sorted names), or see `internal/evaluator/`.
 
-**`schema_version` vs this binary (ADR-0008):** Versioned inputs (at minimum `reinguard.yaml`; also optional `labels.yaml`, `knowledge/manifest.json` when present, and each control rule file under `control/{states,routes,guards}/*.yaml`) declare a semver `schema_version` synchronized with embedded JSON Schemas. This `rgd` build compares each to its contract version (`MAJOR.MINOR.PATCH`):
+**`schema_version` vs this binary (ADR-0008):** Versioned inputs (at minimum `reinguard.yaml`; also optional `labels.yaml`, `knowledge/manifest.json` when present, and each control rule file under `control/{states,routes,guards}/*.{yaml,yml}`) declare a semver `schema_version` synchronized with embedded JSON Schemas. This `rgd` build compares each to its contract version (`MAJOR.MINOR.PATCH`):
 
 | Relationship | Behavior |
 |----------------|----------|

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -68,7 +69,8 @@ type Rule struct {
 
 // RulesDocument wraps the rules array in a YAML file.
 type RulesDocument struct {
-	Rules []Rule `yaml:"rules" json:"rules"`
+	SchemaVersion string `yaml:"schema_version" json:"schema_version"`
+	Rules         []Rule `yaml:"rules" json:"rules"`
 }
 
 // KnowledgeManifestEntry is one knowledge file entry in manifest.json (ADR-0010).
@@ -268,6 +270,18 @@ func schemaVersionSkewWarning(declared string) string {
 	)
 }
 
+// schemaVersionSkewWarningAt is like schemaVersionSkewWarning but names the declaring file for multi-file skew diagnostics.
+func schemaVersionSkewWarningAt(declared, pathHint string) string {
+	w := schemaVersionSkewWarning(declared)
+	if w == "" {
+		return ""
+	}
+	if pathHint == "" {
+		return w
+	}
+	return fmt.Sprintf("config warning: in %s: %s", pathHint, strings.TrimPrefix(w, "config warning: "))
+}
+
 // DeprecatedWarnings returns human-readable stderr lines for deprecated fields and schema skew (ADR-0008).
 func DeprecatedWarnings(root *Root) []string {
 	if root == nil {
@@ -279,6 +293,42 @@ func DeprecatedWarnings(root *Root) []string {
 	}
 	if len(root.LegacyToolHints) > 0 {
 		out = append(out, `config warning: "legacy_tool_hints" is deprecated; remove it from reinguard.yaml (see JSON Schema / docs/cli.md)`)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// ConfigWarnings aggregates schema skew and deprecation warnings for a full validated Load (reinguard.yaml,
+// optional labels and knowledge, and all control rule files). Use after config.Load succeeds.
+func ConfigWarnings(res *LoadResult) []string {
+	if res == nil {
+		return nil
+	}
+	var out []string
+	out = append(out, DeprecatedWarnings(&res.Root)...)
+	if res.LabelsPresent && res.Labels != nil {
+		if w := schemaVersionSkewWarningAt(res.Labels.SchemaVersion, "labels.yaml"); w != "" {
+			out = append(out, w)
+		}
+	}
+	if res.KnowledgePresent && res.Knowledge != nil {
+		if w := schemaVersionSkewWarningAt(res.Knowledge.SchemaVersion, filepath.Join("knowledge", "manifest.json")); w != "" {
+			out = append(out, w)
+		}
+	}
+	var keys []string
+	for k := range res.RuleFiles {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		doc := res.RuleFiles[k]
+		hint := filepath.Join("control", filepath.ToSlash(k))
+		if w := schemaVersionSkewWarningAt(doc.SchemaVersion, hint); w != "" {
+			out = append(out, w)
+		}
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 
 import (
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -319,7 +318,7 @@ func ConfigWarnings(res *LoadResult) []string {
 		}
 	}
 	if res.KnowledgePresent && res.Knowledge != nil {
-		if w := schemaVersionSkewWarningAt(res.Knowledge.SchemaVersion, filepath.Join("knowledge", "manifest.json")); w != "" {
+		if w := schemaVersionSkewWarningAt(res.Knowledge.SchemaVersion, "knowledge/manifest.json"); w != "" {
 			out = append(out, w)
 		}
 	}
@@ -330,7 +329,7 @@ func ConfigWarnings(res *LoadResult) []string {
 	sort.Strings(keys)
 	for _, k := range keys {
 		doc := res.RuleFiles[k]
-		hint := filepath.Join("control", filepath.ToSlash(k))
+		hint := "control/" + k
 		if w := schemaVersionSkewWarningAt(doc.SchemaVersion, hint); w != "" {
 			out = append(out, w)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -307,7 +307,12 @@ func ConfigWarnings(res *LoadResult) []string {
 		return nil
 	}
 	var out []string
-	out = append(out, DeprecatedWarnings(&res.Root)...)
+	if w := schemaVersionSkewWarningAt(res.Root.SchemaVersion, "reinguard.yaml"); w != "" {
+		out = append(out, w)
+	}
+	if len(res.Root.LegacyToolHints) > 0 {
+		out = append(out, `config warning: "legacy_tool_hints" is deprecated; remove it from reinguard.yaml (see JSON Schema / docs/cli.md)`)
+	}
 	if res.LabelsPresent && res.Labels != nil {
 		if w := schemaVersionSkewWarningAt(res.Labels.SchemaVersion, "labels.yaml"); w != "" {
 			out = append(out, w)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -353,7 +354,8 @@ func TestLoad_controlStatesDotYmlAndStableOrder(t *testing.T) {
 	if err := os.MkdirAll(statesDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, filepath.Join(statesDir, "z.yml"), []byte(`rules:
+	writeFile(t, filepath.Join(statesDir, "z.yml"), []byte(fmt.Sprintf(`schema_version: %q
+rules:
   - type: state
     id: z
     priority: 10
@@ -362,8 +364,9 @@ func TestLoad_controlStatesDotYmlAndStableOrder(t *testing.T) {
       path: git.branch
       value: main
     state_id: Z
-`))
-	writeFile(t, filepath.Join(statesDir, "a.yaml"), []byte(`rules:
+`, schema.CurrentSchemaVersion)))
+	writeFile(t, filepath.Join(statesDir, "a.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+rules:
   - type: state
     id: a
     priority: 10
@@ -372,7 +375,7 @@ func TestLoad_controlStatesDotYmlAndStableOrder(t *testing.T) {
       path: git.branch
       value: main
     state_id: A
-`))
+`, schema.CurrentSchemaVersion)))
 	if err := os.Mkdir(filepath.Join(statesDir, "skipdir"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -694,7 +697,8 @@ func TestLoad_controlStatesFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	rulePath := filepath.Join(statesDir, "a.yaml")
-	writeFile(t, rulePath, []byte(`rules:
+	writeFile(t, rulePath, []byte(fmt.Sprintf(`schema_version: %q
+rules:
   - type: state
     id: s1
     priority: 10
@@ -703,7 +707,7 @@ func TestLoad_controlStatesFile(t *testing.T) {
       path: git.branch
       value: main
     state_id: Idle
-`))
+`, schema.CurrentSchemaVersion)))
 
 	// When: Load is called
 	res, err := Load(dir)
@@ -773,12 +777,13 @@ func TestLoad_evaluatorReferencesInWhen_table(t *testing.T) {
 			if err := os.MkdirAll(guardsDir, 0o755); err != nil {
 				t.Fatal(err)
 			}
-			body := `rules:
+			body := fmt.Sprintf(`schema_version: %q
+rules:
   - type: guard
     id: g1
     priority: 1
     guard_id: merge-readiness
-    when:` + tc.whenYAML + "\n"
+    when:`+tc.whenYAML+"\n", schema.CurrentSchemaVersion)
 			writeFile(t, filepath.Join(guardsDir, "g.yaml"), []byte(body))
 
 			res, err := Load(dir)
@@ -808,8 +813,9 @@ func TestLoad_controlStatesSchemaInvalid(t *testing.T) {
 	if err := os.MkdirAll(statesDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeFile(t, filepath.Join(statesDir, "bad.yaml"), []byte(`rules: not-an-array
-`))
+	writeFile(t, filepath.Join(statesDir, "bad.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+rules: not-an-array
+`, schema.CurrentSchemaVersion)))
 
 	// When: Load is called
 	_, err := Load(dir)
@@ -834,37 +840,40 @@ func TestLoad_controlKindTypeMismatchRejected(t *testing.T) {
 		{
 			name: "states_dir_has_route_type",
 			kind: "states",
-			yamlBody: `rules:
+			yamlBody: fmt.Sprintf(`schema_version: %q
+rules:
   - type: route
     id: r1
     priority: 10
     route_id: next
     when: {op: eq, path: x, value: 1}
-`,
+`, schema.CurrentSchemaVersion),
 			wantSub: `expected "state"`,
 		},
 		{
 			name: "routes_dir_has_state_type",
 			kind: "routes",
-			yamlBody: `rules:
+			yamlBody: fmt.Sprintf(`schema_version: %q
+rules:
   - type: state
     id: s1
     priority: 10
     state_id: idle
     when: {op: eq, path: x, value: 1}
-`,
+`, schema.CurrentSchemaVersion),
 			wantSub: `expected "route"`,
 		},
 		{
 			name: "guards_dir_has_state_type",
 			kind: "guards",
-			yamlBody: `rules:
+			yamlBody: fmt.Sprintf(`schema_version: %q
+rules:
   - type: state
     id: s1
     priority: 10
     state_id: idle
     when: {op: eq, path: x, value: 1}
-`,
+`, schema.CurrentSchemaVersion),
 			wantSub: `expected "guard"`,
 		},
 	}
@@ -884,6 +893,175 @@ func TestLoad_controlKindTypeMismatchRejected(t *testing.T) {
 				t.Fatalf("got err=%v, want substring %q", err, tt.wantSub)
 			}
 		})
+	}
+}
+
+func TestSchemaVersionSync_committedVersionedFiles(t *testing.T) {
+	t.Parallel()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	relPaths := []string{
+		".reinguard/reinguard.yaml",
+		".reinguard/labels.yaml",
+		"internal/labels/data/labels.yaml",
+		".reinguard/knowledge/manifest.json",
+		".reinguard/policy/catalog.yaml",
+		".reinguard/control/catalog.yaml",
+		".reinguard/control/states/workflow.yaml",
+		".reinguard/control/routes/workflow.yaml",
+		".reinguard/control/guards/default.yaml",
+	}
+	for _, rel := range relPaths {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(root, rel)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			var got string
+			switch filepath.Ext(rel) {
+			case ".json":
+				var m map[string]any
+				if err := json.Unmarshal(data, &m); err != nil {
+					t.Fatalf("json %s: %v", rel, err)
+				}
+				sv, ok := m["schema_version"].(string)
+				if !ok || strings.TrimSpace(sv) == "" {
+					t.Fatalf("%s: missing string schema_version", rel)
+				}
+				got = sv
+			default:
+				var m map[string]any
+				if err := yaml.Unmarshal(data, &m); err != nil {
+					t.Fatalf("yaml %s: %v", rel, err)
+				}
+				sv, ok := m["schema_version"].(string)
+				if !ok || strings.TrimSpace(sv) == "" {
+					t.Fatalf("%s: missing string schema_version", rel)
+				}
+				got = sv
+			}
+			if got != schema.CurrentSchemaVersion {
+				t.Fatalf("%s: schema_version %q, want %q", rel, got, schema.CurrentSchemaVersion)
+			}
+		})
+	}
+}
+
+func olderSameMajorBelowContract(t *testing.T) string {
+	t.Helper()
+	cur := schema.CurrentSchemaVersion
+	cm, ci, cp, err := parseSemverCore(cur)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cp > 0 {
+		return fmt.Sprintf("%d.%d.%d", cm, ci, cp-1)
+	}
+	if ci > 0 {
+		return fmt.Sprintf("%d.%d.%d", cm, ci-1, 0)
+	}
+	t.Skip("need older same-major skew fixture")
+	return ""
+}
+
+func TestConfigWarnings_labelsSkew(t *testing.T) {
+	t.Parallel()
+	older := olderSameMajorBelowContract(t)
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), reinguardYAMLMinimal())
+	writeFile(t, filepath.Join(dir, "labels.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+categories:
+  x:
+    description: d
+    scope: issue
+    labels:
+      - name: a
+        color: "000000"
+        description: d
+`, older)))
+
+	res, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := ConfigWarnings(res)
+	if len(w) != 1 || !strings.Contains(w[0], "labels.yaml") || !strings.Contains(w[0], "schema_version") {
+		t.Fatalf("want one labels skew warning, got %v", w)
+	}
+}
+
+func TestConfigWarnings_manifestSkew(t *testing.T) {
+	t.Parallel()
+	older := olderSameMajorBelowContract(t)
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), reinguardYAMLMinimal())
+	if err := os.Mkdir(filepath.Join(dir, "knowledge"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "knowledge", "manifest.json"), []byte(fmt.Sprintf(`{
+  "schema_version": %q,
+  "entries": []
+}`, older)))
+
+	res, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := ConfigWarnings(res)
+	if len(w) != 1 || !strings.Contains(w[0], "manifest.json") || !strings.Contains(w[0], "schema_version") {
+		t.Fatalf("want one manifest skew warning, got %v", w)
+	}
+}
+
+func TestConfigWarnings_controlStateSkew(t *testing.T) {
+	t.Parallel()
+	older := olderSameMajorBelowContract(t)
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), reinguardYAMLMinimal())
+	statesDir := filepath.Join(dir, "control", "states")
+	if err := os.MkdirAll(statesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(statesDir, "x.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+rules:
+  - type: state
+    id: s1
+    priority: 10
+    state_id: idle
+    when: {op: eq, path: git.branch, value: main}
+`, older)))
+
+	res, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := ConfigWarnings(res)
+	if len(w) != 1 || !strings.Contains(w[0], "control/states/x.yaml") || !strings.Contains(w[0], "schema_version") {
+		t.Fatalf("want one control skew warning, got %v", w)
+	}
+}
+
+func TestLoad_controlRule_schemaMajorMismatch(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), reinguardYAMLMinimal())
+	statesDir := filepath.Join(dir, "control", "states")
+	if err := os.MkdirAll(statesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(statesDir, "bad.yaml"), []byte(`schema_version: "99.0.0"
+rules: []
+`))
+
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "incompatible") {
+		t.Fatalf("got %v", err)
 	}
 }
 
@@ -983,7 +1161,7 @@ func assertReinguardControlCatalogWorkflowEntries(t *testing.T, reinguardDir str
 func TestEffectiveRuntimeGateRoles_explicitEmptyPassRequiresRoles(t *testing.T) {
 	t.Parallel()
 	// Given: explicit empty pass_requires_roles for pr_readiness in YAML
-	cfg := `schema_version: "0.6.0"
+	cfg := `schema_version: "0.7.0"
 default_branch: main
 workflow:
   runtime_gate_roles:

--- a/internal/config/load_bundle.go
+++ b/internal/config/load_bundle.go
@@ -104,6 +104,33 @@ func rejectLegacyRulesDir(dir string) error {
 	return nil
 }
 
+func readControlRuleFile(kind, kindDir, name string, rulesSch *jsonschema.Schema) (string, RulesDocument, error) {
+	p := filepath.Join(kindDir, name)
+	key := kind + "/" + name
+	data, readErr := os.ReadFile(p)
+	if readErr != nil {
+		return "", RulesDocument{}, fmt.Errorf("config: read %s: %w", p, readErr)
+	}
+	var docMap map[string]any
+	if uerr := yaml.Unmarshal(data, &docMap); uerr != nil {
+		return "", RulesDocument{}, fmt.Errorf("config: parse %s: %w", p, uerr)
+	}
+	if err := validateDoc(rulesSch, docMap, p); err != nil {
+		return "", RulesDocument{}, err
+	}
+	var doc RulesDocument
+	if uerr := yaml.Unmarshal(data, &doc); uerr != nil {
+		return "", RulesDocument{}, fmt.Errorf("config: decode %s: %w", p, uerr)
+	}
+	if err := validateDeclaredSchemaVersion(doc.SchemaVersion, p); err != nil {
+		return "", RulesDocument{}, err
+	}
+	if err := validateRulesMatchControlKind(kind, doc.Rules, p); err != nil {
+		return "", RulesDocument{}, err
+	}
+	return key, doc, nil
+}
+
 func readControlRuleFiles(dir string, rulesSch *jsonschema.Schema) (map[string]RulesDocument, error) {
 	ruleFiles := make(map[string]RulesDocument)
 	controlKinds := []string{"guards", "routes", "states"}
@@ -128,24 +155,8 @@ func readControlRuleFiles(dir string, rulesSch *jsonschema.Schema) (map[string]R
 		}
 		sort.Strings(yamlNames)
 		for _, name := range yamlNames {
-			p := filepath.Join(kindDir, name)
-			key := kind + "/" + name
-			data, readErr := os.ReadFile(p)
-			if readErr != nil {
-				return nil, fmt.Errorf("config: read %s: %w", p, readErr)
-			}
-			var docMap map[string]any
-			if uerr := yaml.Unmarshal(data, &docMap); uerr != nil {
-				return nil, fmt.Errorf("config: parse %s: %w", p, uerr)
-			}
-			if err := validateDoc(rulesSch, docMap, p); err != nil {
-				return nil, err
-			}
-			var doc RulesDocument
-			if uerr := yaml.Unmarshal(data, &doc); uerr != nil {
-				return nil, fmt.Errorf("config: decode %s: %w", p, uerr)
-			}
-			if err := validateRulesMatchControlKind(kind, doc.Rules, p); err != nil {
+			key, doc, err := readControlRuleFile(kind, kindDir, name, rulesSch)
+			if err != nil {
 				return nil, err
 			}
 			ruleFiles[key] = doc

--- a/internal/gate/artifact_test.go
+++ b/internal/gate/artifact_test.go
@@ -135,7 +135,7 @@ func TestRecord_allowsPRReadinessWhenPrePRAIReviewOptional(t *testing.T) {
 	// Given: config with pre_pr_ai_review.required=false and local-verification proof inputs
 	repo := initGitRepo(t)
 	cfgDir := t.TempDir()
-	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(`schema_version: "0.6.0"
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(`schema_version: "0.7.0"
 default_branch: main
 workflow:
   runtime_gate_roles:
@@ -224,7 +224,7 @@ func TestStatus_classifiesArtifacts(t *testing.T) {
 					t.Fatal(err)
 				}
 				writeFile(t, path, marshalArtifactForTest(t, Artifact{
-					SchemaVersion: "0.6.0",
+					SchemaVersion: "0.7.0",
 					GateID:        "other-gate",
 					Status:        StatusPass,
 					RecordedAt:    time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
@@ -242,7 +242,7 @@ func TestStatus_classifiesArtifacts(t *testing.T) {
 			gateID: "local-verification",
 			prepare: func(t *testing.T, cfgDir string) {
 				writeArtifactForTest(t, cfgDir, Artifact{
-					SchemaVersion: "0.6.0",
+					SchemaVersion: "0.7.0",
 					GateID:        "local-verification",
 					Status:        StatusPass,
 					RecordedAt:    time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
@@ -260,7 +260,7 @@ func TestStatus_classifiesArtifacts(t *testing.T) {
 			gateID: "local-verification",
 			prepare: func(t *testing.T, cfgDir string) {
 				writeArtifactForTest(t, cfgDir, Artifact{
-					SchemaVersion: "0.6.0",
+					SchemaVersion: "0.7.0",
 					GateID:        "local-verification",
 					Status:        StatusPass,
 					RecordedAt:    time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
@@ -278,7 +278,7 @@ func TestStatus_classifiesArtifacts(t *testing.T) {
 			gateID: "local-verification",
 			prepare: func(t *testing.T, cfgDir string) {
 				writeArtifactForTest(t, cfgDir, Artifact{
-					SchemaVersion: "0.6.0",
+					SchemaVersion: "0.7.0",
 					GateID:        "local-verification",
 					Status:        StatusPass,
 					RecordedAt:    time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
@@ -295,7 +295,7 @@ func TestStatus_classifiesArtifacts(t *testing.T) {
 			gateID: "local-verification",
 			prepare: func(t *testing.T, cfgDir string) {
 				writeArtifactForTest(t, cfgDir, Artifact{
-					SchemaVersion: "0.6.0",
+					SchemaVersion: "0.7.0",
 					GateID:        "local-verification",
 					Status:        StatusFail,
 					RecordedAt:    time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
@@ -316,7 +316,7 @@ func TestStatus_classifiesArtifacts(t *testing.T) {
 					t.Fatal(err)
 				}
 				writeFile(t, path, marshalArtifactForTest(t, Artifact{
-					SchemaVersion: "0.6.0",
+					SchemaVersion: "0.7.0",
 					GateID:        "local-coderabbit",
 					Status:        StatusPass,
 					RecordedAt:    time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
@@ -359,7 +359,7 @@ func TestLoadSignals_injectsDerivedStatuses(t *testing.T) {
 	branch := currentBranchForTest(t, repo)
 	head := currentHeadForTest(t, repo)
 	writeArtifactForTest(t, cfgDir, Artifact{
-		SchemaVersion: "0.6.0",
+		SchemaVersion: "0.7.0",
 		GateID:        "local-verification",
 		Status:        StatusPass,
 		RecordedAt:    time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),

--- a/internal/labels/data/labels.yaml
+++ b/internal/labels/data/labels.yaml
@@ -1,5 +1,5 @@
 # GitHub label catalog + commit prefix config (ADR-0008). SSOT for rgd ensure-labels, labels sync, CI policy.
-schema_version: "0.3.0"
+schema_version: "0.7.0"
 
 categories:
   type:

--- a/internal/rgdcli/fixtures_test.go
+++ b/internal/rgdcli/fixtures_test.go
@@ -19,12 +19,12 @@ func writeFile(t *testing.T, path string, data []byte) {
 // Shared fixtures for CLI tests: keep rule shapes aligned with config.Load expectations
 // (schema_version, default_branch, providers, control/{states,routes,guards}/*.yaml).
 
-const testFixtureReinguardRoot = `schema_version: "0.6.0"
+const testFixtureReinguardRoot = `schema_version: "0.7.0"
 default_branch: main
 providers: []
 `
 
-const testFixtureReinguardGitOnly = `schema_version: "0.6.0"
+const testFixtureReinguardGitOnly = `schema_version: "0.7.0"
 default_branch: main
 providers:
   - id: git
@@ -32,7 +32,7 @@ providers:
 `
 
 // Git + GitHub providers enabled for context-build tests that need both local and remote-style signals.
-const testFixtureReinguardGitAndGitHub = `schema_version: "0.6.0"
+const testFixtureReinguardGitAndGitHub = `schema_version: "0.7.0"
 default_branch: main
 providers:
   - id: git
@@ -42,7 +42,8 @@ providers:
 `
 
 // Single state rule: branch main -> Idle (used by state eval / context build smoke tests).
-const testFixtureRulesStateIdle = `rules:
+const testFixtureRulesStateIdle = `schema_version: "0.7.0"
+rules:
   - type: state
     id: idle
     priority: 10
@@ -54,7 +55,8 @@ const testFixtureRulesStateIdle = `rules:
 `
 
 // Route rule for context build (keys off resolved state.kind, id: r1); pair with testFixtureRulesStateIdle.
-const testFixtureControlRoutesNext = `rules:
+const testFixtureControlRoutesNext = `schema_version: "0.7.0"
+rules:
   - type: route
     id: r1
     priority: 10
@@ -66,7 +68,8 @@ const testFixtureControlRoutesNext = `rules:
 `
 
 // Two state rules with same priority and overlapping when -> ambiguous with fail-on-non-resolved.
-const testFixtureRulesStateAmbiguous = `rules:
+const testFixtureRulesStateAmbiguous = `schema_version: "0.7.0"
+rules:
   - type: state
     id: a
     priority: 1
@@ -80,7 +83,8 @@ const testFixtureRulesStateAmbiguous = `rules:
 `
 
 // Two route rules with same priority and overlapping when -> ambiguous.
-const testFixtureRulesRouteAmbiguous = `rules:
+const testFixtureRulesRouteAmbiguous = `schema_version: "0.7.0"
+rules:
   - type: route
     id: a
     priority: 1
@@ -93,4 +97,4 @@ const testFixtureRulesRouteAmbiguous = `rules:
     when: {op: eq, path: git.branch, value: feat}
 `
 
-const testFixtureRulesEmpty = "rules: []\n"
+const testFixtureRulesEmpty = "schema_version: \"0.7.0\"\nrules: []\n"

--- a/internal/rgdcli/golden_test.go
+++ b/internal/rgdcli/golden_test.go
@@ -87,7 +87,7 @@ when:
 # Doc
 `))
 	writeFile(t, filepath.Join(root, "knowledge", "manifest.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "entries": [{
     "id": "doc1",
     "path": "knowledge/doc.md",

--- a/internal/rgdcli/rgdcli.go
+++ b/internal/rgdcli/rgdcli.go
@@ -626,7 +626,7 @@ func runConfigValidate(c *cli.Context) error {
 	if _, perr := observe.NewEngineFromConfig(res.Root.Providers); perr != nil {
 		return fmt.Errorf("config: provider build: %w", perr)
 	}
-	for _, w := range config.DeprecatedWarnings(&res.Root) {
+	for _, w := range config.ConfigWarnings(res) {
 		_, _ = fmt.Fprintln(c.App.ErrWriter, w)
 	}
 	repoRoot := configdir.RepoRoot(dir)

--- a/internal/rgdcli/rgdcli_config_test.go
+++ b/internal/rgdcli/rgdcli_config_test.go
@@ -24,7 +24,7 @@ func TestRunConfigValidate_deprecatedLegacyToolHints(t *testing.T) {
 	t.Parallel()
 	// Given: valid config with legacy_tool_hints set
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "reinguard.yaml"), []byte(`schema_version: "0.6.0"
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), []byte(`schema_version: "0.7.0"
 default_branch: main
 providers: []
 legacy_tool_hints:

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -78,7 +78,7 @@ when:
 ---
 `))
 	writeFile(t, filepath.Join(kdir, "manifest.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "entries": [{
     "id": "doc1",
     "path": "knowledge/doc.md",
@@ -179,7 +179,7 @@ func TestRunContextBuild_rejectsScopeFlagsWithObservationFile(t *testing.T) {
 			writeFile(t, filepath.Join(cfgDir, "control", "states", "default.yaml"), []byte(testFixtureRulesStateIdle))
 			writeFile(t, filepath.Join(cfgDir, "control", "routes", "default.yaml"), []byte(testFixtureControlRoutesNext))
 			obsPath := filepath.Join(t.TempDir(), "observation.json")
-			writeFile(t, obsPath, []byte(`{"schema_version":"0.6.0","signals":{"git":{"branch":"main"}},"degraded":false}`))
+			writeFile(t, obsPath, []byte(`{"schema_version":"0.7.0","signals":{"git":{"branch":"main"}},"degraded":false}`))
 
 			// When: context build runs with --observation-file and a scope flag
 			app := NewApp("test")

--- a/internal/rgdcli/rgdcli_gate_test.go
+++ b/internal/rgdcli/rgdcli_gate_test.go
@@ -92,7 +92,8 @@ func TestRunStateEval_mergesRuntimeGateSignals(t *testing.T) {
 	repo := initGitRepoForGateCLI(t)
 	cfgDir := filepath.Join(repo, ".reinguard")
 	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
-	writeFile(t, filepath.Join(cfgDir, "control", "states", "gates.yaml"), []byte(`rules:
+	writeFile(t, filepath.Join(cfgDir, "control", "states", "gates.yaml"), []byte(`schema_version: "0.7.0"
+rules:
   - type: state
     id: local_verified
     priority: 1

--- a/internal/rgdcli/rgdcli_knowledge_test.go
+++ b/internal/rgdcli/rgdcli_knowledge_test.go
@@ -48,7 +48,7 @@ func TestRunKnowledgePack_observationFileFiltersWhen(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeFile(t, filepath.Join(kdir, "manifest.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "entries": [
     {
       "id": "on-main",
@@ -68,7 +68,7 @@ func TestRunKnowledgePack_observationFileFiltersWhen(t *testing.T) {
 }`))
 	obsDir := t.TempDir()
 	writeFile(t, filepath.Join(obsDir, "o.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "signals": {"git": {"branch": "main"}},
   "degraded": false
 }`))
@@ -104,7 +104,7 @@ func TestRunKnowledgePack_observationFileAndQueryUnion(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeFile(t, filepath.Join(kdir, "manifest.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "entries": [
     {
       "id": "on-main",
@@ -124,7 +124,7 @@ func TestRunKnowledgePack_observationFileAndQueryUnion(t *testing.T) {
 }`))
 	obsDir := t.TempDir()
 	writeFile(t, filepath.Join(obsDir, "o.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "signals": {"git": {"branch": "main"}},
   "degraded": false
 }`))
@@ -160,7 +160,7 @@ func TestRunKnowledgePack_rejectsInvalidScopePR(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeFile(t, filepath.Join(cfgDir, "knowledge", "manifest.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "entries": []
 }`))
 	app := NewApp("t")
@@ -184,7 +184,7 @@ func TestRunKnowledgePack_queryFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeFile(t, filepath.Join(cfgDir, "knowledge", "manifest.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "entries": [
     {
       "id": "a",
@@ -332,7 +332,7 @@ when:
 ---
 `))
 	writeFile(t, filepath.Join(kdir, "manifest.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "entries": [{
     "id": "wrong",
     "path": "knowledge/only.md",
@@ -364,7 +364,7 @@ func TestRunConfigValidate_knowledgeMissingPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeFile(t, filepath.Join(kdir, "manifest.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "entries": [{
     "id": "ghost",
     "path": "knowledge/missing.md",

--- a/internal/rgdcli/rgdcli_state_test.go
+++ b/internal/rgdcli/rgdcli_state_test.go
@@ -16,7 +16,7 @@ func TestRunStateEval_observationFile(t *testing.T) {
 	writeFile(t, filepath.Join(cfgDir, "control", "states", "r.yaml"), []byte(testFixtureRulesStateIdle))
 	obsDir := t.TempDir()
 	writeFile(t, filepath.Join(obsDir, "o.json"), []byte(`{
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "signals": {"git": {"branch": "main"}},
   "degraded": false
 }`))
@@ -74,7 +74,8 @@ func TestRunStateEval_failOnUnsupported(t *testing.T) {
 	// Given: state rule whose when-clause cannot be evaluated (unsupported outcome)
 	cfgDir := t.TempDir()
 	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
-	writeFile(t, filepath.Join(cfgDir, "control", "states", "bad.yaml"), []byte(`rules:
+	writeFile(t, filepath.Join(cfgDir, "control", "states", "bad.yaml"), []byte(`schema_version: "0.7.0"
+rules:
   - type: state
     id: bad
     priority: 1
@@ -106,7 +107,8 @@ func TestRunStateEval_unsupportedJSONOmitsEmptyFields(t *testing.T) {
 	// Given: same when as TestRunStateEval_failOnUnsupported (valid at config load; fails at match eval)
 	cfgDir := t.TempDir()
 	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
-	writeFile(t, filepath.Join(cfgDir, "control", "states", "bad.yaml"), []byte(`rules:
+	writeFile(t, filepath.Join(cfgDir, "control", "states", "bad.yaml"), []byte(`schema_version: "0.7.0"
+rules:
   - type: state
     id: bad
     priority: 1

--- a/internal/rgdcli/testdata/golden/context_build/observation.json
+++ b/internal/rgdcli/testdata/golden/context_build/observation.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "signals": {
     "git": {
       "branch": "main",

--- a/internal/rgdcli/testdata/golden/context_build/want.json
+++ b/internal/rgdcli/testdata/golden/context_build/want.json
@@ -25,7 +25,7 @@
   },
   "observation": {
     "degraded": false,
-    "schema_version": "0.6.0",
+    "schema_version": "0.7.0",
     "signals": {
       "git": {
         "ahead_of_upstream": 0,
@@ -75,7 +75,7 @@
       ]
     }
   ],
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "state": {
     "kind": "resolved",
     "state_id": "Idle",

--- a/internal/rgdcli/testdata/golden/state_eval/observation.json
+++ b/internal/rgdcli/testdata/golden/state_eval/observation.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "0.6.0",
+  "schema_version": "0.7.0",
   "signals": {
     "git": {
       "branch": "main",

--- a/pkg/schema/embed.go
+++ b/pkg/schema/embed.go
@@ -20,7 +20,7 @@ const (
 	OperationalContext   = "operational-context.json"
 	LabelsConfig         = "labels-config.json"
 	GateArtifact         = "gate-artifact.json"
-	CurrentSchemaVersion = "0.6.0"
+	CurrentSchemaVersion = "0.7.0"
 )
 
 // Files returns the embedded JSON Schema filesystem (read-only).

--- a/pkg/schema/rules-document.json
+++ b/pkg/schema/rules-document.json
@@ -3,8 +3,13 @@
   "$id": "https://github.com/k-shibuki/reinguard/schemas/rules-document.json",
   "title": "RulesDocument",
   "type": "object",
-  "required": ["rules"],
+  "required": ["schema_version", "rules"],
   "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Synchronized contract version (ADR-0008).",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?(\\+[0-9A-Za-z.-]+)?$"
+    },
     "rules": {
       "type": "array",
       "minItems": 0,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Align Adapter docs with Semantics SSOT (AGENTS, reinguard-bridge.mdc, rgd-next.md, cursor-plan.md) and trim duplicate normative text.
- Bump synchronized contract to **0.7.0**: rules-document.json requires schema_version; every control rule YAML declares it; unified labels and repo versioned files.
- config.ConfigWarnings emits same-major skew warnings for labels.yaml, knowledge/manifest.json, and each control rule file; rgd config validate uses it.
- ADR-0008 (Decision 6–7), ADR-0013/0014/0015 edits; docs/cli.md skew table covers all versioned inputs.
- Tests: TestSchemaVersionSync_committedVersionedFiles, skew tests, major-mismatch control rule test.

## Traceability

Closes #112

Refs: #112

## Definition of Done

- [x] Tests added or updated (go test ./...)
- [x] go vet ./... clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. go test ./... -race -count=1
2. go run ./cmd/rgd config validate
3. golangci-lint run ./...

## Risk / Impact

- Breaking for forks: repos must bump all declared schema_version fields to 0.7.0 and add schema_version to control rule YAML when upgrading rgd.
- Config authors see additional stderr skew lines when any versioned file drifts from the binary contract.

## Rollback Plan

- Revert this PR; restore prior schema_version values and Adapter/ADR text as needed.

## Exception

- (not applicable)
