### PR TITLE
refactor(rgd-next): resume artifact must cross-check fresh observation

### DIFF
--- a/.cursor/commands/rgd-next.md
+++ b/.cursor/commands/rgd-next.md
@@ -11,8 +11,16 @@ artifact:
 bash .reinguard/scripts/adapter-rgd-next-resume.sh status
 ```
 
+Parse the Adapter-local status JSON here (`status`, `resume_eligible`,
+`resume_reason_codes[]`) before running substrate observation. These diagnostics
+come from the Adapter-local resume script, not from `rgd context build`.
+
 If that reports `status: "active"` and `resume_eligible: true`, resume the
 recorded approved Execute path instead of starting a new proposal cycle.
+Resume eligibility conditions, fail-closed behavior, and the
+`resume_reason_codes[]` diagnostic surface are defined in
+[`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md)
+§ **Resume eligibility contract** and ADR-0015.
 If it reports `status: "pending_approval"`, a proposal artifact exists for the
 recorded unit but the user has not yet approved Execute; continue with **Propose**
 (do not treat as an approved run). This artifact is **Adapter-local only**
@@ -35,7 +43,7 @@ as substrate workflow position.
 
    (or `go run ./cmd/rgd context build --pr <N>` from repo root).
 
-2. Parse stdout JSON:
+2. Parse `rgd context build` stdout JSON:
    - `state.state_id`, `state.kind`
    - `routes[0].kind`, `routes[0].route_id` (when `routes[0].kind` is `resolved`)
    - `guards` (e.g. `merge-readiness` for summaries during **Execute**)

--- a/.reinguard/knowledge/review--local-coderabbit-cli.md
+++ b/.reinguard/knowledge/review--local-coderabbit-cli.md
@@ -72,8 +72,10 @@ depending on `~/.coderabbit`.
   `LOCAL_CR_HEARTBEAT_SEC=30`). This matches the **30s / 20m** polling budget
   described for PR-side bot waits in `review--bot-operations.md` (different
   mechanism: subprocess supervision vs `rgd observe` / GitHub polling).
-- Built-in **rate-limit retry** remains: one automatic retry when
-  `--retry-on-rate-limit` is set and the CLI reports a parseable cooldown.
+- Built-in **cooldown retry** remains: one automatic retry when
+  `--retry-on-rate-limit` is set and the CLI failure output includes a
+  parseable duration on the **last** line with an explicit backoff hint
+  (`try again in`, `try after`, or `retry in`).
   The wait is **`parsed_cooldown_seconds + RATE_LIMIT_RETRY_BUFFER_SEC`**
   (default buffer **30s**). PR-side CodeRabbit recovery uses the same
   **`cooldown + 30s`** rule before `@coderabbitai review`; see
@@ -81,8 +83,8 @@ depending on `~/.coderabbit`.
 - Sparse **stdout** from the CLI while it works is **normal**; heartbeats go to
   **stderr** so transcripts stay readable.
 - Only terminal outcomes change control flow: success, explicit CLI failure,
-  supervisor timeout, auth/tooling failure, cooldown parse failure, or second
-  consecutive rate limit (per policy).
+  supervisor timeout, auth/tooling failure, cooldown parse failure, or a failed
+  second attempt after the one automatic retry (per policy).
 - Do not kill the subprocess without positive evidence of hang beyond the
   supervisor limit; the supervisor already bounds worst-case wait.
 - This is a **foreground wait**: a long run or cooldown sleep is **not** failure

--- a/.reinguard/policy/coding--preflight.md
+++ b/.reinguard/policy/coding--preflight.md
@@ -57,13 +57,15 @@ bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- \
   `.reinguard/policy/cursor-sandbox.md` (do not commit user-specific absolute
   paths; portable `networkPolicy.allow` entries are documented there).
 - The script standardizes installation/authentication checks and executes
-  the CLI review against the repository's `.coderabbit.yaml`. On a rate
-  limit, it parses the cooldown **only from the latest rate-limit line in
-  that CLI run** (so earlier log text does not affect the wait), adds a
-  small **safety buffer** (default 30s; override with
-  `RATE_LIMIT_RETRY_BUFFER_SEC`), then retries the review **once**
-  automatically. If the cooldown cannot be parsed from that line, or a
-  second consecutive rate limit occurs, treat the gate as failed.
+  the CLI review against the repository's `.coderabbit.yaml`. When the CLI
+  fails, it may retry **once** with `--retry-on-rate-limit` if it can parse a
+  cooldown from the **latest line that contains an explicit backoff hint**
+  (`try again in`, `try after`, or `retry in`) in that run (so earlier log text
+  and unrelated footers such as `finished in N seconds` do not affect the
+  wait). It adds a small **safety buffer** (default 30s; override with
+  `RATE_LIMIT_RETRY_BUFFER_SEC`) before the retry. If no parseable cooldown is
+  found on that line, or the review still fails after that single automatic
+  retry, treat the gate as failed.
 - The script supervises each `coderabbit review` attempt: stderr **heartbeat**
   every **30 seconds** (default `LOCAL_CR_HEARTBEAT_SEC=30`) and a **20-minute**
   wall-clock maximum per attempt (default `LOCAL_CR_MAX_WAIT_SEC=1200`), aligned

