### PR TITLE
feat(cli): procedure front matter SSOT, context-build hints, and gate record ergonomics

### DIFF
--- a/.cursor/commands/rgd-next.md
+++ b/.cursor/commands/rgd-next.md
@@ -44,7 +44,7 @@ as substrate workflow position.
 
 ## Route
 
-**Normative mapping:** [ADR-0013 § 4](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) (*Adapter mapping (durable)*). When `state.kind` is `resolved`, use that section’s table to choose the procedure file under `.reinguard/procedure/`. ADR-0013 and `.reinguard/control/` are the SSOT for state and route semantics (do not duplicate the mapping here).
+**Normative mapping:** When `state.kind` is `resolved`, choose the procedure under `.reinguard/procedure/` whose YAML front matter `applies_to.state_ids` contains `state.state_id` (and align with `routes[0].route_id` vs `applies_to.route_ids` when procedures scope by route). The durable mapping is machine-readable Semantics validated by `rgd config validate`; [ADR-0013](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) §4 describes the mechanism and FSM context (do not duplicate a routing table here). ADR-0013 and `.reinguard/control/` remain the SSOT for state and route *semantics*.
 
 **Dirty working tree + `review-address`:** When `observation.signals.git.working_tree_clean` is `false` and the resolved procedure is `review-address`, run **Step 0** in that procedure first (`change-inspect` → commit → refresh context). See `.reinguard/knowledge/review--incremental-fix-flow.md`.
 