--- a/.reinguard/procedure/change-inspect.md
+++ b/.reinguard/procedure/change-inspect.md
@@ -87,11 +87,12 @@ bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- \
   bash .reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit
 ```
 
-If the CLI reports a rate limit, the script uses the **latest** rate-limit
-line in that run to parse the cooldown, adds a **safety buffer**, then
+If the CLI fails with a parseable cooldown on the **latest** line that
+contains a backoff hint (`try again in`, `try after`, or `retry in`), the
+script uses that line only to parse the wait, adds a **safety buffer**, then
 retries the review **once** (`--retry-on-rate-limit`). Treat
 installation/authentication/execution failures, unparsed cooldown, or a
-second consecutive rate limit, as a failed gate and do not proceed.
+failed second attempt, as a failed gate and do not proceed.
 While the command is running, treat sparse **stdout** from the CLI as normal;
 the script prints **stderr heartbeats** every **30 seconds** and enforces a
 **20-minute** wall-clock cap per attempt (defaults: `LOCAL_CR_HEARTBEAT_SEC`,

--- a/.reinguard/procedure/next-orchestration.md
+++ b/.reinguard/procedure/next-orchestration.md
@@ -76,6 +76,19 @@ proposal fingerprint (SHA-256 hex of the newline-terminated fields written by
 `adapter-rgd-next-resume.sh` `compute_proposal_fingerprint`, ADR-0015) — so the
 artifact can later answer **what was approved**.
 
+### Resume eligibility contract
+
+If a later turn wants to reuse that approval continuity, the Adapter MUST
+re-validate it against **fresh observation** before resuming Execute. An
+`active` artifact alone is not sufficient. At minimum, resume stays closed
+unless current branch and `HEAD` still match the approved contract and fresh
+`rgd context build --compact` still resolves to the approved `state_id` (and
+approved `route_id` when one was recorded). Machine-readable diagnostics (for
+example `resume_reason_codes[]`) belong on that Adapter-local decision surface.
+When that re-validation fails, the Adapter does **not** continue Execute from
+continuity; it falls back to a fresh `rgd-next` proposal decision for the
+current observed state.
+
 Obtain **explicit user approval** to execute through that completion condition. **No per-procedure re-approval** after this gate (except Hard Stops and genuine blocks below).
 
 ## Post-approval execution contract
@@ -97,6 +110,10 @@ Adapters may persist this approval continuity locally so the next turn can
 resume the same approved path. Such persistence is **Adapter-local** and must
 not be promoted into substrate workflow state, routes, guards, or
 `gates.<id>.*` signals (ADR-0015).
+The same boundary applies to resume re-validation: the Adapter consumes fresh
+substrate observation as an input to decide whether continuity is still safe,
+but the artifact itself does not become substrate state, route, guard, or
+signal output.
 
 ## Loop semantics (after approval)
 

--- a/.reinguard/scripts/adapter-rgd-next-resume.sh
+++ b/.reinguard/scripts/adapter-rgd-next-resume.sh
@@ -42,6 +42,7 @@ artifact_last_recorded_at=""
 artifact_terminal_reason=""
 artifact_terminal_summary=""
 artifact_terminal_recorded_at=""
+status_reason_codes=()
 
 current_branch() {
   local branch
@@ -55,6 +56,21 @@ current_head_sha() {
   printf '%s' "$sha"
 }
 
+reset_status_reason_codes() {
+  status_reason_codes=()
+}
+
+append_status_reason_code() {
+  local code="$1"
+  local existing
+  for existing in ${status_reason_codes[@]+"${status_reason_codes[@]}"}; do
+    if [[ "$existing" == "$code" ]]; then
+      return 0
+    fi
+  done
+  status_reason_codes+=("$code")
+}
+
 compute_proposal_fingerprint() {
   printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
     "$artifact_branch" \
@@ -66,6 +82,105 @@ compute_proposal_fingerprint() {
     "$artifact_ordered_remainder" \
     "$artifact_completion_condition" \
     "$artifact_summary" | sha256sum | awk '{print $1}'
+}
+
+emit_json_string_array() {
+  local key="$1"
+  shift
+  local values=("$@")
+  local i
+  printf '  "%s": [' "$(json_escape "$key")"
+  for i in "${!values[@]}"; do
+    if (( i > 0 )); then
+      printf ', '
+    fi
+    printf '"%s"' "$(json_escape "${values[$i]}")"
+  done
+  printf ']'
+}
+
+build_resume_context_json() {
+  if [[ -n "${REINGUARD_RGD_NEXT_CONTEXT_BUILD_FILE:-}" ]]; then
+    require_file "$REINGUARD_RGD_NEXT_CONTEXT_BUILD_FILE" "resume context file is missing" 2
+    cat "$REINGUARD_RGD_NEXT_CONTEXT_BUILD_FILE"
+    return 0
+  fi
+  if command -v rgd >/dev/null 2>&1; then
+    (
+      cd "$REPO_ROOT" &&
+      rgd context build --compact
+    )
+    return
+  fi
+  if [[ -f "$REPO_ROOT/cmd/rgd/main.go" ]]; then
+    (
+      cd "$REPO_ROOT" &&
+      go run ./cmd/rgd context build --compact
+    )
+    return
+  fi
+  return 1
+}
+
+parse_resume_context_fields() {
+  local raw="$1"
+  python3 -c '
+import json
+import shlex
+import sys
+
+fields = {
+    "fresh_context_parse_error": "",
+    "fresh_state_kind": "",
+    "fresh_state_id": "",
+    "fresh_route_kind": "",
+    "fresh_route_id": "",
+    "fresh_review_trigger_awaiting_ack": "false",
+    "fresh_bot_review_trigger_awaiting_ack": "false",
+}
+
+try:
+    payload = json.load(sys.stdin)
+except Exception as exc:
+    fields["fresh_context_parse_error"] = str(exc)
+else:
+    state = payload.get("state") or {}
+    routes = payload.get("routes") or []
+    route = routes[0] if routes and isinstance(routes[0], dict) else {}
+    signals = (payload.get("observation") or {}).get("signals") or {}
+    github = signals.get("github") or {}
+    reviews = github.get("reviews") or {}
+    fields["fresh_state_kind"] = str(state.get("kind") or "")
+    fields["fresh_state_id"] = str(state.get("state_id") or "")
+    fields["fresh_route_kind"] = str(route.get("kind") or "")
+    fields["fresh_route_id"] = str(route.get("route_id") or "")
+    fields["fresh_review_trigger_awaiting_ack"] = "true" if bool(reviews.get("review_trigger_awaiting_ack")) else "false"
+    fields["fresh_bot_review_trigger_awaiting_ack"] = "true" if bool(reviews.get("bot_review_trigger_awaiting_ack")) else "false"
+
+for key, value in fields.items():
+    print(f"{key}={shlex.quote(value)}")
+' <<<"$raw"
+}
+
+resume_ttl_state() {
+  local approval_at="$1"
+  local ttl_seconds="$2"
+  python3 - "$approval_at" "$ttl_seconds" <<'PY'
+from datetime import datetime, timezone
+import sys
+
+approval_at = sys.argv[1]
+ttl_seconds = int(sys.argv[2])
+
+try:
+    approved = datetime.strptime(approval_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+except ValueError:
+    print("parse_error")
+    raise SystemExit(0)
+
+age = (datetime.now(timezone.utc) - approved).total_seconds()
+print("expired" if age > ttl_seconds else "valid")
+PY
 }
 
 require_positive_integer() {
@@ -192,13 +307,21 @@ emit_status_json() {
     printf '  "current_branch": "%s",\n' "$(json_escape "$current")"
     printf '  "status": "%s",\n' "$(json_escape "$status")"
     printf '  "resume_eligible": %s' "$resume_eligible"
-    if [[ -n "$reason" || -n "$artifact_branch" || -n "$artifact_issue" || -n "$artifact_pr" || -n "$artifact_summary" || -n "$artifact_approval_at" || -n "$artifact_created_at" || -n "$artifact_updated_at" || -n "$artifact_approved_head_sha" || -n "$artifact_last_state" || -n "$artifact_terminal_reason" ]]; then
+    if [[ -n "$reason" || ${#status_reason_codes[@]} -gt 0 || -n "$artifact_branch" || -n "$artifact_issue" || -n "$artifact_pr" || -n "$artifact_summary" || -n "$artifact_approval_at" || -n "$artifact_created_at" || -n "$artifact_updated_at" || -n "$artifact_approved_head_sha" || -n "$artifact_last_state" || -n "$artifact_terminal_reason" ]]; then
       printf ',\n'
     else
       printf '\n'
     fi
     if [[ -n "$reason" ]]; then
       printf '  "reason": "%s"' "$(json_escape "$reason")"
+      if [[ ${#status_reason_codes[@]} -gt 0 || -n "$artifact_branch" || -n "$artifact_issue" || -n "$artifact_pr" || -n "$artifact_summary" || -n "$artifact_approval_at" || -n "$artifact_created_at" || -n "$artifact_updated_at" || -n "$artifact_approved_head_sha" || -n "$artifact_last_state" || -n "$artifact_terminal_reason" ]]; then
+        printf ',\n'
+      else
+        printf '\n'
+      fi
+    fi
+    if [[ ${#status_reason_codes[@]} -gt 0 ]]; then
+      emit_json_string_array "resume_reason_codes" "${status_reason_codes[@]}"
       if [[ -n "$artifact_branch" || -n "$artifact_issue" || -n "$artifact_pr" || -n "$artifact_summary" || -n "$artifact_approval_at" || -n "$artifact_created_at" || -n "$artifact_updated_at" || -n "$artifact_approved_head_sha" || -n "$artifact_last_state" || -n "$artifact_terminal_reason" ]]; then
         printf ',\n'
       else
@@ -470,9 +593,14 @@ finish_cmd() {
 }
 
 status_cmd() {
-  local raw current
+  local raw current current_head current_context status_ttl_seconds ttl_state
+  local fresh_context_parse_error="" fresh_state_kind="" fresh_state_id="" fresh_route_kind="" fresh_route_id=""
+  local fresh_review_trigger_awaiting_ack="false" fresh_bot_review_trigger_awaiting_ack="false"
+  local recomputed_fingerprint=""
   local -a missing=()
   current="$(current_branch)"
+  current_head="$(current_head_sha)"
+  reset_status_reason_codes
 
   artifact_branch=""
   artifact_created_at=""
@@ -496,6 +624,7 @@ status_cmd() {
   artifact_terminal_recorded_at=""
 
   if [[ ! -f "$ARTIFACT_PATH" ]]; then
+    append_status_reason_code "artifact_missing"
     emit_status_json "missing" "false"
     return 0
   fi
@@ -507,30 +636,128 @@ status_cmd() {
     fi
   done
   if (( ${#missing[@]} > 0 )); then
+    append_status_reason_code "artifact_missing_required_keys"
     emit_status_json "invalid" "false" "missing required keys: $(IFS=', '; echo "${missing[*]}")"
     return 0
   fi
 
   load_artifact
   if [[ -z "$artifact_approved_head_sha" || -z "$artifact_approved_state" || -z "$artifact_ordered_remainder" || -z "$artifact_completion_condition" || -z "$artifact_proposal_fingerprint" ]]; then
+    append_status_reason_code "approved_contract_incomplete"
     emit_status_json "invalid" "false" "approved_contract is missing required fields"
     return 0
   fi
   if [[ "$(json_get_string "$raw" "artifact_type")" != "adapter_rgd_next_resume" || "$(json_get_string "$raw" "command")" != "rgd-next" ]]; then
+    append_status_reason_code "artifact_identity_mismatch"
     emit_status_json "invalid" "false" "unexpected artifact_type or command"
     return 0
   fi
   if [[ ( "$artifact_status" == "active" || "$artifact_status" == "pending_approval" ) && -n "$artifact_branch" ]]; then
     if [[ -z "$current" ]]; then
+      append_status_reason_code "detached_head"
       emit_status_json "stale" "false" "detached HEAD"
       return 0
     fi
     if [[ "$artifact_branch" != "$current" ]]; then
+      append_status_reason_code "branch_mismatch"
       emit_status_json "stale" "false" "branch mismatch"
       return 0
     fi
+    append_status_reason_code "branch_match"
   fi
   if [[ "$artifact_status" == "active" ]]; then
+    recomputed_fingerprint="$(compute_proposal_fingerprint)"
+    if [[ "$recomputed_fingerprint" != "$artifact_proposal_fingerprint" ]]; then
+      append_status_reason_code "proposal_fingerprint_mismatch"
+      emit_status_json "invalid" "false" "proposal fingerprint mismatch"
+      return 0
+    fi
+    append_status_reason_code "proposal_fingerprint_match"
+    if [[ -z "$artifact_approval_at" ]]; then
+      append_status_reason_code "approval_record_missing"
+      emit_status_json "invalid" "false" "active artifact is missing approval_recorded_at"
+      return 0
+    fi
+    if [[ -z "$current_head" ]]; then
+      append_status_reason_code "current_head_unavailable"
+      emit_status_json "stale" "false" "current HEAD is unavailable"
+      return 0
+    fi
+    if [[ "$current_head" != "$artifact_approved_head_sha" ]]; then
+      append_status_reason_code "head_mismatch"
+      emit_status_json "stale" "false" "head mismatch"
+      return 0
+    fi
+    append_status_reason_code "head_match"
+    status_ttl_seconds="${REINGUARD_RGD_NEXT_RESUME_TTL_SECONDS:-}"
+    if [[ -n "$status_ttl_seconds" ]]; then
+      if [[ ! "$status_ttl_seconds" =~ ^[0-9]+$ ]] || (( status_ttl_seconds <= 0 )); then
+        append_status_reason_code "ttl_config_invalid"
+        emit_status_json "invalid" "false" "REINGUARD_RGD_NEXT_RESUME_TTL_SECONDS must be a positive integer"
+        return 0
+      fi
+      ttl_state="$(resume_ttl_state "$artifact_approval_at" "$status_ttl_seconds")"
+      if [[ "$ttl_state" == "parse_error" ]]; then
+        append_status_reason_code "approval_record_invalid"
+        emit_status_json "invalid" "false" "approval_recorded_at is not RFC3339 UTC"
+        return 0
+      fi
+      if [[ "$ttl_state" == "expired" ]]; then
+        append_status_reason_code "ttl_expired"
+        emit_status_json "stale" "false" "resume TTL expired"
+        return 0
+      fi
+      append_status_reason_code "ttl_valid"
+    fi
+    if ! current_context="$(build_resume_context_json)"; then
+      append_status_reason_code "fresh_context_unavailable"
+      emit_status_json "stale" "false" "fresh context build failed"
+      return 0
+    fi
+    eval "$(parse_resume_context_fields "$current_context")"
+    if [[ -n "$fresh_context_parse_error" ]]; then
+      append_status_reason_code "fresh_context_invalid"
+      emit_status_json "stale" "false" "fresh context JSON could not be parsed"
+      return 0
+    fi
+    append_status_reason_code "fresh_context_loaded"
+    if [[ "$fresh_state_kind" != "resolved" ]]; then
+      append_status_reason_code "fresh_context_unresolved"
+      emit_status_json "stale" "false" "fresh context state is not resolved"
+      return 0
+    fi
+    append_status_reason_code "state_resolved"
+    if [[ "$fresh_state_id" != "$artifact_approved_state" ]]; then
+      append_status_reason_code "state_mismatch"
+      if [[ "$fresh_review_trigger_awaiting_ack" == "true" ]]; then
+        append_status_reason_code "review_trigger_awaiting_ack_true"
+      fi
+      if [[ "$fresh_bot_review_trigger_awaiting_ack" == "true" ]]; then
+        append_status_reason_code "bot_review_trigger_awaiting_ack_true"
+      fi
+      emit_status_json "stale" "false" "state mismatch"
+      return 0
+    fi
+    append_status_reason_code "state_match"
+    if [[ -n "$artifact_approved_route" ]]; then
+      if [[ "$fresh_route_kind" != "resolved" ]]; then
+        append_status_reason_code "route_unresolved"
+        emit_status_json "stale" "false" "fresh context route is not resolved"
+        return 0
+      fi
+      if [[ "$fresh_route_id" != "$artifact_approved_route" ]]; then
+        append_status_reason_code "route_mismatch"
+        if [[ "$fresh_review_trigger_awaiting_ack" == "true" ]]; then
+          append_status_reason_code "review_trigger_awaiting_ack_true"
+        fi
+        if [[ "$fresh_bot_review_trigger_awaiting_ack" == "true" ]]; then
+          append_status_reason_code "bot_review_trigger_awaiting_ack_true"
+        fi
+        emit_status_json "stale" "false" "route mismatch"
+        return 0
+      fi
+      append_status_reason_code "route_match"
+    fi
     emit_status_json "$artifact_status" "true"
     return 0
   fi

--- a/.reinguard/scripts/check-local-review.sh
+++ b/.reinguard/scripts/check-local-review.sh
@@ -137,24 +137,25 @@ echo "  Config file: $CONFIG_FILE"
 echo "  Supervisor: max ${LOCAL_CR_MAX_WAIT_SEC}s per attempt; heartbeat every ${LOCAL_CR_HEARTBEAT_SEC}s on stderr while running"
 echo
 
-# The last line containing "rate limit exceeded" (case-insensitive). Cooldown is parsed
-# from this line only so unrelated footer text (e.g. "finished in N seconds") cannot
-# satisfy extraction when the rate-limit line itself is unparseable.
-last_rate_limit_line_only() {
+# The last line containing an explicit cooldown instruction (case-insensitive). Retry uses
+# only this line so unrelated footer text (e.g. "finished in N seconds") cannot satisfy
+# extraction when the instruction line itself is unparseable. This avoids depending on
+# CodeRabbit's exact "rate limit" wording as long as the CLI emits try-after hints.
+last_cooldown_instruction_line_only() {
   local text="$1"
   local -a lines
-  local i start=-1
+  local i last=-1
 
   mapfile -t lines <<< "$(printf '%s\n' "$text")"
   for ((i = 0; i < ${#lines[@]}; i++)); do
-    if grep -qi "rate limit exceeded" <<< "${lines[$i]}"; then
-      start=$i
+    if grep -qiE 'try[[:space:]]+after|try[[:space:]]+again[[:space:]]+in|retry[[:space:]]+in' <<< "${lines[$i]}"; then
+      last=$i
     fi
   done
-  if [[ $start -lt 0 ]]; then
+  if [[ $last -lt 0 ]]; then
     return 1
   fi
-  printf '%s\n' "${lines[$start]}"
+  printf '%s\n' "${lines[$last]}"
 }
 
 # Parse hours/minutes/seconds from a single rate-limit snippet (one CLI message block).
@@ -164,12 +165,13 @@ extract_rate_limit_seconds() {
 
   lower="$(printf '%s\n' "$text" | tr '[:upper:]' '[:lower:]')"
   parse_target="$lower"
-  if [[ $parse_target == *"try after "* ]]; then
-    parse_target="${parse_target#*try after }"
-  elif [[ $parse_target == *"try again in "* ]]; then
-    parse_target="${parse_target#*try again in }"
-  elif [[ $parse_target == *"retry in "* ]]; then
-    parse_target="${parse_target#*retry in }"
+  # Strip the longest matching cooldown prefix (flexible whitespace in CLI text).
+  if [[ $parse_target =~ try[[:space:]]+after[[:space:]]+(.*) ]]; then
+    parse_target="${BASH_REMATCH[1]}"
+  elif [[ $parse_target =~ try[[:space:]]+again[[:space:]]+in[[:space:]]+(.*) ]]; then
+    parse_target="${BASH_REMATCH[1]}"
+  elif [[ $parse_target =~ retry[[:space:]]+in[[:space:]]+(.*) ]]; then
+    parse_target="${BASH_REMATCH[1]}"
   fi
   hours=0
   minutes=0
@@ -261,34 +263,52 @@ while true; do
   fi
 
   REVIEW_OUTPUT_CLEAN="$(strip_ansi_cr "$REVIEW_OUTPUT")"
-  if grep -qi "rate limit exceeded" <<< "$REVIEW_OUTPUT_CLEAN"; then
-    if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -lt $max_attempts ]]; then
-      LATEST_RL_LINE=""
-      if LATEST_RL_LINE="$(last_rate_limit_line_only "$REVIEW_OUTPUT_CLEAN")"; then
-        wait_seconds=""
-        if wait_seconds="$(extract_rate_limit_seconds "$LATEST_RL_LINE")" && [[ "$wait_seconds" =~ ^[0-9]+$ ]]; then
-          total_sleep=$((wait_seconds + RATE_LIMIT_RETRY_BUFFER_SEC))
-          echo "" >&2
-          echo "Rate limit detected on attempt ${attempt}/${max_attempts} (using latest rate-limit line from this CLI run only; ignoring earlier text)." >&2
-          echo "Parsed cooldown: ${wait_seconds}s; safety buffer: ${RATE_LIMIT_RETRY_BUFFER_SEC}s; sleeping ${total_sleep}s before one automatic retry..." >&2
-          sleep "$total_sleep"
-          echo "Retrying CodeRabbit local review (attempt $((attempt + 1))/${max_attempts})..." >&2
-          attempt=$((attempt + 1))
-          continue
-        fi
-      fi
-      echo "ERROR: CodeRabbit CLI reported rate limit but cooldown could not be parsed from the latest rate-limit line in this CLI run. Re-run after cooldown or check CLI output." >&2
-      exit 2
-    else
-      if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -eq $max_attempts ]]; then
-        echo "ERROR: CodeRabbit CLI is rate limited again after automatic retry (second consecutive). Wait for the reported cooldown and rerun manually." >&2
-      else
-        echo "ERROR: CodeRabbit CLI is rate limited. Pass --retry-on-rate-limit for one automatic cooldown wait, or wait and rerun manually." >&2
-      fi
-    fi
-  else
-    echo "ERROR: CodeRabbit local review failed. Resolve the CLI error and rerun before PR creation." >&2
+
+  LATEST_COOLDOWN_LINE=""
+  has_cooldown_line=0
+  if LATEST_COOLDOWN_LINE="$(last_cooldown_instruction_line_only "$REVIEW_OUTPUT_CLEAN")"; then
+    has_cooldown_line=1
   fi
+
+  wait_seconds=""
+  parse_ok=0
+  if [[ $has_cooldown_line -eq 1 ]]; then
+    if wait_seconds="$(extract_rate_limit_seconds "$LATEST_COOLDOWN_LINE")" && [[ "$wait_seconds" =~ ^[0-9]+$ ]]; then
+      parse_ok=1
+    fi
+  fi
+
+  if [[ $parse_ok -eq 1 && $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -lt $max_attempts ]]; then
+    total_sleep=$((wait_seconds + RATE_LIMIT_RETRY_BUFFER_SEC))
+    echo "" >&2
+    echo "Cooldown instruction detected on attempt ${attempt}/${max_attempts} (using latest cooldown line from this CLI run only; ignoring earlier text)." >&2
+    echo "Parsed cooldown: ${wait_seconds}s; safety buffer: ${RATE_LIMIT_RETRY_BUFFER_SEC}s; sleeping ${total_sleep}s before one automatic retry..." >&2
+    sleep "$total_sleep"
+    echo "Retrying CodeRabbit local review (attempt $((attempt + 1))/${max_attempts})..." >&2
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  if [[ $parse_ok -eq 1 ]]; then
+    if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -eq $max_attempts ]]; then
+      echo "ERROR: CodeRabbit CLI reported a cooldown again after automatic retry (second consecutive). Wait for the reported cooldown and rerun manually." >&2
+    else
+      echo "ERROR: CodeRabbit CLI reported a cooldown (backoff). Pass --retry-on-rate-limit for one automatic cooldown wait, or wait and rerun manually." >&2
+    fi
+    exit 2
+  fi
+
+  if [[ $has_cooldown_line -eq 1 && $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -lt $max_attempts ]]; then
+    echo "ERROR: CodeRabbit CLI output included a cooldown hint but duration could not be parsed from the latest cooldown instruction line in this CLI run. Re-run after cooldown or check CLI output." >&2
+    exit 2
+  fi
+
+  if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -eq $max_attempts ]]; then
+    echo "ERROR: CodeRabbit local review failed again after automatic retry. Wait for any reported cooldown and rerun manually." >&2
+    exit 2
+  fi
+
+  echo "ERROR: CodeRabbit local review failed. Resolve the CLI error and rerun before PR creation." >&2
   exit 2
 done
 

--- a/docs/adr/0015-adapter-local-execute-resume.md
+++ b/docs/adr/0015-adapter-local-execute-resume.md
@@ -51,10 +51,41 @@ orchestration state, not repository workflow position.
 5. An Adapter implementation (for example the Cursor chat Adapter) checks
    this artifact **before** fresh `rgd-next` proposal logic. The Adapter may
    create a `pending_approval` record **before** the approval gate so unit
-   identity is durable, then transition to `active` after approval. When the
-   artifact says an approved unit is still `active` and matches the current
-   branch, the Adapter resumes Execute instead of starting a new proposal
-   cycle.
+   identity is durable, then transition to `active` after approval.
+   Resume eligibility is a **fresh-evidence** decision, not an artifact-only
+   decision: an `active` artifact may resume Execute **only if** a fresh
+   cross-check still proves the approved proposition.
+   At minimum, the cross-check MUST fail closed unless all of the following
+   still hold:
+   - current branch matches the artifact branch
+   - current `git rev-parse HEAD` matches `approved_contract.head_sha`
+   - fresh `rgd context build --compact` still resolves to the approved
+     `state_id`
+   - when the approved contract recorded a `route_id`, fresh
+     `rgd context build --compact` still resolves to that same `route_id`
+   - any fresh observation-derived signals that materially contribute to the
+     current workflow position do not contradict the approved path. "Materially
+     contribute" means signals whose current values explain or block the fresh
+     resolved `state_id` / `route_id` that the Adapter is about to continue.
+     "Contradict" means either (a) fresh `state_id` / `route_id` no longer
+     equals the approved contract, or (b) a known same-HEAD blocking signal
+     now requires a different path even before a new commit exists. This must
+     stay aligned with ADR-0012 facts in the current schema (for example
+     bot-review facts such as `review_trigger_awaiting_ack` and
+     `bot_review_trigger_awaiting_ack`)
+     Example: if the user approved Execute while
+     `review_trigger_awaiting_ack=false`, then a later same-HEAD
+     `@coderabbitai review` causes fresh observation to report
+     `review_trigger_awaiting_ack=true`, the approved path is contradicted even
+     though `HEAD` did not change and resume must fail closed.
+   - the stored proposal fingerprint still recomputes from the artifact fields
+   An Adapter MAY layer a TTL on top as defense in depth, but TTL alone is not
+   sufficient to authorize resume.
+   The decision surface MUST expose machine-readable diagnostics (for example
+   `resume_reason_codes[]`) and MUST distinguish at least: branch drift, head
+   drift, state / route drift, stale review-trigger facts, malformed artifacts,
+   unavailable fresh context, fingerprint mismatch, and TTL expiry when
+   enabled.
 6. Terminality remains evidence-based per `next-orchestration.md`. The
    artifact is a durable record of the Adapter contract, not an authority
    that overrides procedure semantics.
@@ -100,10 +131,12 @@ not mixed with workspace tool caches under `.tmp/`.
   condition the user approved, not merely that approval happened
 - **Easier**: substrate boundaries stay intact because repo/platform state
   still comes only from `rgd`
+- **Easier**: resume decisions fail closed when fresh observation no longer
+  matches the approved path, including same-HEAD observation drift
 - **Harder**: Adapter commands must explicitly record start / update /
   terminal transitions
-- **Harder**: each Adapter must own its own persistence details instead of
-  delegating continuity to `rgd`
+- **Harder**: each Adapter must own its own persistence details and its own
+  fresh-observation revalidation instead of delegating continuity to `rgd`
 
 ## Refs
 

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -1,7 +1,9 @@
 package scripttest
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,16 +30,17 @@ type resumeScriptStatus struct {
 		Summary    string `json:"summary"`
 		RecordedAt string `json:"recorded_at"`
 	} `json:"terminal"`
-	ArtifactPath   string `json:"artifact_path"`
-	Status         string `json:"status"`
-	Reason         string `json:"reason"`
-	Branch         string `json:"branch"`
-	CurrentBranch  string `json:"current_branch"`
-	ApprovalAt     string `json:"approval_recorded_at"`
-	CreatedAt      string `json:"created_at"`
-	UpdatedAt      string `json:"updated_at"`
-	IssueNumber    int    `json:"issue_number"`
-	ResumeEligible bool   `json:"resume_eligible"`
+	ArtifactPath      string   `json:"artifact_path"`
+	Status            string   `json:"status"`
+	Reason            string   `json:"reason"`
+	Branch            string   `json:"branch"`
+	CurrentBranch     string   `json:"current_branch"`
+	ApprovalAt        string   `json:"approval_recorded_at"`
+	CreatedAt         string   `json:"created_at"`
+	UpdatedAt         string   `json:"updated_at"`
+	ResumeReasonCodes []string `json:"resume_reason_codes"`
+	IssueNumber       int      `json:"issue_number"`
+	ResumeEligible    bool     `json:"resume_eligible"`
 }
 
 func TestAdapterRgdNextResumeScript_ShellSyntax(t *testing.T) {
@@ -93,7 +96,8 @@ func TestAdapterRgdNextResumeScript_ProposalThenApprove(t *testing.T) {
 	if err != nil {
 		t.Fatalf("approve: %v\n%s", err, approveOut)
 	}
-	activeOut, err := runBashScript(t, repo, script, nil, "status")
+	activeEnv := resumeStatusEnv(t, repo, "working_no_pr", "user-implement", false, false)
+	activeOut, err := runBashScript(t, repo, script, activeEnv, "status")
 	if err != nil {
 		t.Fatalf("status after approve: %v\n%s", err, activeOut)
 	}
@@ -102,6 +106,10 @@ func TestAdapterRgdNextResumeScript_ProposalThenApprove(t *testing.T) {
 	if active.Status != "active" || !active.ResumeEligible || active.ApprovalAt == "" {
 		t.Fatalf("expected active after approve, got %+v", active)
 	}
+	assertHasReasonCode(t, active.ResumeReasonCodes, "branch_match")
+	assertHasReasonCode(t, active.ResumeReasonCodes, "head_match")
+	assertHasReasonCode(t, active.ResumeReasonCodes, "state_match")
+	assertHasReasonCode(t, active.ResumeReasonCodes, "route_match")
 	if active.ApprovedContract.StateID != "working_no_pr" || active.ApprovedContract.RouteID != "user-implement" {
 		t.Fatalf("approved_contract = %+v", active.ApprovedContract)
 	}
@@ -311,9 +319,204 @@ func TestAdapterRgdNextResumeScript_StatusInvalidForMalformedArtifact(t *testing
 	if got.Status != "invalid" || got.ResumeEligible {
 		t.Fatalf("status = %+v", got)
 	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "artifact_missing_required_keys")
 	if !strings.Contains(got.Reason, "missing required keys") {
 		t.Fatalf("reason = %q", got.Reason)
 	}
+}
+
+func TestAdapterRgdNextResumeScript_StatusStaleOnHeadMismatch(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--state-id", "working_no_pr",
+		"--route-id", "user-implement",
+		"--ordered-remainder", "implement -> change-inspect -> pr-create",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+	gitEmptyCommit(t, repo)
+
+	statusEnv := resumeStatusEnv(t, repo, "working_no_pr", "user-implement", false, false)
+	statusOut, err := runBashScript(t, repo, script, statusEnv, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "stale" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Reason != "head mismatch" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "branch_match")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "head_mismatch")
+}
+
+func TestAdapterRgdNextResumeScript_StatusStaleOnFreshStateMismatch(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--state-id", "merge_ready",
+		"--route-id", "user-pr-merge",
+		"--ordered-remainder", "pr-merge -> branch cleanup",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	statusEnv := resumeStatusEnv(t, repo, "waiting_bot_review", "user-wait-bot-review", false, false)
+	statusOut, err := runBashScript(t, repo, script, statusEnv, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "stale" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Reason != "state mismatch" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "head_match")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "fresh_context_loaded")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "state_mismatch")
+}
+
+func TestAdapterRgdNextResumeScript_StatusStaleOnBotReviewAwaitingAck(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--state-id", "merge_ready",
+		"--route-id", "user-pr-merge",
+		"--ordered-remainder", "pr-merge -> branch cleanup",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	statusEnv := resumeStatusEnv(t, repo, "waiting_bot_review", "user-wait-bot-review", true, true)
+	statusOut, err := runBashScript(t, repo, script, statusEnv, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "stale" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "state_mismatch")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "review_trigger_awaiting_ack_true")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "bot_review_trigger_awaiting_ack_true")
+}
+
+func TestAdapterRgdNextResumeScript_StatusStaleOnTTLExpiry(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--state-id", "working_no_pr",
+		"--route-id", "user-implement",
+		"--ordered-remainder", "implement -> change-inspect -> pr-create",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	artifactPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
+	raw, readErr := os.ReadFile(artifactPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	var artifact map[string]any
+	unmarshalJSON(t, string(raw), &artifact)
+	if _, ok := artifact["approval_recorded_at"].(string); !ok {
+		t.Fatal("artifact missing or has invalid approval_recorded_at")
+	}
+	artifact["approval_recorded_at"] = "2000-01-01T00:00:00Z"
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if encodeErr := enc.Encode(artifact); encodeErr != nil {
+		t.Fatal(encodeErr)
+	}
+	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("encoded artifact is empty")
+	}
+
+	statusEnv := append(
+		resumeStatusEnv(t, repo, "working_no_pr", "user-implement", false, false),
+		"REINGUARD_RGD_NEXT_RESUME_TTL_SECONDS=60",
+	)
+	statusOut, err := runBashScript(t, repo, script, statusEnv, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "stale" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Reason != "resume TTL expired" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "ttl_expired")
 }
 
 func TestAdapterRgdNextResumeScript_FinishValidatesTerminalReason(t *testing.T) {
@@ -437,4 +640,46 @@ func unmarshalJSON(t *testing.T, raw string, target any) {
 	if err := json.Unmarshal([]byte(raw), target); err != nil {
 		t.Fatalf("unmarshal JSON: %v\n%s", err, raw)
 	}
+}
+
+func resumeStatusEnv(t *testing.T, repo, stateID, routeID string, reviewAwaitingAck, botReviewAwaitingAck bool) []string {
+	t.Helper()
+	contextPath := writeTempFile(t, repo, "resume-context-*.json", resumeContextJSON(stateID, routeID, reviewAwaitingAck, botReviewAwaitingAck))
+	return []string{"REINGUARD_RGD_NEXT_CONTEXT_BUILD_FILE=" + contextPath}
+}
+
+func resumeContextJSON(stateID, routeID string, reviewAwaitingAck, botReviewAwaitingAck bool) string {
+	return fmt.Sprintf(`{
+  "state": {
+    "kind": "resolved",
+    "state_id": %q
+  },
+  "routes": [
+    {
+      "kind": "resolved",
+      "route_id": %q
+    }
+  ],
+  "observation": {
+    "signals": {
+      "github": {
+        "reviews": {
+          "review_trigger_awaiting_ack": %t,
+          "bot_review_trigger_awaiting_ack": %t
+        }
+      }
+    }
+  }
+}
+`, stateID, routeID, reviewAwaitingAck, botReviewAwaitingAck)
+}
+
+func assertHasReasonCode(t *testing.T, codes []string, want string) {
+	t.Helper()
+	for _, code := range codes {
+		if code == want {
+			return
+		}
+	}
+	t.Fatalf("resume_reason_codes = %v, want %q", codes, want)
 }

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -203,6 +203,7 @@ func TestAdapterRgdNextResumeScript_StatusStaleOnDetachedHead(t *testing.T) {
 	if got.Reason != "detached HEAD" {
 		t.Fatalf("reason = %q", got.Reason)
 	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "detached_head")
 }
 
 func TestAdapterRgdNextResumeScript_SummaryRoundTripWithQuotes(t *testing.T) {
@@ -290,6 +291,7 @@ func TestAdapterRgdNextResumeScript_StatusStaleOnBranchMismatch(t *testing.T) {
 	if got.Reason != "branch mismatch" || got.CurrentBranch != "main" {
 		t.Fatalf("stale metadata = %+v", got)
 	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "branch_mismatch")
 }
 
 func TestAdapterRgdNextResumeScript_StatusInvalidForMalformedArtifact(t *testing.T) {
@@ -492,11 +494,11 @@ func TestAdapterRgdNextResumeScript_StatusStaleOnTTLExpiry(t *testing.T) {
 	if encodeErr := enc.Encode(artifact); encodeErr != nil {
 		t.Fatal(encodeErr)
 	}
-	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
-		t.Fatal(writeErr)
-	}
 	if buf.Len() == 0 {
 		t.Fatal("encoded artifact is empty")
+	}
+	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
+		t.Fatal(writeErr)
 	}
 
 	statusEnv := append(
@@ -517,6 +519,73 @@ func TestAdapterRgdNextResumeScript_StatusStaleOnTTLExpiry(t *testing.T) {
 		t.Fatalf("reason = %q", got.Reason)
 	}
 	assertHasReasonCode(t, got.ResumeReasonCodes, "ttl_expired")
+}
+
+func TestAdapterRgdNextResumeScript_StatusInvalidOnProposalFingerprintMismatch(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--state-id", "working_no_pr",
+		"--route-id", "user-implement",
+		"--ordered-remainder", "implement -> change-inspect -> pr-create",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	artifactPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
+	raw, readErr := os.ReadFile(artifactPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	var artifact map[string]any
+	unmarshalJSON(t, string(raw), &artifact)
+	approved, ok := artifact["approved_contract"].(map[string]any)
+	if !ok {
+		t.Fatalf("approved_contract missing or wrong type: %+v", artifact)
+	}
+	approved["proposal_fingerprint"] = strings.Repeat("0", 64)
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if encodeErr := enc.Encode(artifact); encodeErr != nil {
+		t.Fatal(encodeErr)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("encoded artifact is empty")
+	}
+	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	statusEnv := resumeStatusEnv(t, repo, "working_no_pr", "user-implement", false, false)
+	statusOut, err := runBashScript(t, repo, script, statusEnv, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "invalid" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Reason != "proposal fingerprint mismatch" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "proposal_fingerprint_mismatch")
 }
 
 func TestAdapterRgdNextResumeScript_FinishValidatesTerminalReason(t *testing.T) {

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -522,27 +522,13 @@ func TestAdapterRgdNextResumeScript_StatusInvalidOnApprovedContractIncomplete(t 
 	}
 
 	artifactPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
-	raw, readErr := os.ReadFile(artifactPath)
-	if readErr != nil {
-		t.Fatal(readErr)
-	}
-	var artifact map[string]any
-	unmarshalJSON(t, string(raw), &artifact)
-	approved, ok := artifact["approved_contract"].(map[string]any)
-	if !ok {
-		t.Fatalf("approved_contract missing: %+v", artifact)
-	}
-	delete(approved, "ordered_remainder")
-
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if encodeErr := enc.Encode(artifact); encodeErr != nil {
-		t.Fatal(encodeErr)
-	}
-	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
-		t.Fatal(writeErr)
-	}
+	mutateResumeArtifact(t, artifactPath, func(artifact map[string]any) {
+		approved, ok := artifact["approved_contract"].(map[string]any)
+		if !ok {
+			t.Fatalf("approved_contract missing: %+v", artifact)
+		}
+		delete(approved, "ordered_remainder")
+	})
 
 	statusOut, err := runBashScript(t, repo, script, nil, "status")
 	if err != nil {
@@ -585,23 +571,9 @@ func TestAdapterRgdNextResumeScript_StatusInvalidOnArtifactIdentityMismatch(t *t
 	}
 
 	artifactPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
-	raw, readErr := os.ReadFile(artifactPath)
-	if readErr != nil {
-		t.Fatal(readErr)
-	}
-	var artifact map[string]any
-	unmarshalJSON(t, string(raw), &artifact)
-	artifact["artifact_type"] = "wrong_type"
-
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if encodeErr := enc.Encode(artifact); encodeErr != nil {
-		t.Fatal(encodeErr)
-	}
-	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
-		t.Fatal(writeErr)
-	}
+	mutateResumeArtifact(t, artifactPath, func(artifact map[string]any) {
+		artifact["artifact_type"] = "wrong_type"
+	})
 
 	statusOut, err := runBashScript(t, repo, script, nil, "status")
 	if err != nil {
@@ -684,28 +656,12 @@ func TestAdapterRgdNextResumeScript_StatusStaleOnTTLExpiry(t *testing.T) {
 	}
 
 	artifactPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
-	raw, readErr := os.ReadFile(artifactPath)
-	if readErr != nil {
-		t.Fatal(readErr)
-	}
-	var artifact map[string]any
-	unmarshalJSON(t, string(raw), &artifact)
-	if _, ok := artifact["approval_recorded_at"].(string); !ok {
-		t.Fatal("artifact missing or has invalid approval_recorded_at")
-	}
-	artifact["approval_recorded_at"] = "2000-01-01T00:00:00Z"
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if encodeErr := enc.Encode(artifact); encodeErr != nil {
-		t.Fatal(encodeErr)
-	}
-	if buf.Len() == 0 {
-		t.Fatal("encoded artifact is empty")
-	}
-	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
-		t.Fatal(writeErr)
-	}
+	mutateResumeArtifact(t, artifactPath, func(artifact map[string]any) {
+		if _, ok := artifact["approval_recorded_at"].(string); !ok {
+			t.Fatal("artifact missing or has invalid approval_recorded_at")
+		}
+		artifact["approval_recorded_at"] = "2000-01-01T00:00:00Z"
+	})
 
 	statusEnv := append(
 		resumeStatusEnv(t, repo, "working_no_pr", "user-implement", false, false),
@@ -752,30 +708,13 @@ func TestAdapterRgdNextResumeScript_StatusInvalidOnProposalFingerprintMismatch(t
 	}
 
 	artifactPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
-	raw, readErr := os.ReadFile(artifactPath)
-	if readErr != nil {
-		t.Fatal(readErr)
-	}
-	var artifact map[string]any
-	unmarshalJSON(t, string(raw), &artifact)
-	approved, ok := artifact["approved_contract"].(map[string]any)
-	if !ok {
-		t.Fatalf("approved_contract missing or wrong type: %+v", artifact)
-	}
-	approved["proposal_fingerprint"] = strings.Repeat("0", 64)
-
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if encodeErr := enc.Encode(artifact); encodeErr != nil {
-		t.Fatal(encodeErr)
-	}
-	if buf.Len() == 0 {
-		t.Fatal("encoded artifact is empty")
-	}
-	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
-		t.Fatal(writeErr)
-	}
+	mutateResumeArtifact(t, artifactPath, func(artifact map[string]any) {
+		approved, ok := artifact["approved_contract"].(map[string]any)
+		if !ok {
+			t.Fatalf("approved_contract missing or wrong type: %+v", artifact)
+		}
+		approved["proposal_fingerprint"] = strings.Repeat("0", 64)
+	})
 
 	statusEnv := resumeStatusEnv(t, repo, "working_no_pr", "user-implement", false, false)
 	statusOut, err := runBashScript(t, repo, script, statusEnv, "status")
@@ -914,6 +853,29 @@ func unmarshalJSON(t *testing.T, raw string, target any) {
 	t.Helper()
 	if err := json.Unmarshal([]byte(raw), target); err != nil {
 		t.Fatalf("unmarshal JSON: %v\n%s", err, raw)
+	}
+}
+
+func mutateResumeArtifact(t *testing.T, path string, mutate func(map[string]any)) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var artifact map[string]any
+	unmarshalJSON(t, string(raw), &artifact)
+	mutate(artifact)
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(artifact); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -603,7 +603,7 @@ func TestAdapterRgdNextResumeScript_StatusInvalidOnArtifactIdentityMismatch(t *t
 	assertHasReasonCode(t, got.ResumeReasonCodes, "artifact_identity_mismatch")
 }
 
-func TestAdapterRgdNextResumeScript_StatusStaleOnBotReviewAwaitingAck(t *testing.T) {
+func TestAdapterRgdNextResumeScript_StatusStaleOnStateMismatch_EmitsReviewAndBotReviewAwaitingAck(t *testing.T) {
 	t.Parallel()
 
 	script := scriptPath(t, "adapter-rgd-next-resume.sh")

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -413,6 +413,212 @@ func TestAdapterRgdNextResumeScript_StatusStaleOnFreshStateMismatch(t *testing.T
 	assertHasReasonCode(t, got.ResumeReasonCodes, "state_mismatch")
 }
 
+func TestAdapterRgdNextResumeScript_StatusStaleOnRouteMismatch(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--state-id", "merge_ready",
+		"--route-id", "user-pr-merge",
+		"--ordered-remainder", "pr-merge -> branch cleanup",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	statusEnv := resumeStatusEnv(t, repo, "merge_ready", "user-monitor-pr", false, false)
+	statusOut, err := runBashScript(t, repo, script, statusEnv, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "stale" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Reason != "route mismatch" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "state_match")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "route_mismatch")
+}
+
+func TestAdapterRgdNextResumeScript_StatusStaleOnFreshContextInvalid(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--state-id", "working_no_pr",
+		"--route-id", "user-implement",
+		"--ordered-remainder", "implement -> change-inspect -> pr-create",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	contextPath := writeTempFile(t, repo, "resume-context-*.json", "not json")
+	statusEnv := []string{"REINGUARD_RGD_NEXT_CONTEXT_BUILD_FILE=" + contextPath}
+	statusOut, err := runBashScript(t, repo, script, statusEnv, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "stale" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Reason != "fresh context JSON could not be parsed" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "fresh_context_invalid")
+}
+
+func TestAdapterRgdNextResumeScript_StatusInvalidOnApprovedContractIncomplete(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--state-id", "working_no_pr",
+		"--route-id", "user-implement",
+		"--ordered-remainder", "implement -> change-inspect -> pr-create",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	artifactPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
+	raw, readErr := os.ReadFile(artifactPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	var artifact map[string]any
+	unmarshalJSON(t, string(raw), &artifact)
+	approved, ok := artifact["approved_contract"].(map[string]any)
+	if !ok {
+		t.Fatalf("approved_contract missing: %+v", artifact)
+	}
+	delete(approved, "ordered_remainder")
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if encodeErr := enc.Encode(artifact); encodeErr != nil {
+		t.Fatal(encodeErr)
+	}
+	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	statusOut, err := runBashScript(t, repo, script, nil, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "invalid" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Reason != "approved_contract is missing required fields" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "approved_contract_incomplete")
+}
+
+func TestAdapterRgdNextResumeScript_StatusInvalidOnArtifactIdentityMismatch(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/104")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/104",
+		"--issue", "104",
+		"--state-id", "working_no_pr",
+		"--route-id", "user-implement",
+		"--ordered-remainder", "implement -> change-inspect -> pr-create",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	artifactPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
+	raw, readErr := os.ReadFile(artifactPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	var artifact map[string]any
+	unmarshalJSON(t, string(raw), &artifact)
+	artifact["artifact_type"] = "wrong_type"
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if encodeErr := enc.Encode(artifact); encodeErr != nil {
+		t.Fatal(encodeErr)
+	}
+	if writeErr := os.WriteFile(artifactPath, buf.Bytes(), 0o644); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	statusOut, err := runBashScript(t, repo, script, nil, "status")
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, statusOut)
+	}
+
+	var got resumeScriptStatus
+	unmarshalJSON(t, statusOut, &got)
+	if got.Status != "invalid" || got.ResumeEligible {
+		t.Fatalf("status = %+v", got)
+	}
+	if got.Reason != "unexpected artifact_type or command" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "artifact_identity_mismatch")
+}
+
 func TestAdapterRgdNextResumeScript_StatusStaleOnBotReviewAwaitingAck(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -3,7 +3,6 @@ package scripttest
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -408,9 +407,15 @@ func TestAdapterRgdNextResumeScript_StatusStaleOnFreshStateMismatch(t *testing.T
 	if got.Reason != "state mismatch" {
 		t.Fatalf("reason = %q", got.Reason)
 	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "branch_match")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "proposal_fingerprint_match")
 	assertHasReasonCode(t, got.ResumeReasonCodes, "head_match")
 	assertHasReasonCode(t, got.ResumeReasonCodes, "fresh_context_loaded")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "state_resolved")
 	assertHasReasonCode(t, got.ResumeReasonCodes, "state_mismatch")
+	assertLacksReasonCode(t, got.ResumeReasonCodes, "state_match")
+	assertLacksReasonCode(t, got.ResumeReasonCodes, "route_match")
+	assertLacksReasonCode(t, got.ResumeReasonCodes, "route_mismatch")
 }
 
 func TestAdapterRgdNextResumeScript_StatusStaleOnRouteMismatch(t *testing.T) {
@@ -451,8 +456,15 @@ func TestAdapterRgdNextResumeScript_StatusStaleOnRouteMismatch(t *testing.T) {
 	if got.Reason != "route mismatch" {
 		t.Fatalf("reason = %q", got.Reason)
 	}
+	assertHasReasonCode(t, got.ResumeReasonCodes, "branch_match")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "proposal_fingerprint_match")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "head_match")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "fresh_context_loaded")
+	assertHasReasonCode(t, got.ResumeReasonCodes, "state_resolved")
 	assertHasReasonCode(t, got.ResumeReasonCodes, "state_match")
 	assertHasReasonCode(t, got.ResumeReasonCodes, "route_mismatch")
+	assertLacksReasonCode(t, got.ResumeReasonCodes, "state_mismatch")
+	assertLacksReasonCode(t, got.ResumeReasonCodes, "route_match")
 }
 
 func TestAdapterRgdNextResumeScript_StatusStaleOnFreshContextInvalid(t *testing.T) {
@@ -881,34 +893,39 @@ func mutateResumeArtifact(t *testing.T, path string, mutate func(map[string]any)
 
 func resumeStatusEnv(t *testing.T, repo, stateID, routeID string, reviewAwaitingAck, botReviewAwaitingAck bool) []string {
 	t.Helper()
-	contextPath := writeTempFile(t, repo, "resume-context-*.json", resumeContextJSON(stateID, routeID, reviewAwaitingAck, botReviewAwaitingAck))
+	contextPath := writeTempFile(t, repo, "resume-context-*.json", resumeContextJSON(t, stateID, routeID, reviewAwaitingAck, botReviewAwaitingAck))
 	return []string{"REINGUARD_RGD_NEXT_CONTEXT_BUILD_FILE=" + contextPath}
 }
 
-func resumeContextJSON(stateID, routeID string, reviewAwaitingAck, botReviewAwaitingAck bool) string {
-	return fmt.Sprintf(`{
-  "state": {
-    "kind": "resolved",
-    "state_id": %q
-  },
-  "routes": [
-    {
-      "kind": "resolved",
-      "route_id": %q
-    }
-  ],
-  "observation": {
-    "signals": {
-      "github": {
-        "reviews": {
-          "review_trigger_awaiting_ack": %t,
-          "bot_review_trigger_awaiting_ack": %t
-        }
-      }
-    }
-  }
-}
-`, stateID, routeID, reviewAwaitingAck, botReviewAwaitingAck)
+func resumeContextJSON(t *testing.T, stateID, routeID string, reviewAwaitingAck, botReviewAwaitingAck bool) string {
+	t.Helper()
+	ctx := map[string]any{
+		"state": map[string]any{
+			"kind":     "resolved",
+			"state_id": stateID,
+		},
+		"routes": []any{
+			map[string]any{
+				"kind":     "resolved",
+				"route_id": routeID,
+			},
+		},
+		"observation": map[string]any{
+			"signals": map[string]any{
+				"github": map[string]any{
+					"reviews": map[string]any{
+						"review_trigger_awaiting_ack":     reviewAwaitingAck,
+						"bot_review_trigger_awaiting_ack": botReviewAwaitingAck,
+					},
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
 }
 
 func assertHasReasonCode(t *testing.T, codes []string, want string) {
@@ -919,4 +936,13 @@ func assertHasReasonCode(t *testing.T, codes []string, want string) {
 		}
 	}
 	t.Fatalf("resume_reason_codes = %v, want %q", codes, want)
+}
+
+func assertLacksReasonCode(t *testing.T, codes []string, unwanted string) {
+	t.Helper()
+	for _, c := range codes {
+		if c == unwanted {
+			t.Fatalf("resume_reason_codes = %v, unexpected %q present", codes, unwanted)
+		}
+	}
 }

--- a/internal/scripttest/local_review_script_test.go
+++ b/internal/scripttest/local_review_script_test.go
@@ -142,7 +142,7 @@ case "$subcmd" in
     ;;
   review)
     cat <<'EOF'
-[2026-04-03T00:00:00Z] ERROR: Rate limit exceeded, please wait for cooldown reset
+[2026-04-03T00:00:00Z] ERROR: Rate limit exceeded, please try after cooldown reset
 EOF
     exit 1
     ;;
@@ -165,12 +165,12 @@ printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
 	// When: the local review script runs with automatic retry enabled.
 	out, err := runBashScript(t, repo, script, env, "--base", "main", "--retry-on-rate-limit")
 
-	// Then: it stops with a parse failure tied to the latest rate-limit line.
+	// Then: it stops with a parse failure tied to the latest cooldown instruction line.
 	if err == nil {
 		t.Fatalf("expected failure, got success:\n%s", out)
 	}
 	requireExitCode(t, err, 2, out)
-	if !strings.Contains(out, "could not be parsed from the latest rate-limit line") {
+	if !strings.Contains(out, "duration could not be parsed from the latest cooldown instruction line") {
 		t.Fatalf("expected parse failure message, got:\n%s", out)
 	}
 	if _, err := os.Stat(sleepFile); err == nil {
@@ -202,7 +202,7 @@ case "$subcmd" in
     ;;
   review)
     cat <<'EOF'
-[2026-04-03T00:00:00Z] ERROR: Rate limit exceeded, please wait for cooldown reset
+[2026-04-03T00:00:00Z] ERROR: Rate limit exceeded, please try after cooldown reset
 Job finished in 5 seconds
 EOF
     exit 1
@@ -228,7 +228,7 @@ printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
 		t.Fatalf("expected failure, got success:\n%s", out)
 	}
 	requireExitCode(t, err, 2, out)
-	if !strings.Contains(out, "could not be parsed from the latest rate-limit line") {
+	if !strings.Contains(out, "duration could not be parsed from the latest cooldown instruction line") {
 		t.Fatalf("expected parse failure message, got:\n%s", out)
 	}
 	if _, err := os.Stat(sleepFile); err == nil {
@@ -333,5 +333,145 @@ esac
 	requireExitCode(t, err, 2, out)
 	if !strings.Contains(out, "CodeRabbit CLI is not authenticated") {
 		t.Fatalf("expected unauthenticated error, got:\n%s", out)
+	}
+}
+
+func TestCheckLocalReviewScript_TryAgainInWithoutRateLimitPhraseRetries(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "check-local-review.sh")
+	repo := setupLocalReviewRepo(t)
+
+	stubDir := t.TempDir()
+	logFile := filepath.Join(stubDir, "coderabbit.log")
+	countFile := filepath.Join(stubDir, "coderabbit-count.txt")
+	sleepFile := filepath.Join(stubDir, "sleep.log")
+
+	writeExecutable(t, stubDir, "coderabbit", `#!/usr/bin/env bash
+set -euo pipefail
+log_file="${TEST_LOG_FILE:?}"
+count_file="${TEST_COUNT_FILE:?}"
+subcmd="$1"
+shift
+case "$subcmd" in
+  auth)
+    echo "Authentication: logged in"
+    ;;
+  review)
+    count=0
+    if [[ -f "$count_file" ]]; then
+      count=$(cat "$count_file")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$count_file"
+    echo "review attempt $count: $*" >>"$log_file"
+    if [[ $count -eq 1 ]]; then
+      cat <<'EOF'
+Your review has hit the rate limit for this repository. Please try again in 1 minute and 1 second.
+EOF
+      exit 1
+    fi
+    cat <<'EOF'
+Review completed: 0 findings
+EOF
+    ;;
+  *)
+    echo "unexpected subcommand: $subcmd" >&2
+    exit 1
+    ;;
+esac
+`)
+	writeExecutable(t, stubDir, "sleep", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
+`)
+
+	env := []string{
+		"PATH=" + stubDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"TEST_LOG_FILE=" + logFile,
+		"TEST_COUNT_FILE=" + countFile,
+		"TEST_SLEEP_FILE=" + sleepFile,
+		"RATE_LIMIT_RETRY_BUFFER_SEC=30",
+	}
+
+	out, err := runBashScript(t, repo, script, env, "--base", "main", "--retry-on-rate-limit")
+	if err != nil {
+		t.Fatalf("check-local-review: %v\n%s", err, out)
+	}
+
+	sleepLog, err := os.ReadFile(sleepFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1 minute + 1 second = 61s cooldown + 30s buffer
+	if got := strings.TrimSpace(string(sleepLog)); got != "91" {
+		t.Fatalf("sleep seconds = %q, want 91", got)
+	}
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(logData), "review attempt") != 2 {
+		t.Fatalf("expected two review attempts, got log:\n%s", logData)
+	}
+	if !strings.Contains(out, "CodeRabbit local review completed.") {
+		t.Fatalf("expected completion message, got:\n%s", out)
+	}
+}
+
+func TestCheckLocalReviewScript_GeneralFailureWithoutCooldownHintFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "check-local-review.sh")
+	repo := setupLocalReviewRepo(t)
+
+	stubDir := t.TempDir()
+	sleepFile := filepath.Join(stubDir, "sleep.log")
+	writeExecutable(t, stubDir, "coderabbit", `#!/usr/bin/env bash
+set -euo pipefail
+subcmd="$1"
+shift
+case "$subcmd" in
+  auth)
+    echo "Authentication: logged in"
+    ;;
+  review)
+    cat <<'EOF'
+ERROR: Something went wrong while contacting the review service.
+EOF
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+`)
+	writeExecutable(t, stubDir, "sleep", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
+`)
+
+	env := []string{
+		"PATH=" + stubDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"RATE_LIMIT_RETRY_BUFFER_SEC=30",
+		"TEST_SLEEP_FILE=" + sleepFile,
+	}
+
+	out, err := runBashScript(t, repo, script, env, "--base", "main", "--retry-on-rate-limit")
+	if err == nil {
+		t.Fatalf("expected failure, got success:\n%s", out)
+	}
+	requireExitCode(t, err, 2, out)
+	if !strings.Contains(out, "CodeRabbit local review failed. Resolve the CLI error") {
+		t.Fatalf("expected general failure message, got:\n%s", out)
+	}
+	if _, err := os.Stat(sleepFile); err == nil {
+		sleepLog, readErr := os.ReadFile(sleepFile)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		t.Fatalf("expected fail-closed behavior without sleep, got sleep log:\n%s", sleepLog)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error checking sleep file: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Extend `adapter-rgd-next-resume.sh status` to require branch, HEAD, approved `state_id` / `route_id`, and proposal fingerprint agreement with fresh `rgd context build --compact` before `resume_eligible: true`.
- Emit machine-readable `resume_reason_codes[]` for eligibility decisions.
- Amend ADR-0015 and align `rgd-next` Sense + `next-orchestration.md` resume contract wording.
- Add script tests covering stale HEAD, stale state, fingerprint mismatch, and successful resume.

## Traceability

Closes #124

Refs: #124

## Definition of Done

- [x] Tests added or updated (`go test ./internal/scripttest -race`)
- [x] `go vet ./...` clean
- [x] Lint clean (local golangci-lint)
- [x] Documentation updated (ADR-0015, command, procedure)

## Test plan

1. `go test ./internal/scripttest -run Adapter -count=1 -race`
2. `go test ./internal/scripttest -count=1 -race`
3. `go run ./cmd/rgd config validate`

## Risk / Impact

- Operators see stricter resume: stale artifact no longer resumes without fresh observation agreement.

## Rollback Plan

Revert this PR; resume falls back to prior branch-only checks.