@@ -68,7 +68,7 @@ Persistent JSON defaults to `.reinguard/local/adapter/rgd-next/execute-resume.js
 
 This writes `status: "pending_approval"` and persists the **proposed** contract inputs (`state-id`, `ordered-remainder`, `completion-condition`, fingerprint inputs) so the artifact records **what** the user will approve. The status stays `pending_approval` until the user approves Execute (next section).
 
-Proposal content, approval gate, and user-visible output requirements: [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Full-path proposal format** and § **Approval gate**. Trace from the current `state_id` ([ADR-0013 § 4](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md)) through **Per-unit Definition of Done** in `next-orchestration.md`. **No per-procedure re-approval** after the single gate.
+Proposal content, approval gate, and user-visible output requirements: [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Full-path proposal format** and § **Approval gate**. Trace from the current `state_id` and mapped procedure (front matter SSOT per ADR-0013 § 4) through **Per-unit Definition of Done** in `next-orchestration.md`. **No per-procedure re-approval** after the single gate.
 
 **Output (for agents):** Per **`next-orchestration.md`** § **Output** and procedure front matter — not merely `state_id` / `route_id` bullets.
 

--- a/.cursor/rules/reinguard-bridge.mdc
+++ b/.cursor/rules/reinguard-bridge.mdc
@@ -30,7 +30,7 @@ Follow these policy documents in every interaction:
 
 ## Workflow
 
-Follow [.reinguard/policy/workflow--pr-discipline.md](../../.reinguard/policy/workflow--pr-discipline.md). Which procedures apply to which FSM `state_id` / `route_id` is defined in each procedure’s YAML front matter (`applies_to`) and in [ADR-0013 § 4](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) (*Adapter mapping*). After Sense and Route, `rgd-next` applies [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) (single full-path proposal, one approval gate, then Execute). Adapter flow: [`rgd-next.md`](../commands/rgd-next.md) § **Propose** then § **Execute**.
+Follow [.reinguard/policy/workflow--pr-discipline.md](../../.reinguard/policy/workflow--pr-discipline.md). Which procedures apply to which FSM `state_id` / `route_id` is defined in each procedure’s YAML front matter (`applies_to`) under [.reinguard/procedure/](../../.reinguard/procedure/); `rgd config validate` checks mapping consistency with `control/states`. [ADR-0013](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) documents FSM semantics and the mapping *mechanism* (not a duplicate Markdown routing table). After Sense and Route, `rgd-next` applies [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) (single full-path proposal, one approval gate, then Execute). Adapter flow: [`rgd-next.md`](../commands/rgd-next.md) § **Propose** then § **Execute**.
 
 ### rgd-next Execute — Cursor chat transcript (Adapter)
 

--- a/.reinguard/knowledge/workflow--state-gate-guard-extension.md
+++ b/.reinguard/knowledge/workflow--state-gate-guard-extension.md
@@ -25,8 +25,8 @@ when:
 1. [ ] Update `.reinguard/control/states/*.yaml` — priorities (lower wins); residual vs refined ordering.
 2. [ ] Update ADR-0013 § State catalog and any route/Adapter notes.
 3. [ ] Update `.reinguard/control/routes/*.yaml` if the primary `route_id` or matching rules change.
-4. [ ] Update `.cursor/commands/rgd-next.md` heuristic table if the primary procedure changes.
-5. [ ] Update `.reinguard/procedure/*.md` `applies_to.state_ids` for affected procedures.
+4. [ ] Update `.reinguard/procedure/*.md` `applies_to.state_ids` / `applies_to.route_ids` for affected procedures; run `rgd config validate` (no Adapter “heuristic table”; `rgd-next` derives routing from front matter).
+5. [ ] Confirm `.cursor/commands/rgd-next.md` still points at substrate + Semantics only (no duplicated mapping table).
 6. [ ] Add or extend `internal/rgdcli/workflow_fsm_test.go` (or equivalent) for non-obvious resolution.
 
 ## Adding or changing a runtime **gate** (`gate_id`)
@@ -34,7 +34,7 @@ when:
 1. [ ] Document producer procedure(s) (`rgd gate record <gate-id>` after verification) and consumer(s) (`rgd gate status`, FSM `gates.<gate-id>.*`). On-disk files: `.reinguard/local/gates/<gate-id>.json` (gitignored).
 2. [ ] Update ADR-0014 extension contract if semantics are new or changed.
 3. [ ] Update `.reinguard/control/states/*.yaml` / `routes/*.yaml` if FSM rules reference `gates.<gate-id>`.
-4. [ ] Update ADR-0013 § State catalog / Adapter mapping if a new `state_id` or mapping is introduced.
+4. [ ] Update ADR-0013 § State catalog / procedure mapping notes if a new `state_id` or primary procedure changes.
 5. [ ] Add CLI/FSM tests for `pass` vs `stale` / `missing` behavior if resolution depends on the gate.
 
 ## Adding or changing **guards** (`guard eval`)
@@ -51,7 +51,7 @@ when:
 
 ## Validation and tests (run before push)
 
-1. [ ] `rgd config validate` — control YAML, manifest freshness, `when` static checks.
+1. [ ] `rgd config validate` — control YAML, procedure `applies_to` mapping checks, manifest freshness, `when` static checks.
 2. [ ] `go test ./... -race` (and `go vet`, `golangci-lint` per project policy) when Go or tests change.
 
 **Targeted tests (when touched by the change):**
@@ -77,7 +77,7 @@ when:
 
 1. ADR-0013 / ADR-0014 — durable rules and catalog rows.
 2. `.reinguard/control/states/*.yaml` and `routes/*.yaml` — priorities and `when` clauses.
-3. Procedures and `.cursor/commands/rgd-next.md` — `applies_to`, Adapter heuristic table.
+3. Procedures — `applies_to` updates; Adapter commands reference substrate + procedure files only.
 4. Knowledge — new/changed atoms; `rgd knowledge index`; manifest committed.
 5. `docs/cli.md` — if built-in guard or CLI behavior changes.
 6. Go tests — `workflow_fsm_test` and package tests per the table above; then full `go test ./... -race`.

--- a/.reinguard/procedure/next-orchestration.md
+++ b/.reinguard/procedure/next-orchestration.md
@@ -22,12 +22,12 @@ escalate_when: "HS-* violation; genuine cannot-proceed with evidence."
 
 **Not a Cursor slash command** — the invocable Adapter entry is [`.cursor/commands/rgd-next.md`](../../.cursor/commands/rgd-next.md) (Propose → Execute after approval).
 
-**Design alignment**: [ADR-0001](../../docs/adr/0001-system-positioning.md) — `state_id` → procedure routing is normative in [ADR-0013](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) § 4; this document holds **orchestration** (proposal, approval, execution contract, loop).
+**Design alignment**: [ADR-0001](../../docs/adr/0001-system-positioning.md) — `state_id` → procedure routing uses `.reinguard/procedure/*.md` front matter (`applies_to`), validated by `rgd config validate`; [ADR-0013](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) § 4 documents the mechanism and FSM semantics. This document holds **orchestration** (proposal, approval, execution contract, loop).
 
 ## Context
 
 - [`../policy/safety--agent-invariants.md`](../policy/safety--agent-invariants.md) — **HS-*** hard stops
-- [ADR-0013](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) — FSM states; **§ 4 Adapter mapping (durable)** for `state_id` → procedure routing
+- [ADR-0013](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) — FSM states; **§ 4** procedure mapping mechanism (`applies_to` SSOT)
 
 **Already in context** (always-active Adapter rule): HS-* codes, catalogs, workflow and commit policy.
 
@@ -50,7 +50,7 @@ Concrete gates: HS-* invariants, `merge-readiness` / `rgd guard eval merge-readi
 Before the approval gate, present:
 
 1. **Current position** — `state_id`, `route_id` (when resolved), and brief evidence basis from `rgd context build` JSON.
-2. **Ordered remainder** — Trace **forward** from the current `state_id` using **ADR-0013 § 4** (*Adapter mapping*) through **Per-unit Definition of Done** above. List the **sequence of procedures** you expect (e.g. `review-address` → `wait-bot-review` → `pr-merge` → branch cleanup). Include `change-inspect` and `pr-create` on the path from `working_no_pr` when applicable.
+2. **Ordered remainder** — Trace **forward** from the current `state_id` using the mapped primary procedure (procedure front matter per ADR-0013 § 4) through **Per-unit Definition of Done** above. List the **sequence of procedures** you expect (e.g. `review-address` → `wait-bot-review` → `pr-merge` → branch cleanup). Include `change-inspect` and `pr-create` on the path from `working_no_pr` when applicable.
 3. **Gaps** — State honestly what is unknown until the next observation (e.g. “PR not opened yet — review steps are projected”).
 4. **Completion condition** — Reference **Per-unit Definition of Done** (this section).
 
@@ -105,7 +105,7 @@ Repeat until Per-unit Definition of Done is satisfied or an **allowed stop** fir
 
 1. **Sense** — `rgd context build` (same cwd / `--config-dir` as the workflow’s initial context build from repo root).
 2. **Parse** — `state`, `routes[0]` (interpret `routes[0].route_id` only when `routes[0].kind` is `resolved`), `guards`, `knowledge.entries`; record a short iteration context **agent-internally** (e.g. tool logs or internal notes). Whether any of that appears in a user-facing channel is defined by the Adapter (see [`../../.cursor/rules/reinguard-bridge.mdc`](../../.cursor/rules/reinguard-bridge.mdc) § **rgd-next Execute — Cursor chat transcript**); Semantics does not require per-iteration user-visible output.
-3. **Route** — Resolve procedure(s) per **ADR-0013 § 4** (*Adapter mapping*). If `state.kind` is not `resolved`, follow ADR-0007 handoff; do not invent a winning state.
+3. **Route** — Resolve procedure(s) from `.reinguard/procedure/` front matter (`applies_to`) consistent with ADR-0013 § 4. If `state.kind` is not `resolved`, follow ADR-0007 handoff; do not invent a winning state.
 4. **Act (procedure)** — Open the mapped procedure file(s) and **follow each procedure in full** (Context, Reads, Sense, Act, Output, Guard, front-matter `done_when` / `escalate_when` as applicable). Treat any “confirm” / “verify” language in mapped procedures as **agent self-checks** (evidence-backed), not a new user-approval gate, unless an **allowed stop** applies. Do not shortcut HS-*.
 5. **Refresh** — After any **material** remote or local change (push, merge, thread resolve batch, bot re-review when the procedure says so), run **`rgd context build` again** before the next Route.
 

--- a/.reinguard/scripts/adapter-rgd-next-resume.sh
+++ b/.reinguard/scripts/adapter-rgd-next-resume.sh
@@ -8,6 +8,8 @@ source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/json_minimal.sh"
 
 SCRIPT_NAME="adapter-rgd-next-resume.sh"
+# SSOT for the resume artifact schema version (ADR-0015).
+RESUME_SCHEMA_VERSION="1.0.0"
 
 if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
   fail_with "$SCRIPT_NAME must run inside a Git repository." 2
@@ -118,7 +120,7 @@ write_artifact_file() {
   mkdir -p "$ARTIFACT_DIR"
   {
     printf '{\n'
-    printf '  "schema_version": "1",\n'
+    printf '  "schema_version": "%s",\n' "$RESUME_SCHEMA_VERSION"
     printf '  "artifact_type": "adapter_rgd_next_resume",\n'
     printf '  "command": "rgd-next",\n'
     printf '  "status": "%s",\n' "$(json_escape "$artifact_status")"

--- a/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
+++ b/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
@@ -94,19 +94,24 @@ primary `route_id` in `rgd route select` output. Alternatives appear in
 `control/guards/*.yaml` as today. State `merge_ready` is a **coarse** picture;
 `guard eval merge-readiness` remains the explicit merge gate signal.
 
-### 4. Adapter mapping (durable)
+### 4. Adapter mapping (machine-readable SSOT)
 
-| state_id | Primary procedure (Semantics) |
-|----------|------------------------------|
-| `working_no_pr` | `.reinguard/procedure/implement.md` |
-| `ready_for_pr` | `.reinguard/procedure/pr-create.md` |
-| `pr_open` | `.reinguard/procedure/review-address.md` |
-| `waiting_ci` | `.reinguard/procedure/review-address.md` |
-| `unresolved_threads` | `.reinguard/procedure/review-address.md` |
-| `non_thread_findings_pending` | `.reinguard/procedure/review-address.md` |
-| `changes_requested` | `.reinguard/procedure/review-address.md` |
-| `waiting_bot_rate_limited` / `waiting_bot_paused` / `waiting_bot_failed` / `waiting_bot_stale` / `waiting_bot_run` | `.reinguard/procedure/wait-bot-review.md` (+ `review--bot-operations.md` in `knowledge.entries`) |
-| `merge_ready` | `.reinguard/procedure/pr-merge.md` |
+The mapping from a resolved workflow `state_id` to the **primary** Adapter
+procedure document is **not** maintained as a Markdown table in this ADR.
+
+**SSOT:** `.reinguard/procedure/*.md` YAML front matter (`applies_to.state_ids`,
+and optionally `applies_to.route_ids`) per ADR-0011.
+
+**Rules:**
+
+- Each mapped `state_id` is claimed by **exactly one** procedure’s `applies_to.state_ids`. `rgd config validate` rejects duplicates and
+  `state_id` values that do not appear on any `control/states` rule.
+- Adapters resolve the procedure file by matching `state.state_id` from
+  `rgd context build` against that front matter (and cross-check
+  `routes[0].route_id` against `applies_to.route_ids` when procedures scope by
+  route). Optional `state.procedure_hint` in context JSON, when present, is a
+  derived advisory field from the same SSOT; the Markdown files remain
+  authoritative.
 
 Self-inspection before PR creation remains `.reinguard/procedure/change-inspect.md`;
 it prepares `ready_for_pr` by recording the configured pre-PR AI review proof
@@ -115,7 +120,7 @@ it prepares `ready_for_pr` by recording the configured pre-PR AI review proof
 itself a state-mapped procedure.
 Post-review learning: `.reinguard/procedure/internalize.md`.
 
-**Cursor entries:** `.cursor/commands/rgd-next.md` — Sense (`rgd context build`), Route per **§ 4** above, then Propose / Execute per `.reinguard/procedure/next-orchestration.md` (no duplicate procedure mapping table in Adapter files). `.cursor/commands/cursor-plan.md` — planning only (`AskQuestion` / `CreatePlan`); not part of the FSM.
+**Cursor entries:** `.cursor/commands/rgd-next.md` — Sense (`rgd context build`), Route using procedure front matter as above, then Propose / Execute per `.reinguard/procedure/next-orchestration.md` (do not duplicate a mapping table in Adapter files). `.cursor/commands/cursor-plan.md` — planning only (`AskQuestion` / `CreatePlan`); not part of the FSM.
 
 ### 5. Extension contract (state / route / Adapter)
 
@@ -124,8 +129,8 @@ When adding or changing FSM wiring, keep these touchpoints consistent:
 1. **State catalog (this ADR)** — Add or update the row in section 1 for every new or changed `state_id`. Residual states must stay documented (observation gaps, missing facets) and their **numeric `priority`** must be explicit relative to refinements (lower wins; ADR-0004).
 2. **Control state rules** — Edit `.reinguard/control/states/*.yaml`. Ensure rules do not accidentally overlap: a more specific condition (e.g. a gate-backed state) must use a **lower** numeric `priority` than its residual fallback.
 3. **Routes** — Edit `.reinguard/control/routes/*.yaml` when a `state_id` needs a different primary `route_id` or when new states share an existing route with different procedure hints (section 2).
-4. **Adapter mapping** — Update section 4 (Primary procedure) when the primary Cursor procedure for a `state_id` changes. Adapter commands reference this section; do not duplicate the mapping table outside ADR-0013.
-5. **Procedures** — Update `applies_to.state_ids` in affected `.reinguard/procedure/*.md` files. Procedures that are **not** state-mapped (e.g. `change-inspect`) remain documented here and in their body as producers or prerequisites, not as `state_id` values.
+4. **Procedure mapping (`applies_to`)** — When the primary procedure for a `state_id` changes, update the affected `.reinguard/procedure/*.md` front matter (`applies_to.state_ids` / `route_ids` as appropriate). Run `rgd config validate`. Do not add a second mapping table to this ADR; section 4 documents the mechanism only.
+5. **Procedures (not state-mapped)** — Procedures that are not tied to a `state_id` (e.g. `change-inspect`, `next-orchestration`) keep `applies_to.state_ids: []` and remain documented in their bodies as producers, orchestration, or prerequisites.
 6. **Tests** — Extend scenario tests (e.g. `internal/rgdcli/workflow_fsm_test.go`) when resolution or fallback behavior is non-obvious (residual vs refined state, stale gate fallback).
 
 **Guards vs states:** `guard eval` outputs (e.g. built-in `merge-readiness`) are **not** `state_id` values. FSM states may *align* with guard signals (e.g. `merge_ready` with merge-readiness); wiring belongs in `control/states/*.yaml` and this ADR, not by conflating guard JSON with state without explicit rules.
@@ -139,7 +144,7 @@ Operational checklist (files, validation commands, knowledge surfacing): see `.r
 
 ## Consequences
 
-- **Easier**: One YAML-defined FSM; `rgd-next` routes substrate output to procedures.
+- **Easier**: One YAML-defined FSM; Adapters map substrate output to procedures via machine-readable Semantics (`applies_to`) validated by `rgd`.
 - **Harder**: Priority authoring must stay global across states/routes/guards
   (ADR-0004).
 - **Harder**: Observation providers and tests must cover the timing gap where a

--- a/docs/adr/0014-runtime-gate-artifacts.md
+++ b/docs/adr/0014-runtime-gate-artifacts.md
@@ -38,7 +38,10 @@ but it must not become a workflow brain or execute arbitrary repository scripts.
    gates without inventing agent-internal memory.
 6. `rgd` does **not** execute verification commands for gates. Procedures or
    agents run checks such as `go test`, `go vet`, or `golangci-lint`, then
-   record the resulting verified outcome into a gate artifact.
+   record the resulting verified outcome into a gate artifact. Checks can be
+   supplied inline via the repeatable `--check id:status:summary` flag
+   (preferred for simple cases) or via `--checks-file` for bulk / evidence-
+   rich payloads. The two may be combined; entries are merged.
 7. Runtime gates may define **gate-specific proof contracts** on top of the
    common schema:
    - `local-verification` proves HS-LOCAL-VERIFY work on one `subject`

--- a/docs/adr/0015-adapter-local-execute-resume.md
+++ b/docs/adr/0015-adapter-local-execute-resume.md
@@ -64,6 +64,14 @@ orchestration state, not repository workflow position.
    must not be promoted into `gates.*`, `state_id`, `route_id`, or guard
    inputs.
 
+### Schema versioning
+
+The resume artifact carries its own `schema_version`, independent of the
+substrate `CurrentSchemaVersion` in `pkg/schema/embed.go`. The SSOT is
+`RESUME_SCHEMA_VERSION` at the top of
+`.reinguard/scripts/adapter-rgd-next-resume.sh`. The version follows semver
+(`MAJOR.MINOR.PATCH`); breaking shape changes increment MAJOR.
+
 ## Migration note
 
 Previously the resume file defaulted under `.tmp/adapter/rgd-next/` (and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,7 +38,7 @@ before `state`.
 rgd version
 rgd config validate
 rgd schema export [--dir DIR]
-rgd gate record <gate-id> --status pass|fail --checks-file FILE
+rgd gate record <gate-id> --status pass|fail --check id:status:summary [--checks-file FILE]
 rgd gate status <gate-id>
 rgd gate show <gate-id>
 rgd observe [workflow-position]
@@ -379,9 +379,12 @@ Records one validated gate artifact for the current branch HEAD.
 | `--status` | yes | Top-level gate outcome: `pass` or `fail` |
 | `--producer-procedure` | yes | Procedure that is recording the proof (for example `implement` or `change-inspect`) |
 | `--producer-tool` | no | Recording tool identifier. Defaults to `rgd gate record` |
-| `--checks-file` | yes | JSON array of check objects with fields `id`, `status`, required `summary`, and optional `evidence`; check `status` may be `pass`, `fail`, or `skipped`. At least one check entry is required; the command rejects an empty array. |
+| `--check` | no* | Inline check as `id:status:summary` (repeatable). Preferred over `--checks-file` for simple cases. |
+| `--checks-file` | no* | JSON array of check objects with fields `id`, `status`, required `summary`, and optional `evidence`; check `status` may be `pass`, `fail`, or `skipped`. |
 | `--inputs-file` | no | JSON array of upstream gate proof objects (`gate_id`, `status`, `subject`, `recorded_at`) |
 | `--input-gate` | no | Repeatable shortcut: copy one **fresh passing** stored gate artifact into `inputs[]` |
+
+\* At least one check entry is required from either `--check` or `--checks-file` (or both). `--check` and `--checks-file` may be combined; entries are merged.
 
 The command attaches:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -530,7 +530,12 @@ The `knowledge` object in the output has **`entries`** (same shape as
 Optional per-step flags may be added in future issues; Phase 1 runs the full
 default chain when not using `--observation-file`.
 
-The `state` field is the state-resolution **Result** (same JSON shape as `rgd state eval` stdout).
+The `state` field is the state-resolution **Result** (same JSON shape as `rgd state eval` stdout),
+plus an optional **`procedure_hint`** when `state.kind` is **`resolved`**: an object
+`{"procedure_id":"…","path":"…","derived_from":"state_id"}` derived from `.reinguard/procedure/*.md`
+front matter (`applies_to.state_ids`, and `applies_to.route_ids` as a filter when non-empty).
+It is **advisory** for Adapters; omit when no matching procedure is found, when `state.kind` is not
+`resolved`, or when a route filter does not match the resolved `routes[0].route_id`.
 The `routes` array contains one route-resolution **Result** (same shape as `rgd route select` stdout,
 including `route_candidates` when applicable). See `pkg/schema/operational-context.json` (`resolutionResult`).
 
@@ -569,15 +574,15 @@ The command shells out to `gh api graphql` with a single
 
 ### Authors: extending State / Gate / Guard
 
-- **Normative FSM and gate rules:** [ADR-0013](adr/0013-fsm-workflow-states-and-adapter-mapping.md) (states, routes, Adapter mapping), [ADR-0014](adr/0014-runtime-gate-artifacts.md) (runtime gates, `gates.*` signals, freshness).
+- **Normative FSM and gate rules:** [ADR-0013](adr/0013-fsm-workflow-states-and-adapter-mapping.md) (states, routes, procedure `applies_to` SSOT), [ADR-0014](adr/0014-runtime-gate-artifacts.md) (runtime gates, `gates.*` signals, freshness).
 - **Operational checklist** (which files to update, `rgd config validate`, tests, knowledge manifest): `.reinguard/knowledge/workflow--state-gate-guard-extension.md`.
 - **`knowledge.entries`:** Filtered using the **merged** flat map that includes `gates.<gate-id>.*` and, after state resolution, `state.kind`, `state.state_id`, and `state.rule_id`. Use **`rgd context build`** when authoring or debugging `when` clauses that reference `gates.*` or `state.*`. `rgd knowledge pack --observation-file` alone does **not** merge state or gates unless those keys are already in the observation file—see the `knowledge pack` section above.
 - **`rgd gate status` / `rgd gate record`:** Verify CLI behavior and flag order against this document when documenting new gates in procedures.
 
 ## `rgd config validate`
 
-Validates `reinguard.yaml`, `control/{states,routes,guards}/*.yaml`, and `knowledge/manifest.json` when
-present, against embedded JSON Schemas. Also **builds enabled observation providers** (same path as `rgd observe`) so invalid `providers[].options` (e.g. unknown `bot_reviewers[].enrich` names) fail validation. Non-zero exit on hard validation
+Validates `reinguard.yaml`, `control/{states,routes,guards}/*.yaml`, `procedure/*.md` procedure front matter (when the directory exists), and `knowledge/manifest.json` when
+present, against embedded JSON Schemas and mapping consistency rules. Also **builds enabled observation providers** (same path as `rgd observe`) so invalid `providers[].options` (e.g. unknown `bot_reviewers[].enrich` names) fail validation. Non-zero exit on hard validation
 errors. **Deprecated** configuration keys (marked in JSON Schema) emit **warnings
 on stderr** but still exit **0** when validation succeeds.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
 
 	"github.com/k-shibuki/reinguard/internal/labels"
+	"github.com/k-shibuki/reinguard/internal/procedure"
 	"github.com/k-shibuki/reinguard/pkg/schema"
 )
 
@@ -90,6 +91,8 @@ type KnowledgeManifest struct {
 }
 
 // LoadResult holds validated configuration from a config directory.
+//
+//nolint:govet // fieldalignment: keep JSON/config field grouping for readability
 type LoadResult struct {
 	RuleFiles        map[string]RulesDocument
 	Knowledge        *KnowledgeManifest
@@ -98,6 +101,8 @@ type LoadResult struct {
 	Root             Root
 	KnowledgePresent bool
 	LabelsPresent    bool
+	ProcedurePresent bool
+	ProcedureEntries []procedure.Entry
 }
 
 // Load reads reinguard.yaml, all control/{states,routes,guards}/*.yaml, and optional knowledge/manifest.json.
@@ -125,6 +130,9 @@ func Load(dir string) (*LoadResult, error) {
 		return nil, err
 	}
 	if err := applyOptionalKnowledge(res, dir, ss.km); err != nil {
+		return nil, err
+	}
+	if err := applyOptionalProcedures(res, dir); err != nil {
 		return nil, err
 	}
 	return res, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1065,6 +1065,155 @@ rules: []
 	}
 }
 
+func TestLoad_procedureMapping_ok(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), reinguardYAMLMinimal())
+	statesDir := filepath.Join(dir, "control", "states")
+	if err := os.MkdirAll(statesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(statesDir, "t.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+rules:
+  - type: state
+    id: only
+    priority: 10
+    when:
+      op: eq
+      path: git.branch
+      value: main
+    state_id: working_no_pr
+`, schema.CurrentSchemaVersion)))
+	procDir := filepath.Join(dir, "procedure")
+	if err := os.MkdirAll(procDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(procDir, "p.md"), []byte(`---
+id: procedure-test
+purpose: Test procedure.
+applies_to:
+  state_ids:
+    - working_no_pr
+  route_ids: []
+---
+`))
+	res, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.ProcedurePresent || len(res.ProcedureEntries) != 1 {
+		t.Fatalf("procedure: present=%v entries=%+v", res.ProcedurePresent, res.ProcedureEntries)
+	}
+}
+
+func TestLoad_procedureMapping_duplicateStateRejected(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), reinguardYAMLMinimal())
+	statesDir := filepath.Join(dir, "control", "states")
+	if err := os.MkdirAll(statesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(statesDir, "t.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+rules:
+  - type: state
+    id: only
+    priority: 10
+    when:
+      op: eq
+      path: git.branch
+      value: main
+    state_id: working_no_pr
+`, schema.CurrentSchemaVersion)))
+	procDir := filepath.Join(dir, "procedure")
+	if err := os.MkdirAll(procDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `---
+id: procedure-a
+purpose: A
+applies_to:
+  state_ids:
+    - working_no_pr
+  route_ids: []
+---
+`
+	writeFile(t, filepath.Join(procDir, "a.md"), []byte(body))
+	writeFile(t, filepath.Join(procDir, "b.md"), []byte(strings.Replace(body, "procedure-a", "procedure-b", 1)))
+
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "state_id \"working_no_pr\"") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestLoad_procedureMapping_orphanStateRejected(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), reinguardYAMLMinimal())
+	statesDir := filepath.Join(dir, "control", "states")
+	if err := os.MkdirAll(statesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(statesDir, "t.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+rules:
+  - type: state
+    id: only
+    priority: 10
+    when:
+      op: eq
+      path: git.branch
+      value: main
+    state_id: working_no_pr
+`, schema.CurrentSchemaVersion)))
+	procDir := filepath.Join(dir, "procedure")
+	if err := os.MkdirAll(procDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(procDir, "p.md"), []byte(`---
+id: procedure-bad
+purpose: Bad mapping.
+applies_to:
+  state_ids:
+    - not_a_real_state
+  route_ids: []
+---
+`))
+
+	_, err := Load(dir)
+	if err == nil || !strings.Contains(err.Error(), "no matching control state rule") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestLoad_procedureDirAbsent_ok(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), reinguardYAMLMinimal())
+	statesDir := filepath.Join(dir, "control", "states")
+	if err := os.MkdirAll(statesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(statesDir, "t.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+rules:
+  - type: state
+    id: only
+    priority: 10
+    when:
+      op: eq
+      path: git.branch
+      value: main
+    state_id: working_no_pr
+`, schema.CurrentSchemaVersion)))
+	res, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ProcedurePresent || len(res.ProcedureEntries) != 0 {
+		t.Fatalf("expected no procedure bundle, got present=%v n=%d", res.ProcedurePresent, len(res.ProcedureEntries))
+	}
+}
+
 func TestLoad_repositoryReinguard(t *testing.T) {
 	t.Parallel()
 	// Given: this repository's committed .reinguard bundle (control + knowledge)
@@ -1079,8 +1228,15 @@ func TestLoad_repositoryReinguard(t *testing.T) {
 	}
 	// When: Load runs
 	// Then: no error (schema + when validation for FSM YAML)
-	if _, err := Load(dir); err != nil {
+	res, err := Load(dir)
+	if err != nil {
 		t.Fatalf("Load: %v", err)
+	}
+	if !res.ProcedurePresent {
+		t.Fatal("expected .reinguard/procedure to be loaded")
+	}
+	if len(res.ProcedureEntries) < 1 {
+		t.Fatalf("expected procedure entries, got %d", len(res.ProcedureEntries))
 	}
 
 	// And: control catalog lists workflow bundle entries expected by adapter/docs

--- a/internal/config/load_bundle.go
+++ b/internal/config/load_bundle.go
@@ -11,8 +11,10 @@ import (
 	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
 	"gopkg.in/yaml.v3"
 
+	"github.com/k-shibuki/reinguard/internal/configdir"
 	"github.com/k-shibuki/reinguard/internal/evaluator"
 	"github.com/k-shibuki/reinguard/internal/labels"
+	"github.com/k-shibuki/reinguard/internal/procedure"
 	"github.com/k-shibuki/reinguard/pkg/schema"
 )
 
@@ -256,4 +258,37 @@ func validateKnowledgeWhenClauses(km *KnowledgeManifest, pathHint string) error 
 		}
 	}
 	return nil
+}
+
+func applyOptionalProcedures(res *LoadResult, dir string) error {
+	repoRoot := configdir.RepoRoot(dir)
+	procDir := filepath.Join(dir, "procedure")
+	entries, present, err := procedure.LoadEntries(repoRoot, procDir)
+	if err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+	if !present {
+		return nil
+	}
+	declared := declaredStateIDsFromRules(res.Rules())
+	if err := procedure.ValidateStateMapping(entries, declared); err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+	res.ProcedurePresent = true
+	res.ProcedureEntries = entries
+	return nil
+}
+
+func declaredStateIDsFromRules(rules []Rule) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, r := range rules {
+		if r.Type != "state" {
+			continue
+		}
+		sid := strings.TrimSpace(r.StateID)
+		if sid != "" {
+			out[sid] = struct{}{}
+		}
+	}
+	return out
 }

--- a/internal/procedure/catalog.go
+++ b/internal/procedure/catalog.go
@@ -1,0 +1,141 @@
+package procedure
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Entry is one indexed procedure file (repo-relative path and parsed mapping fields).
+//
+//nolint:govet // fieldalignment: keep id/path grouping for readability
+type Entry struct {
+	ID        string
+	Path      string
+	StateIDs  []string
+	RouteIDs  []string
+	Purpose   string
+	AbsSource string
+}
+
+// LoadEntries scans procedureAbsDir for *.md, parses front matter, and returns sorted entries.
+// If procedureAbsDir does not exist, returns (nil, false, nil).
+// If the directory exists but contains no procedure .md files, returns (empty slice, true, nil).
+func LoadEntries(repoRootAbs, procedureAbsDir string) ([]Entry, bool, error) {
+	repoRootAbs = filepath.Clean(repoRootAbs)
+	procedureAbsDir = filepath.Clean(procedureAbsDir)
+	if _, statErr := os.Stat(procedureAbsDir); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("procedure: stat %s: %w", procedureAbsDir, statErr)
+	}
+	de, err := os.ReadDir(procedureAbsDir)
+	if err != nil {
+		return nil, true, fmt.Errorf("procedure: read directory: %w", err)
+	}
+	var names []string
+	for _, e := range de {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.EqualFold(filepath.Ext(name), ".md") {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	seenProcID := make(map[string]string)
+	var entries []Entry
+	for _, name := range names {
+		absPath := filepath.Join(procedureAbsDir, name)
+		data, rerr := os.ReadFile(absPath)
+		if rerr != nil {
+			return nil, true, fmt.Errorf("procedure: read %s: %w", absPath, rerr)
+		}
+		fm, perr := ParseFrontMatter(data)
+		if perr != nil {
+			return nil, true, fmt.Errorf("%s: %w", absPath, perr)
+		}
+		if prev, ok := seenProcID[fm.ID]; ok {
+			return nil, true, fmt.Errorf("procedure: duplicate procedure id %q in %s and %s", fm.ID, prev, absPath)
+		}
+		seenProcID[fm.ID] = absPath
+
+		rel, rerr := filepath.Rel(repoRootAbs, absPath)
+		if rerr != nil {
+			return nil, true, fmt.Errorf("procedure: rel path: %w", rerr)
+		}
+		rel = filepath.ToSlash(rel)
+
+		entries = append(entries, Entry{
+			ID:        fm.ID,
+			Path:      rel,
+			StateIDs:  append([]string(nil), fm.AppliesTo.StateIDs...),
+			RouteIDs:  append([]string(nil), fm.AppliesTo.RouteIDs...),
+			Purpose:   fm.Purpose,
+			AbsSource: absPath,
+		})
+	}
+	return entries, true, nil
+}
+
+// ValidateStateMapping checks that each state_id appears in at most one procedure entry
+// and that every mapped state_id exists in declaredStateIDs (from control state rules).
+func ValidateStateMapping(entries []Entry, declaredStateIDs map[string]struct{}) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	stateOwner := make(map[string]string) // state_id -> procedure id
+	for _, e := range entries {
+		for _, sid := range e.StateIDs {
+			if prev, ok := stateOwner[sid]; ok {
+				return fmt.Errorf(
+					"procedure: state_id %q is mapped by both %q and %q",
+					sid, prev, e.ID,
+				)
+			}
+			stateOwner[sid] = e.ID
+		}
+	}
+	for sid, procID := range stateOwner {
+		if _, ok := declaredStateIDs[sid]; !ok {
+			return fmt.Errorf(
+				"procedure: state_id %q in procedure %q has no matching control state rule",
+				sid, procID,
+			)
+		}
+	}
+	return nil
+}
+
+func containsString(list []string, v string) bool {
+	for _, x := range list {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// HintEntry returns the procedure mapped to stateID, optionally filtered by routeID
+// when the entry declares non-empty RouteIDs (must match a resolved route).
+func HintEntry(entries []Entry, stateID string, routeResolved bool, routeID string) *Entry {
+	for i := range entries {
+		e := &entries[i]
+		if !containsString(e.StateIDs, stateID) {
+			continue
+		}
+		if len(e.RouteIDs) > 0 {
+			if !routeResolved || routeID == "" || !containsString(e.RouteIDs, routeID) {
+				continue
+			}
+		}
+		return e
+	}
+	return nil
+}

--- a/internal/procedure/catalog.go
+++ b/internal/procedure/catalog.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -113,25 +114,16 @@ func ValidateStateMapping(entries []Entry, declaredStateIDs map[string]struct{})
 	return nil
 }
 
-func containsString(list []string, v string) bool {
-	for _, x := range list {
-		if x == v {
-			return true
-		}
-	}
-	return false
-}
-
 // HintEntry returns the procedure mapped to stateID, optionally filtered by routeID
 // when the entry declares non-empty RouteIDs (must match a resolved route).
 func HintEntry(entries []Entry, stateID string, routeResolved bool, routeID string) *Entry {
 	for i := range entries {
 		e := &entries[i]
-		if !containsString(e.StateIDs, stateID) {
+		if !slices.Contains(e.StateIDs, stateID) {
 			continue
 		}
 		if len(e.RouteIDs) > 0 {
-			if !routeResolved || routeID == "" || !containsString(e.RouteIDs, routeID) {
+			if !routeResolved || routeID == "" || !slices.Contains(e.RouteIDs, routeID) {
 				continue
 			}
 		}

--- a/internal/procedure/catalog_test.go
+++ b/internal/procedure/catalog_test.go
@@ -1,0 +1,125 @@
+package procedure
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeProcFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadEntries_missingDir(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	entries, present, err := LoadEntries(root, filepath.Join(root, "nope"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if present || entries != nil {
+		t.Fatalf("present=%v entries=%v", present, entries)
+	}
+}
+
+func TestLoadEntries_okAndSorted(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	pdir := filepath.Join(root, "procedure")
+	writeProcFile(t, filepath.Join(pdir, "b.md"), `---
+id: procedure-b
+purpose: B
+applies_to:
+  state_ids:
+    - merge_ready
+  route_ids:
+    - user-merge
+---
+`)
+	writeProcFile(t, filepath.Join(pdir, "a.md"), `---
+id: procedure-a
+purpose: A
+applies_to:
+  state_ids:
+    - working_no_pr
+  route_ids: []
+---
+`)
+	entries, present, err := LoadEntries(root, pdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !present || len(entries) != 2 {
+		t.Fatalf("present=%v %+v", present, entries)
+	}
+	if entries[0].ID != "procedure-a" || entries[1].ID != "procedure-b" {
+		t.Fatalf("%+v", entries)
+	}
+	if entries[0].Path != "procedure/a.md" {
+		t.Fatalf("path %q", entries[0].Path)
+	}
+}
+
+func TestLoadEntries_duplicateProcedureID(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	pdir := filepath.Join(root, "procedure")
+	body := `---
+id: same
+purpose: x
+applies_to:
+  state_ids: []
+  route_ids: []
+---
+`
+	writeProcFile(t, filepath.Join(pdir, "a.md"), body)
+	writeProcFile(t, filepath.Join(pdir, "b.md"), body)
+	_, _, err := LoadEntries(root, pdir)
+	if err == nil || !strings.Contains(err.Error(), "duplicate procedure id") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestValidateStateMapping_duplicateAcrossProcedures(t *testing.T) {
+	t.Parallel()
+	declared := map[string]struct{}{"s1": {}}
+	err := ValidateStateMapping([]Entry{
+		{ID: "p1", StateIDs: []string{"s1"}},
+		{ID: "p2", StateIDs: []string{"s1"}},
+	}, declared)
+	if err == nil || !strings.Contains(err.Error(), "state_id \"s1\"") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestValidateStateMapping_orphanState(t *testing.T) {
+	t.Parallel()
+	err := ValidateStateMapping([]Entry{
+		{ID: "p1", StateIDs: []string{"unknown_state"}},
+	}, map[string]struct{}{"working_no_pr": {}})
+	if err == nil || !strings.Contains(err.Error(), "no matching control state rule") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestValidateStateMapping_ok(t *testing.T) {
+	t.Parallel()
+	declared := map[string]struct{}{
+		"working_no_pr": {},
+		"merge_ready":   {},
+	}
+	err := ValidateStateMapping([]Entry{
+		{ID: "p1", StateIDs: []string{"working_no_pr"}},
+		{ID: "p2", StateIDs: []string{"merge_ready"}},
+	}, declared)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/procedure/frontmatter.go
+++ b/internal/procedure/frontmatter.go
@@ -1,0 +1,84 @@
+// Package procedure loads procedure markdown front matter under .reinguard/procedure (ADR-0011, Issue #117).
+package procedure
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AppliesTo mirrors procedure YAML front matter applies_to.
+type AppliesTo struct {
+	StateIDs []string `yaml:"state_ids"`
+	RouteIDs []string `yaml:"route_ids"`
+}
+
+// FrontMatter is YAML metadata from the leading block in a procedure .md file.
+//
+//nolint:govet // fieldalignment: keep id/purpose/applies_to grouping for readability
+type FrontMatter struct {
+	ID        string    `yaml:"id"`
+	Purpose   string    `yaml:"purpose"`
+	AppliesTo AppliesTo `yaml:"applies_to"`
+	// Other keys (reads, sense, act, …) are ignored for machine validation.
+}
+
+// ParseFrontMatter extracts and parses the first YAML front matter block (--- ... ---).
+func ParseFrontMatter(md []byte) (*FrontMatter, error) {
+	s := strings.TrimSpace(string(md))
+	if !strings.HasPrefix(s, "---") {
+		return nil, fmt.Errorf("procedure: missing opening front matter delimiter")
+	}
+	s = strings.TrimPrefix(s, "---")
+	s = strings.TrimLeft(s, "\r\n")
+	end := strings.Index(s, "\n---")
+	if end < 0 {
+		return nil, fmt.Errorf("procedure: missing closing front matter delimiter")
+	}
+	yamlBlock := strings.TrimSpace(s[:end])
+	var fm FrontMatter
+	if err := yaml.Unmarshal([]byte(yamlBlock), &fm); err != nil {
+		return nil, fmt.Errorf("procedure: parse front matter yaml: %w", err)
+	}
+	fm.ID = strings.TrimSpace(fm.ID)
+	fm.Purpose = strings.TrimSpace(fm.Purpose)
+	fm.AppliesTo.StateIDs = trimNonEmptyStrings(fm.AppliesTo.StateIDs)
+	fm.AppliesTo.RouteIDs = trimNonEmptyStrings(fm.AppliesTo.RouteIDs)
+	if fm.ID == "" {
+		return nil, fmt.Errorf("procedure: front matter: missing id")
+	}
+	if fm.Purpose == "" {
+		return nil, fmt.Errorf("procedure: front matter: missing purpose")
+	}
+	if err := validateUniqueStrings("state_id", fm.ID, fm.AppliesTo.StateIDs); err != nil {
+		return nil, err
+	}
+	if err := validateUniqueStrings("route_id", fm.ID, fm.AppliesTo.RouteIDs); err != nil {
+		return nil, err
+	}
+	return &fm, nil
+}
+
+func trimNonEmptyStrings(in []string) []string {
+	var out []string
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func validateUniqueStrings(kind, procedureID string, values []string) error {
+	seen := make(map[string]string)
+	for _, v := range values {
+		key := v
+		if prev, ok := seen[key]; ok {
+			return fmt.Errorf("procedure: front matter: duplicate %s %q in procedure id %q (also %q)", kind, v, procedureID, prev)
+		}
+		seen[key] = v
+	}
+	return nil
+}

--- a/internal/procedure/frontmatter.go
+++ b/internal/procedure/frontmatter.go
@@ -27,16 +27,21 @@ type FrontMatter struct {
 // ParseFrontMatter extracts and parses the first YAML front matter block (--- ... ---).
 func ParseFrontMatter(md []byte) (*FrontMatter, error) {
 	s := strings.TrimSpace(string(md))
-	if !strings.HasPrefix(s, "---") {
+	lines := strings.Split(s, "\n")
+	if len(lines) == 0 || strings.TrimRight(lines[0], "\r") != "---" {
 		return nil, fmt.Errorf("procedure: missing opening front matter delimiter")
 	}
-	s = strings.TrimPrefix(s, "---")
-	s = strings.TrimLeft(s, "\r\n")
-	end := strings.Index(s, "\n---")
+	end := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimRight(lines[i], "\r") == "---" {
+			end = i
+			break
+		}
+	}
 	if end < 0 {
 		return nil, fmt.Errorf("procedure: missing closing front matter delimiter")
 	}
-	yamlBlock := strings.TrimSpace(s[:end])
+	yamlBlock := strings.TrimSpace(strings.Join(lines[1:end], "\n"))
 	var fm FrontMatter
 	if err := yaml.Unmarshal([]byte(yamlBlock), &fm); err != nil {
 		return nil, fmt.Errorf("procedure: parse front matter yaml: %w", err)
@@ -72,13 +77,12 @@ func trimNonEmptyStrings(in []string) []string {
 }
 
 func validateUniqueStrings(kind, procedureID string, values []string) error {
-	seen := make(map[string]string)
+	seen := make(map[string]struct{})
 	for _, v := range values {
-		key := v
-		if prev, ok := seen[key]; ok {
-			return fmt.Errorf("procedure: front matter: duplicate %s %q in procedure id %q (also %q)", kind, v, procedureID, prev)
+		if _, ok := seen[v]; ok {
+			return fmt.Errorf("procedure: front matter: duplicate %s %q in procedure id %q", kind, v, procedureID)
 		}
-		seen[key] = v
+		seen[v] = struct{}{}
 	}
 	return nil
 }

--- a/internal/procedure/frontmatter_test.go
+++ b/internal/procedure/frontmatter_test.go
@@ -1,0 +1,87 @@
+package procedure
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseFrontMatter_ok(t *testing.T) {
+	t.Parallel()
+	md := `---
+id: procedure-test
+purpose: Test purpose.
+applies_to:
+  state_ids:
+    - working_no_pr
+  route_ids:
+    - user-implement
+---
+# Body
+`
+	fm, err := ParseFrontMatter([]byte(md))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fm.ID != "procedure-test" || fm.Purpose != "Test purpose." {
+		t.Fatalf("%+v", fm)
+	}
+	if len(fm.AppliesTo.StateIDs) != 1 || fm.AppliesTo.StateIDs[0] != "working_no_pr" {
+		t.Fatalf("state_ids %+v", fm.AppliesTo.StateIDs)
+	}
+	if len(fm.AppliesTo.RouteIDs) != 1 || fm.AppliesTo.RouteIDs[0] != "user-implement" {
+		t.Fatalf("route_ids %+v", fm.AppliesTo.RouteIDs)
+	}
+}
+
+func TestParseFrontMatter_emptyAppliesTo(t *testing.T) {
+	t.Parallel()
+	md := `---
+id: procedure-meta
+purpose: Orchestration only.
+applies_to:
+  state_ids: []
+  route_ids: []
+---
+`
+	fm, err := ParseFrontMatter([]byte(md))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fm.AppliesTo.StateIDs) != 0 || len(fm.AppliesTo.RouteIDs) != 0 {
+		t.Fatalf("%+v", fm.AppliesTo)
+	}
+}
+
+func TestParseFrontMatter_errors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		contain string
+	}{
+		{name: "missing_open", input: "# no fm", contain: "opening"},
+		{name: "missing_close", input: "---\nid: x\npurpose: p\n", contain: "closing"},
+		{name: "missing_id", input: "---\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\n---\n", contain: "id"},
+		{name: "missing_purpose", input: "---\nid: x\napplies_to:\n  state_ids: []\n  route_ids: []\n---\n", contain: "purpose"},
+		{name: "dup_state_in_file", input: `---
+id: x
+purpose: p
+applies_to:
+  state_ids:
+    - a
+    - a
+  route_ids: []
+---
+`, contain: "duplicate state_id"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ParseFrontMatter([]byte(tt.input))
+			if err == nil || !strings.Contains(err.Error(), tt.contain) {
+				t.Fatalf("got %v", err)
+			}
+		})
+	}
+}

--- a/internal/procedure/frontmatter_test.go
+++ b/internal/procedure/frontmatter_test.go
@@ -52,6 +52,28 @@ applies_to:
 	}
 }
 
+func TestParseFrontMatter_blockScalarAllowsIndentedDelimiters(t *testing.T) {
+	t.Parallel()
+	md := `---
+id: procedure-block-scalar
+purpose: |
+  Keep the literal line below as part of the YAML value.
+  ---
+  More text.
+applies_to:
+  state_ids: []
+  route_ids: []
+---
+`
+	fm, err := ParseFrontMatter([]byte(md))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(fm.Purpose, "More text.") {
+		t.Fatalf("purpose=%q", fm.Purpose)
+	}
+}
+
 func TestParseFrontMatter_errors(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -73,9 +95,18 @@ applies_to:
   route_ids: []
 ---
 `, contain: "duplicate state_id"},
+		{name: "dup_route_in_file", input: `---
+id: x
+purpose: p
+applies_to:
+  state_ids: []
+  route_ids:
+    - r
+    - r
+---
+`, contain: "duplicate route_id"},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := ParseFrontMatter([]byte(tt.input))

--- a/internal/procedure/hint_test.go
+++ b/internal/procedure/hint_test.go
@@ -2,47 +2,88 @@ package procedure
 
 import "testing"
 
-func TestHintEntry_routeFilter(t *testing.T) {
+func TestHintEntry(t *testing.T) {
 	t.Parallel()
-	entries := []Entry{
-		{
-			ID:       "p1",
-			Path:     "procedure/a.md",
-			StateIDs: []string{"Idle"},
-			RouteIDs: []string{"next"},
+	stateIDs := []string{"Idle", "ready_for_pr", "B"}
+	routeIDs := []string{"", "next", "wrong", "r"}
+	tests := map[string]struct {
+		entries       []Entry
+		stateIDIndex  int
+		routeIDIndex  int
+		wantIndex     int
+		routeResolved bool
+	}{
+		"route filter match": {
+			entries: []Entry{{
+				ID:       "p1",
+				Path:     "procedure/a.md",
+				StateIDs: []string{"Idle"},
+				RouteIDs: []string{"next"},
+			}},
+			stateIDIndex:  0,
+			routeResolved: true,
+			routeIDIndex:  1,
+			wantIndex:     0,
+		},
+		"route filter mismatch": {
+			entries: []Entry{{
+				ID:       "p1",
+				Path:     "procedure/a.md",
+				StateIDs: []string{"Idle"},
+				RouteIDs: []string{"next"},
+			}},
+			stateIDIndex:  0,
+			routeResolved: true,
+			routeIDIndex:  2,
+			wantIndex:     -1,
+		},
+		"route unresolved blocks filtered match": {
+			entries: []Entry{{
+				ID:       "p1",
+				Path:     "procedure/a.md",
+				StateIDs: []string{"Idle"},
+				RouteIDs: []string{"next"},
+			}},
+			stateIDIndex:  0,
+			routeResolved: false,
+			routeIDIndex:  0,
+			wantIndex:     -1,
+		},
+		"empty route scope still matches state": {
+			entries: []Entry{{
+				ID:       "p2",
+				Path:     "procedure/b.md",
+				StateIDs: []string{"ready_for_pr"},
+				RouteIDs: nil,
+			}},
+			stateIDIndex:  1,
+			routeResolved: false,
+			routeIDIndex:  0,
+			wantIndex:     0,
+		},
+		"unknown state": {
+			entries:       []Entry{{ID: "x", StateIDs: []string{"A"}}},
+			stateIDIndex:  2,
+			routeResolved: true,
+			routeIDIndex:  3,
+			wantIndex:     -1,
 		},
 	}
-	got := HintEntry(entries, "Idle", true, "next")
-	if got == nil || got.ID != "p1" {
-		t.Fatalf("got %+v", got)
-	}
-	if HintEntry(entries, "Idle", true, "wrong") != nil {
-		t.Fatal("expected no match when route filter fails")
-	}
-	if HintEntry(entries, "Idle", false, "") != nil {
-		t.Fatal("expected no match when route not resolved")
-	}
-}
-
-func TestHintEntry_emptyRouteIDs(t *testing.T) {
-	t.Parallel()
-	entries := []Entry{
-		{
-			ID:       "p2",
-			Path:     "procedure/b.md",
-			StateIDs: []string{"ready_for_pr"},
-			RouteIDs: nil,
-		},
-	}
-	got := HintEntry(entries, "ready_for_pr", false, "")
-	if got == nil || got.ID != "p2" {
-		t.Fatalf("got %+v", got)
-	}
-}
-
-func TestHintEntry_unknownState(t *testing.T) {
-	t.Parallel()
-	if HintEntry([]Entry{{ID: "x", StateIDs: []string{"A"}}}, "B", true, "r") != nil {
-		t.Fatal("expected nil")
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := HintEntry(tc.entries, stateIDs[tc.stateIDIndex], tc.routeResolved, routeIDs[tc.routeIDIndex])
+			if tc.wantIndex < 0 {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			wantID := tc.entries[tc.wantIndex].ID
+			if got == nil || got.ID != wantID {
+				t.Fatalf("got %+v, want id %q", got, wantID)
+			}
+		})
 	}
 }

--- a/internal/procedure/hint_test.go
+++ b/internal/procedure/hint_test.go
@@ -1,0 +1,48 @@
+package procedure
+
+import "testing"
+
+func TestHintEntry_routeFilter(t *testing.T) {
+	t.Parallel()
+	entries := []Entry{
+		{
+			ID:       "p1",
+			Path:     "procedure/a.md",
+			StateIDs: []string{"Idle"},
+			RouteIDs: []string{"next"},
+		},
+	}
+	got := HintEntry(entries, "Idle", true, "next")
+	if got == nil || got.ID != "p1" {
+		t.Fatalf("got %+v", got)
+	}
+	if HintEntry(entries, "Idle", true, "wrong") != nil {
+		t.Fatal("expected no match when route filter fails")
+	}
+	if HintEntry(entries, "Idle", false, "") != nil {
+		t.Fatal("expected no match when route not resolved")
+	}
+}
+
+func TestHintEntry_emptyRouteIDs(t *testing.T) {
+	t.Parallel()
+	entries := []Entry{
+		{
+			ID:       "p2",
+			Path:     "procedure/b.md",
+			StateIDs: []string{"ready_for_pr"},
+			RouteIDs: nil,
+		},
+	}
+	got := HintEntry(entries, "ready_for_pr", false, "")
+	if got == nil || got.ID != "p2" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestHintEntry_unknownState(t *testing.T) {
+	t.Parallel()
+	if HintEntry([]Entry{{ID: "x", StateIDs: []string{"A"}}}, "B", true, "r") != nil {
+		t.Fatal("expected nil")
+	}
+}

--- a/internal/rgdcli/flag_factories.go
+++ b/internal/rgdcli/flag_factories.go
@@ -57,7 +57,11 @@ func newGateStatusFlag() *cli.StringFlag {
 }
 
 func newGateChecksFileFlag() *cli.StringFlag {
-	return &cli.StringFlag{Name: "checks-file", Usage: "JSON file containing gate check results"}
+	return &cli.StringFlag{Name: "checks-file", Usage: "JSON file containing gate check results (alternative to --check)"}
+}
+
+func newGateCheckFlag() *cli.StringSliceFlag {
+	return &cli.StringSliceFlag{Name: "check", Usage: "inline check as id:status:summary (repeatable; alternative to --checks-file)"}
 }
 
 func newGateInputsFileFlag() *cli.StringFlag {

--- a/internal/rgdcli/golden_test.go
+++ b/internal/rgdcli/golden_test.go
@@ -96,6 +96,19 @@ when:
     "when": {"eval": "constant", "params": {"value": true}}
   }]
 }`))
+	if err := os.Mkdir(filepath.Join(root, "procedure"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(root, "procedure", "golden.md"), []byte(`---
+id: procedure-golden-idle
+purpose: Golden fixture for context build procedure_hint.
+applies_to:
+  state_ids:
+    - Idle
+  route_ids:
+    - next
+---
+`))
 	return root
 }
 

--- a/internal/rgdcli/rgdcli.go
+++ b/internal/rgdcli/rgdcli.go
@@ -383,8 +383,13 @@ func RunGateRecord(c *cli.Context, gateID string) error {
 	if err != nil {
 		return err
 	}
+	inlineChecks, err := parseInlineChecks(c.StringSlice("check"))
+	if err != nil {
+		return err
+	}
+	checks = append(checks, inlineChecks...)
 	if len(checks) == 0 {
-		return fmt.Errorf("gate record: at least one check entry is required (provide --checks-file with a JSON array of checks)")
+		return fmt.Errorf("gate record: at least one check entry is required (provide --check or --checks-file)")
 	}
 	inputs, err := loadGateInputsFile(wd, c.String("inputs-file"))
 	if err != nil {
@@ -494,6 +499,22 @@ func mergeGateSignalsIntoFlat(ctx context.Context, cfgDir, wd string, flat map[s
 		flat[k] = v
 	}
 	return nil
+}
+
+func parseInlineChecks(raw []string) ([]gate.Check, error) {
+	var out []gate.Check
+	for _, s := range raw {
+		parts := strings.SplitN(s, ":", 3)
+		if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+			return nil, fmt.Errorf("gate record: --check value %q must be id:status:summary", s)
+		}
+		out = append(out, gate.Check{
+			ID:      parts[0],
+			Status:  parts[1],
+			Summary: parts[2],
+		})
+	}
+	return out, nil
 }
 
 func loadChecksFile(wd, path string) ([]gate.Check, error) {
@@ -876,6 +897,7 @@ func NewApp(version string) *cli.App {
 					ArgsUsage: "<gate-id>",
 					Flags: []cli.Flag{
 						newGateStatusFlag(),
+						newGateCheckFlag(),
 						newGateChecksFileFlag(),
 						newGateInputsFileFlag(),
 						newGateInputGateFlag(),

--- a/internal/rgdcli/rgdcli.go
+++ b/internal/rgdcli/rgdcli.go
@@ -31,6 +31,7 @@ import (
 	"github.com/k-shibuki/reinguard/internal/knowledge"
 	"github.com/k-shibuki/reinguard/internal/observation"
 	"github.com/k-shibuki/reinguard/internal/observe"
+	"github.com/k-shibuki/reinguard/internal/procedure"
 	"github.com/k-shibuki/reinguard/internal/resolve"
 	"github.com/k-shibuki/reinguard/internal/schemaexport"
 	"github.com/k-shibuki/reinguard/internal/signals"
@@ -76,6 +77,22 @@ func resolveEvalOutputMap(res resolve.Result) map[string]any {
 	}
 	if res.ReEntryHint != "" {
 		out["re_entry_hint"] = res.ReEntryHint
+	}
+	return out
+}
+
+func contextBuildStateOutput(stateRes resolve.Result, routeRes resolve.Result, loaded *config.LoadResult) map[string]any {
+	out := resolveEvalOutputMap(stateRes)
+	if stateRes.Kind != resolve.OutcomeResolved || stateRes.StateID == "" || !loaded.ProcedurePresent {
+		return out
+	}
+	routeOK := routeRes.Kind == resolve.OutcomeResolved && routeRes.RouteID != ""
+	if e := procedure.HintEntry(loaded.ProcedureEntries, stateRes.StateID, routeOK, routeRes.RouteID); e != nil {
+		out["procedure_hint"] = map[string]any{
+			"procedure_id": e.ID,
+			"path":         e.Path,
+			"derived_from": "state_id",
+		}
 	}
 	return out
 }
@@ -311,7 +328,7 @@ func RunContextBuild(c *cli.Context) error {
 	ctxDoc := map[string]any{
 		"schema_version": schema.CurrentSchemaVersion,
 		"observation":    obsDoc,
-		"state":          stateRes,
+		"state":          contextBuildStateOutput(stateRes, routeRes, loaded),
 		"routes":         []any{routeRes},
 		"guards": map[string]any{
 			"merge-readiness": gr,

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -195,6 +195,14 @@ applies_to:
 		t.Fatal(err)
 	}
 	state := mustMap(t, out["state"], "state")
+	if state["kind"] != "resolved" || state["state_id"] != "Idle" {
+		t.Fatalf("unexpected state resolution: %v", state)
+	}
+	routes := mustSlice(t, out["routes"], "routes")
+	r0 := mustMap(t, routes[0], "routes[0]")
+	if r0["kind"] != "resolved" || r0["route_id"] != "next" {
+		t.Fatalf("unexpected route resolution: %v", r0)
+	}
 	if _, ok := state["procedure_hint"]; ok {
 		t.Fatalf("unexpected procedure_hint: %v", state["procedure_hint"])
 	}

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -159,6 +159,90 @@ exit 1
 	assertObservationDegradedWithLocalGitHubRepo(t, out)
 }
 
+func TestRunContextBuild_procedureHint_omitsWhenRouteDoesNotMatchProcFilter(t *testing.T) {
+	t.Parallel()
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+	writeFile(t, filepath.Join(cfgDir, "control", "states", "default.yaml"), []byte(testFixtureRulesStateIdle))
+	writeFile(t, filepath.Join(cfgDir, "control", "routes", "default.yaml"), []byte(testFixtureControlRoutesNext))
+	if err := os.Mkdir(filepath.Join(cfgDir, "knowledge"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cfgDir, "knowledge", "manifest.json"), []byte(`{"schema_version":"0.7.0","entries":[]}`))
+	if err := os.Mkdir(filepath.Join(cfgDir, "procedure"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cfgDir, "procedure", "p.md"), []byte(`---
+id: proc-wrong-route
+purpose: Fixture procedure with route filter mismatch.
+applies_to:
+  state_ids:
+    - Idle
+  route_ids:
+    - not-next
+---
+`))
+	dir := goldenCaseDir(t, "context_build")
+	obs := filepath.Join(dir, "observation.json")
+	var buf bytes.Buffer
+	app := NewApp("test")
+	app.Writer = &buf
+	if err := app.Run([]string{"rgd", "context", "build", "--config-dir", cfgDir, "--observation-file", obs}); err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	state := mustMap(t, out["state"], "state")
+	if _, ok := state["procedure_hint"]; ok {
+		t.Fatalf("unexpected procedure_hint: %v", state["procedure_hint"])
+	}
+}
+
+func TestRunContextBuild_procedureHint_omitsWhenStateAmbiguous(t *testing.T) {
+	t.Parallel()
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+	writeFile(t, filepath.Join(cfgDir, "control", "states", "default.yaml"), []byte(testFixtureRulesStateAmbiguous))
+	writeFile(t, filepath.Join(cfgDir, "control", "routes", "default.yaml"), []byte(testFixtureControlRoutesNext))
+	if err := os.Mkdir(filepath.Join(cfgDir, "knowledge"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cfgDir, "knowledge", "manifest.json"), []byte(`{"schema_version":"0.7.0","entries":[]}`))
+	if err := os.Mkdir(filepath.Join(cfgDir, "procedure"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cfgDir, "procedure", "p.md"), []byte(`---
+id: proc-a
+purpose: Maps only state A for ambiguous fixture.
+applies_to:
+  state_ids:
+    - A
+  route_ids: []
+---
+`))
+	obsPath := filepath.Join(t.TempDir(), "obs.json")
+	writeFile(t, obsPath, []byte(`{"schema_version":"0.7.0","signals":{"git":{"branch":"feat"}},"degraded":false}`))
+	var buf bytes.Buffer
+	app := NewApp("test")
+	app.Writer = &buf
+	if err := app.Run([]string{"rgd", "context", "build", "--config-dir", cfgDir, "--observation-file", obsPath}); err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	state := mustMap(t, out["state"], "state")
+	if state["kind"] != "ambiguous" {
+		t.Fatalf("want ambiguous state, got %v", state["kind"])
+	}
+	if _, ok := state["procedure_hint"]; ok {
+		t.Fatal("unexpected procedure_hint for non-resolved state")
+	}
+}
+
 func TestRunContextBuild_rejectsScopeFlagsWithObservationFile(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/rgdcli/rgdcli_gate_test.go
+++ b/internal/rgdcli/rgdcli_gate_test.go
@@ -213,27 +213,57 @@ func TestRunGateRecord_inlineChecksAndFileChecks(t *testing.T) {
 	if !ok || len(checks) != 2 {
 		t.Fatalf("expected 2 checks (1 from file + 1 inline), got %v", out)
 	}
+	got := map[string]string{}
+	for _, raw := range checks {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("check entry must be object: %T", raw)
+		}
+		id, _ := m["id"].(string)
+		status, _ := m["status"].(string)
+		summary, _ := m["summary"].(string)
+		got[id] = status + "|" + summary
+	}
+	if got["go-test"] != "pass|go test ./... -race" {
+		t.Fatalf("missing/invalid file check: %+v", got)
+	}
+	if got["golangci-lint"] != "pass|golangci-lint run" {
+		t.Fatalf("missing/invalid inline check: %+v", got)
+	}
 }
 
 func TestRunGateRecord_inlineCheckBadFormat(t *testing.T) {
 	t.Parallel()
-	repo := initGitRepoForGateCLI(t)
-	cfgDir := t.TempDir()
+	tests := []string{
+		"bad-format",
+		":pass:summary",
+		"id::summary",
+		"id:pass:",
+		"id:pass",
+	}
+	for _, v := range tests {
+		v := v
+		t.Run(v, func(t *testing.T) {
+			t.Parallel()
+			repo := initGitRepoForGateCLI(t)
+			cfgDir := t.TempDir()
 
-	var buf bytes.Buffer
-	app := NewApp("t")
-	app.Writer = &buf
-	err := app.Run([]string{
-		"rgd", "gate", "record",
-		"--config-dir", cfgDir,
-		"--cwd", repo,
-		"--status", "pass",
-		"--producer-procedure", "implement",
-		"--check", "bad-format",
-		"local-verification",
-	})
-	if err == nil {
-		t.Fatal("expected error for malformed --check value")
+			var buf bytes.Buffer
+			app := NewApp("t")
+			app.Writer = &buf
+			err := app.Run([]string{
+				"rgd", "gate", "record",
+				"--config-dir", cfgDir,
+				"--cwd", repo,
+				"--status", "pass",
+				"--producer-procedure", "implement",
+				"--check", v,
+				"local-verification",
+			})
+			if err == nil {
+				t.Fatalf("expected error for malformed --check value %q", v)
+			}
+		})
 	}
 }
 

--- a/internal/rgdcli/rgdcli_gate_test.go
+++ b/internal/rgdcli/rgdcli_gate_test.go
@@ -146,6 +146,97 @@ rules:
 	}
 }
 
+func TestRunGateRecord_inlineChecks(t *testing.T) {
+	t.Parallel()
+	repo := initGitRepoForGateCLI(t)
+	cfgDir := t.TempDir()
+
+	var buf bytes.Buffer
+	app := NewApp("t")
+	app.Writer = &buf
+	if err := app.Run([]string{
+		"rgd", "gate", "record",
+		"--config-dir", cfgDir,
+		"--cwd", repo,
+		"--status", "pass",
+		"--producer-procedure", "implement",
+		"--check", "go-test:pass:go test ./... -race",
+		"--check", "golangci-lint:pass:golangci-lint run",
+		"local-verification",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("json: %v raw=%s", err, buf.String())
+	}
+	checks, ok := out["checks"].([]any)
+	if !ok || len(checks) != 2 {
+		t.Fatalf("expected 2 checks, got %v", out)
+	}
+	first := checks[0].(map[string]any)
+	if first["id"] != "go-test" || first["status"] != "pass" || first["summary"] != "go test ./... -race" {
+		t.Fatalf("unexpected first check: %v", first)
+	}
+}
+
+func TestRunGateRecord_inlineChecksAndFileChecks(t *testing.T) {
+	t.Parallel()
+	repo := initGitRepoForGateCLI(t)
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(repo, "checks.json"), []byte(`[
+  {"id":"go-test","status":"pass","summary":"go test ./... -race"}
+]`))
+
+	var buf bytes.Buffer
+	app := NewApp("t")
+	app.Writer = &buf
+	if err := app.Run([]string{
+		"rgd", "gate", "record",
+		"--config-dir", cfgDir,
+		"--cwd", repo,
+		"--status", "pass",
+		"--producer-procedure", "implement",
+		"--checks-file", "checks.json",
+		"--check", "golangci-lint:pass:golangci-lint run",
+		"local-verification",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("json: %v raw=%s", err, buf.String())
+	}
+	checks, ok := out["checks"].([]any)
+	if !ok || len(checks) != 2 {
+		t.Fatalf("expected 2 checks (1 from file + 1 inline), got %v", out)
+	}
+}
+
+func TestRunGateRecord_inlineCheckBadFormat(t *testing.T) {
+	t.Parallel()
+	repo := initGitRepoForGateCLI(t)
+	cfgDir := t.TempDir()
+
+	var buf bytes.Buffer
+	app := NewApp("t")
+	app.Writer = &buf
+	err := app.Run([]string{
+		"rgd", "gate", "record",
+		"--config-dir", cfgDir,
+		"--cwd", repo,
+		"--status", "pass",
+		"--producer-procedure", "implement",
+		"--check", "bad-format",
+		"local-verification",
+	})
+	if err == nil {
+		t.Fatal("expected error for malformed --check value")
+	}
+}
+
 func TestRunGateRecord_badChecksFile(t *testing.T) {
 	t.Parallel()
 	// Given: a git repo and a malformed checks file

--- a/internal/rgdcli/rgdcli_gate_test.go
+++ b/internal/rgdcli/rgdcli_gate_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/k-shibuki/reinguard/pkg/schema"
@@ -175,9 +176,22 @@ func TestRunGateRecord_inlineChecks(t *testing.T) {
 	if !ok || len(checks) != 2 {
 		t.Fatalf("expected 2 checks, got %v", out)
 	}
-	first := checks[0].(map[string]any)
-	if first["id"] != "go-test" || first["status"] != "pass" || first["summary"] != "go test ./... -race" {
-		t.Fatalf("unexpected first check: %v", first)
+	got := map[string]string{}
+	for _, raw := range checks {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("check entry must be object: %T", raw)
+		}
+		id, _ := m["id"].(string)
+		status, _ := m["status"].(string)
+		summary, _ := m["summary"].(string)
+		got[id] = status + "|" + summary
+	}
+	if got["go-test"] != "pass|go test ./... -race" {
+		t.Fatalf("missing/invalid go-test check: %+v", got)
+	}
+	if got["golangci-lint"] != "pass|golangci-lint run" {
+		t.Fatalf("missing/invalid golangci-lint check: %+v", got)
 	}
 }
 
@@ -262,6 +276,9 @@ func TestRunGateRecord_inlineCheckBadFormat(t *testing.T) {
 			})
 			if err == nil {
 				t.Fatalf("expected error for malformed --check value %q", v)
+			}
+			if !strings.Contains(err.Error(), "must be id:status:summary") {
+				t.Fatalf("unexpected error for malformed --check value %q: %v", v, err)
 			}
 		})
 	}

--- a/internal/rgdcli/testdata/golden/context_build/want.json
+++ b/internal/rgdcli/testdata/golden/context_build/want.json
@@ -81,6 +81,11 @@
     "state_id": "Idle",
     "rule_id": "idle",
     "priority": 10,
-    "target_id": "Idle"
+    "target_id": "Idle",
+    "procedure_hint": {
+      "procedure_id": "procedure-golden-idle",
+      "path": "procedure/golden.md",
+      "derived_from": "state_id"
+    }
   }
 }

--- a/pkg/schema/compiler_test.go
+++ b/pkg/schema/compiler_test.go
@@ -32,3 +32,45 @@ func TestNewCompiler(t *testing.T) {
 		})
 	}
 }
+
+func TestOperationalContextSchema_procedureHintResolvedOnly(t *testing.T) {
+	t.Parallel()
+	c, err := NewCompiler()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := c.Compile(URIOperationalContext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := map[string]any{
+		"schema_version": CurrentSchemaVersion,
+		"state": map[string]any{
+			"kind":     "resolved",
+			"state_id": "working_no_pr",
+			"procedure_hint": map[string]any{
+				"procedure_id": "procedure-implement",
+				"path":         ".reinguard/procedure/implement.md",
+				"derived_from": "state_id",
+			},
+		},
+	}
+	if err := s.Validate(valid); err != nil {
+		t.Fatalf("valid context rejected: %v", err)
+	}
+	invalid := map[string]any{
+		"schema_version": CurrentSchemaVersion,
+		"state": map[string]any{
+			"kind":     "ambiguous",
+			"state_id": "working_no_pr",
+			"procedure_hint": map[string]any{
+				"procedure_id": "procedure-implement",
+				"path":         ".reinguard/procedure/implement.md",
+				"derived_from": "state_id",
+			},
+		},
+	}
+	if err := s.Validate(invalid); err == nil {
+		t.Fatal("expected schema validation error for procedure_hint on non-resolved state")
+	}
+}

--- a/pkg/schema/operational-context.json
+++ b/pkg/schema/operational-context.json
@@ -50,6 +50,20 @@
           "additionalProperties": false
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": { "const": "resolved" }
+            }
+          },
+          "else": {
+            "not": {
+              "required": ["procedure_hint"]
+            }
+          }
+        }
+      ],
       "additionalProperties": true
     }
   },

--- a/pkg/schema/operational-context.json
+++ b/pkg/schema/operational-context.json
@@ -37,7 +37,18 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "re_entry_hint": { "type": "string" }
+        "re_entry_hint": { "type": "string" },
+        "procedure_hint": {
+          "type": "object",
+          "description": "Optional advisory mapping from resolved state_id to a procedure file (front matter SSOT). Omitted when state.kind is not resolved.",
+          "required": ["procedure_id", "path", "derived_from"],
+          "properties": {
+            "procedure_id": { "type": "string" },
+            "path": { "type": "string" },
+            "derived_from": { "type": "string", "const": "state_id" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": true
     }


### PR DESCRIPTION
## Summary

- Load and validate `.reinguard/procedure/*.md` YAML front matter as the machine-readable state-to-procedure mapping SSOT (`applies_to.state_ids` / `applies_to.route_ids`), and reject duplicate or unmapped state references during `rgd config validate`
- Surface `state.procedure_hint` in `rgd context build` when a resolved state matches procedure front matter, and tighten the operational-context schema and tests around when that hint is allowed
- Add repeatable inline `--check id:status:summary` support to `rgd gate record` alongside `--checks-file`, plus refresh the adapter resume artifact schema version handling

## Traceability

Closes #116
Closes #117

Refs: #116
Refs: #117

## Definition of Done

- [x] Procedure front matter is the machine-readable SSOT for adapter procedure mapping, with validation coverage for duplicates and orphaned state references
- [x] `rgd context build` emits `state.procedure_hint` only for resolved states that match procedure front matter, with schema and CLI tests updated
- [x] `rgd gate record` supports repeatable inline `--check` entries and merged check assertions are covered by tests
- [x] Resume artifact schema version handling is aligned with ADR-0015 and local gate proofs were refreshed on the latest head

## Test plan

1. `bash .reinguard/scripts/with-repo-local-state.sh -- go test ./...`
2. `bash .reinguard/scripts/with-repo-local-state.sh -- go vet ./...`
3. `bash .reinguard/scripts/with-repo-local-state.sh -- golangci-lint run`
4. `go run ./cmd/rgd config validate`
5. `bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- bash .reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit`

## Risk / Impact

- The changes touch procedure loading, operational-context schema validation, and gate-record CLI parsing, so a regression could affect adapter routing hints or runtime gate artifact authoring.
- Review fixes also tighten parser edge cases and schema expectations, which is low risk but broad enough to warrant full CLI and package verification.

## Rollback Plan

- Revert commit `4de808d` if the review-driven tightening causes regressions in procedure parsing, schema validation, or gate recording behavior.
- If needed, re-open the previous PR head while keeping the issue linkage and PR template sections intact.

## Exception

- Type:
- Justification: