### PR TITLE
fix(rgd-next): forbid terminal stop on resumable wait states

### DIFF
--- a/.cursor/commands/rgd-next.md
+++ b/.cursor/commands/rgd-next.md
@@ -102,6 +102,8 @@ bash .reinguard/scripts/adapter-rgd-next-resume.sh update --state-id <state_id> 
 
 Do **not** treat per-iteration chat as required user-visible output — follow [`.cursor/rules/reinguard-bridge.mdc`](../../.cursor/rules/reinguard-bridge.mdc) § **rgd-next Execute — Cursor chat transcript** for what may appear in the Cursor chat panel. When DoD or an allowed stop is reached, close the artifact with `finish --status ... --reason ...` before returning the final user-facing report.
 
+**Resumable wait stops (normative detail):** [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Allowed stops**. The `adapter-rgd-next-resume.sh` `finish` subcommand enforces the fail-closed contract using fresh `rgd context build --compact` (ADR-0015); do not duplicate policy here.
+
 ## Guard
 
 - FSM and priorities: [`docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md`](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md)

--- a/.reinguard/procedure/next-orchestration.md
+++ b/.reinguard/procedure/next-orchestration.md
@@ -106,6 +106,13 @@ After approval, the agent **must** drive toward **Per-unit Definition of Done** 
 - **Hard Stops** (**HS-***) in [`../policy/safety--agent-invariants.md`](../policy/safety--agent-invariants.md).
 - **Genuine cannot proceed** — missing credentials, org enforcement, unrecoverable GitHub block — report with **evidence** and stop.
 
+**Resumable wait states: do not close as `allowed_stop` with `cannot_proceed` or `tooling_session_limit`.** When fresh `rgd context build --compact` still resolves to one of these **temporary wait** `state_id` values, the run remains on a normative retry path (see [`.reinguard/procedure/wait-bot-review.md`](wait-bot-review.md), [`.reinguard/knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md)):
+
+- **Wait states (resumable):** `waiting_ci`, `waiting_bot_rate_limited`, `waiting_bot_paused`, `waiting_bot_stale`, `waiting_bot_run`, `waiting_bot_failed` (normative `state_id` SSOT: [`.reinguard/control/states/workflow.yaml`](../control/states/workflow.yaml)).
+- **Forbidden:** `allowed_stop` with reason `cannot_proceed` or `tooling_session_limit` for those resolved states — continue the mapped wait procedure (cooldown + re-trigger), refresh context, then Route again. `tooling_session_limit` is not a substitute for repository-state terminality when observation still resolves to a wait/retry procedure.
+- **When stopping is allowed:** only an **HS-*** (hard stop), or a genuine unrecoverable external failure (for example GitHub itself unreachable, org-level enforcement permanently blocking the required bot) — and only as `allowed_stop` + `hard_stop`, with evidence that names the external block.
+- **Status:** this does **not** introduce a new non-terminal `suspended` status; resumable waits stay on the loop until fresh observation moves the FSM or DoD is met.
+
 Adapters may persist this approval continuity locally so the next turn can
 resume the same approved path. Such persistence is **Adapter-local** and must
 not be promoted into substrate workflow state, routes, guards, or

--- a/.reinguard/scripts/adapter-rgd-next-resume.sh
+++ b/.reinguard/scripts/adapter-rgd-next-resume.sh
@@ -122,6 +122,19 @@ build_resume_context_json() {
   return 1
 }
 
+is_resumable_wait_state() {
+  # Resumable wait states per next-orchestration.md § Allowed stops and
+  # .reinguard/control/states/workflow.yaml. Keep in sync with that SSOT.
+  case "$1" in
+    waiting_ci|waiting_bot_rate_limited|waiting_bot_paused|waiting_bot_stale|waiting_bot_run|waiting_bot_failed)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 parse_resume_context_fields() {
   local raw="$1"
   python3 -c '
@@ -583,6 +596,28 @@ finish_cmd() {
   require_file "$ARTIFACT_PATH" "resume artifact is missing; start must run before finish" 2
   load_artifact
   ensure_artifact_branch_matches_current
+
+  # Resumable-wait guard (Issue #132, ADR-0015, next-orchestration.md § Allowed stops):
+  # allowed_stop with cannot_proceed or tooling_session_limit must not silently terminalize a
+  # resumable wait state. Only hard_stop is permitted for those conditions, and only with a
+  # genuinely unrecoverable external block. hard_stop, dod_satisfied, and scope_revoked do not
+  # need the fresh-observation check because they are not substitutes for a wait/retry procedure.
+  if [[ "$status" == "allowed_stop" && ( "$reason" == "cannot_proceed" || "$reason" == "tooling_session_limit" ) ]]; then
+    local fresh_context fresh_context_parse_error="" fresh_state_kind="" fresh_state_id=""
+    local fresh_route_kind="" fresh_route_id=""
+    local fresh_review_trigger_awaiting_ack="false" fresh_bot_review_trigger_awaiting_ack="false"
+    if ! fresh_context="$(build_resume_context_json)"; then
+      fail_with "finish refused: cannot verify resumable-wait guard — fresh 'rgd context build --compact' unavailable (see next-orchestration.md § Allowed stops). Run it successfully, or use --reason hard_stop with evidence of a genuinely unrecoverable external block." 2
+    fi
+    eval "$(parse_resume_context_fields "$fresh_context")"
+    if [[ -n "$fresh_context_parse_error" ]]; then
+      fail_with "finish refused: fresh 'rgd context build --compact' JSON could not be parsed ($fresh_context_parse_error); cannot verify resumable-wait guard. Re-run substrate observation, or use --reason hard_stop with evidence." 2
+    fi
+    if [[ "$fresh_state_kind" == "resolved" ]] && is_resumable_wait_state "$fresh_state_id"; then
+      fail_with "finish refused: fresh state_id '$fresh_state_id' is a resumable wait state (waiting_ci / waiting_bot_*); allowed_stop with reason '$reason' is forbidden for resumable waits (see next-orchestration.md § Allowed stops). Continue the mapped wait procedure (cooldown + re-trigger) and refresh context, or use --reason hard_stop with evidence of a genuinely unrecoverable external block." 2
+    fi
+  fi
+
   artifact_status="$status"
   artifact_terminal_reason="$reason"
   artifact_terminal_summary="$summary"

--- a/docs/adr/0015-adapter-local-execute-resume.md
+++ b/docs/adr/0015-adapter-local-execute-resume.md
@@ -88,7 +88,48 @@ orchestration state, not repository workflow position.
    enabled.
 6. Terminality remains evidence-based per `next-orchestration.md`. The
    artifact is a durable record of the Adapter contract, not an authority
-   that overrides procedure semantics.
+   that overrides procedure semantics. In particular, the Adapter-local
+   continuity contract **distinguishes temporary waits from terminal allowed
+   stops**:
+   - **Temporary / resumable wait states** — The **normative** FSM
+     `state_id` values are defined in
+     [`.reinguard/control/states/workflow.yaml`](../../.reinguard/control/states/workflow.yaml).
+     This ADR and `.reinguard/scripts/adapter-rgd-next-resume.sh` enumerate the
+     **wait/retry subset** aligned with that file: `waiting_ci`,
+     `waiting_bot_rate_limited`, `waiting_bot_paused`, `waiting_bot_stale`,
+     `waiting_bot_run`, `waiting_bot_failed`. If the control plane adds a new
+     wait `state_id`, update the control rules, the script guard, and this
+     Semantics text together (same-kind sweep) so the fail-closed check cannot
+     drift. Procedure docs
+     (`.reinguard/procedure/wait-bot-review.md`,
+     `.reinguard/knowledge/review--bot-operations.md`) explain **how** to
+     retry; they do not silently extend the script's guarded set. An
+     Adapter's `finish` subcommand MUST fail closed when a caller attempts to
+     record `allowed_stop` with reason `cannot_proceed` or
+     `tooling_session_limit` while fresh `rgd context build --compact` still
+     resolves to one of these states. `tooling_session_limit` is not a
+     substitute for repository-state terminality when current observation
+     still resolves to a wait/retry procedure. The terminal reason enum
+     (`dod_satisfied`, `hard_stop`, `cannot_proceed`, `tooling_session_limit`,
+     `scope_revoked`) is defined by the resume artifact schema in
+     `.reinguard/scripts/adapter-rgd-next-resume.sh` (see
+     `RESUME_SCHEMA_VERSION` and the script's `usage` section); the reference
+     implementation there enforces the resumable-wait guard by re-running
+     substrate observation at `finish` time.
+   - **Terminal allowed stops** — narrowed to **HS-*** hard stops
+     (procedural hard-stop invariants; SSOT in
+     [`.reinguard/policy/safety--agent-invariants.md`](../../.reinguard/policy/safety--agent-invariants.md))
+     and genuine unrecoverable external blocks (for example GitHub itself
+     unreachable, org-level enforcement that permanently blocks the required
+     bot). These are expressed as `allowed_stop` + `hard_stop` with
+     evidence.
+   - **Out of scope for this ADR revision:** introducing a new non-terminal
+     `suspended` / `resumable_wait` artifact status, and any substrate FSM
+     / observation contract changes owned by the Phase 2 substrate-alignment
+     epic ([#59](https://github.com/k-shibuki/reinguard/issues/59)). Resumable
+     waits remain `active` until the loop re-enters them or fresh observation
+     transitions them; this Adapter-local contract tightens only the stop
+     semantics, not artifact lifecycle states.
 7. The artifact is allowed to answer **what was approved** for adapter-local
    audit / resume decisions, but it must still not become substrate state.
    In particular, the approved contract is evidence for the Adapter only and

--- a/internal/scripttest/adapter_rgd_next_resume_script_test.go
+++ b/internal/scripttest/adapter_rgd_next_resume_script_test.go
@@ -152,7 +152,10 @@ func TestAdapterRgdNextResumeScript_Lifecycle(t *testing.T) {
 	if got.LastIteration.StateID != "waiting_ci" || got.LastIteration.RouteID != "user-wait-ci" {
 		t.Fatalf("last_iteration = %+v", got.LastIteration)
 	}
-	if got.Terminal.Reason != "tooling_session_limit" || got.Terminal.Summary != "context limit reached" {
+	// Issue #132: resumable wait states cannot be terminalized as cannot_proceed /
+	// tooling_session_limit; the lifecycle uses hard_stop with an unrecoverable
+	// external block as evidence.
+	if got.Terminal.Reason != "hard_stop" || got.Terminal.Summary != "github unreachable from runner" {
 		t.Fatalf("terminal = %+v", got.Terminal)
 	}
 	wantPath := filepath.Join(repo, ".reinguard", "local", "adapter", "rgd-next", "execute-resume.json")
@@ -809,6 +812,281 @@ func TestAdapterRgdNextResumeScript_FinishValidatesTerminalReason(t *testing.T) 
 	}
 }
 
+func TestAdapterRgdNextResumeScript_FinishForbidsTerminalStopOnResumableWait(t *testing.T) {
+	t.Parallel()
+
+	// Issue #132 / ADR-0015: allowed_stop with cannot_proceed or tooling_session_limit
+	// must fail closed when fresh `rgd context build --compact` still resolves to a
+	// resumable wait state (waiting_ci or waiting_bot_*). The field failure came from
+	// PR #128 where a rate-limited bot review was closed as allowed_stop/cannot_proceed.
+	tests := []struct {
+		name       string
+		state      string
+		route      string
+		reason     string
+		wantSubstr string
+	}{
+		{
+			name:       "waitingBotRateLimited_cannotProceed",
+			state:      "waiting_bot_rate_limited",
+			route:      "user-wait-bot-quota",
+			reason:     "cannot_proceed",
+			wantSubstr: "fresh state_id 'waiting_bot_rate_limited' is a resumable wait state",
+		},
+		{
+			name:       "waitingBotRateLimited_toolingSessionLimit",
+			state:      "waiting_bot_rate_limited",
+			route:      "user-wait-bot-quota",
+			reason:     "tooling_session_limit",
+			wantSubstr: "fresh state_id 'waiting_bot_rate_limited' is a resumable wait state",
+		},
+		{
+			name:       "waitingCI_cannotProceed",
+			state:      "waiting_ci",
+			route:      "user-wait-ci",
+			reason:     "cannot_proceed",
+			wantSubstr: "fresh state_id 'waiting_ci' is a resumable wait state",
+		},
+		{
+			name:       "waitingCI_toolingSessionLimit",
+			state:      "waiting_ci",
+			route:      "user-wait-ci",
+			reason:     "tooling_session_limit",
+			wantSubstr: "fresh state_id 'waiting_ci' is a resumable wait state",
+		},
+		{
+			name:       "waitingBotPaused_cannotProceed",
+			state:      "waiting_bot_paused",
+			route:      "user-wait-bot-paused",
+			reason:     "cannot_proceed",
+			wantSubstr: "fresh state_id 'waiting_bot_paused' is a resumable wait state",
+		},
+		{
+			name:       "waitingBotPaused_toolingSessionLimit",
+			state:      "waiting_bot_paused",
+			route:      "user-wait-bot-paused",
+			reason:     "tooling_session_limit",
+			wantSubstr: "fresh state_id 'waiting_bot_paused' is a resumable wait state",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			script := scriptPath(t, "adapter-rgd-next-resume.sh")
+			repo := setupLocalReviewRepo(t)
+			renameBranch(t, repo, "feature/132")
+
+			// Given: an approved Execute run on a resumable wait branch
+			startOut, err := runBashScript(t, repo, script, nil,
+				"start",
+				"--branch", "feature/132",
+				"--issue", "132",
+				"--state-id", "working_no_pr",
+				"--route-id", "user-implement",
+				"--ordered-remainder", "implement -> change-inspect -> pr-create",
+				"--completion-condition", "Per-unit Definition of Done",
+			)
+			if err != nil {
+				t.Fatalf("start: %v\n%s", err, startOut)
+			}
+			approveOut, err := runBashScript(t, repo, script, nil, "approve")
+			if err != nil {
+				t.Fatalf("approve: %v\n%s", err, approveOut)
+			}
+
+			// When: finish is attempted as allowed_stop / resumable-wait reason while fresh
+			// observation still reports a resumable wait state
+			finishEnv := resumeStatusEnv(t, repo, tt.state, tt.route, false, false)
+			finishOut, err := runBashScript(t, repo, script, finishEnv,
+				"finish",
+				"--status", "allowed_stop",
+				"--reason", tt.reason,
+				"--summary", "attempted terminalization",
+			)
+
+			// Then: the adapter contract refuses fail-closed and names the resumable wait
+			if err == nil {
+				t.Fatalf("expected fail-closed finish, got success:\n%s", finishOut)
+			}
+			if !strings.Contains(finishOut, tt.wantSubstr) {
+				t.Fatalf("expected refusal to mention %q, got:\n%s", tt.wantSubstr, finishOut)
+			}
+			if !strings.Contains(finishOut, "--reason hard_stop") {
+				t.Fatalf("expected refusal to reference hard_stop escape hatch, got:\n%s", finishOut)
+			}
+		})
+	}
+}
+
+func TestAdapterRgdNextResumeScript_FinishAllowsHardStopOnResumableWait(t *testing.T) {
+	t.Parallel()
+
+	// Issue #132: hard_stop is preserved for genuinely unrecoverable external blocks,
+	// including when the current resolved state is a resumable wait.
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/132")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/132",
+		"--issue", "132",
+		"--state-id", "working_no_pr",
+		"--route-id", "user-implement",
+		"--ordered-remainder", "implement -> change-inspect -> pr-create",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	finishEnv := resumeStatusEnv(t, repo, "waiting_bot_rate_limited", "user-wait-bot-quota", false, false)
+	finishOut, err := runBashScript(t, repo, script, finishEnv,
+		"finish",
+		"--status", "allowed_stop",
+		"--reason", "hard_stop",
+		"--summary", "github unreachable from runner",
+	)
+	if err != nil {
+		t.Fatalf("finish hard_stop: %v\n%s", err, finishOut)
+	}
+
+	var artifact map[string]any
+	unmarshalJSON(t, finishOut, &artifact)
+	if status, _ := artifact["status"].(string); status != "allowed_stop" {
+		t.Fatalf("status = %q, want allowed_stop", status)
+	}
+	terminal, ok := artifact["terminal"].(map[string]any)
+	if !ok {
+		t.Fatalf("terminal missing: %+v", artifact)
+	}
+	if reason, _ := terminal["reason"].(string); reason != "hard_stop" {
+		t.Fatalf("terminal.reason = %q, want hard_stop", reason)
+	}
+}
+
+func TestAdapterRgdNextResumeScript_FinishAllowsAllowedStopReasonsOnNonWaitState(t *testing.T) {
+	t.Parallel()
+
+	// Issue #132: for non-wait FSM states, both cannot_proceed and tooling_session_limit
+	// may still close the artifact; the resumable-wait guard only applies when fresh
+	// observation resolves to waiting_ci / waiting_bot_*.
+	tests := []struct {
+		name   string
+		state  string
+		route  string
+		reason string
+	}{
+		{name: "workingNoPR_cannotProceed", state: "working_no_pr", route: "user-implement", reason: "cannot_proceed"},
+		{name: "workingNoPR_toolingSessionLimit", state: "working_no_pr", route: "user-implement", reason: "tooling_session_limit"},
+		{name: "unresolvedThreads_cannotProceed", state: "unresolved_threads", route: "user-address-review", reason: "cannot_proceed"},
+		{name: "mergeReady_cannotProceed", state: "merge_ready", route: "user-pr-merge", reason: "cannot_proceed"},
+		{name: "mergeReady_toolingSessionLimit", state: "merge_ready", route: "user-pr-merge", reason: "tooling_session_limit"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			script := scriptPath(t, "adapter-rgd-next-resume.sh")
+			repo := setupLocalReviewRepo(t)
+			renameBranch(t, repo, "feature/132")
+
+			startOut, err := runBashScript(t, repo, script, nil,
+				"start",
+				"--branch", "feature/132",
+				"--issue", "132",
+				"--state-id", "working_no_pr",
+				"--route-id", "user-implement",
+				"--ordered-remainder", "implement -> change-inspect -> pr-create",
+				"--completion-condition", "Per-unit Definition of Done",
+			)
+			if err != nil {
+				t.Fatalf("start: %v\n%s", err, startOut)
+			}
+			approveOut, err := runBashScript(t, repo, script, nil, "approve")
+			if err != nil {
+				t.Fatalf("approve: %v\n%s", err, approveOut)
+			}
+
+			finishEnv := resumeStatusEnv(t, repo, tt.state, tt.route, false, false)
+			finishOut, err := runBashScript(t, repo, script, finishEnv,
+				"finish",
+				"--status", "allowed_stop",
+				"--reason", tt.reason,
+				"--summary", "external credential revoked",
+			)
+			if err != nil {
+				t.Fatalf("finish %s on %s: %v\n%s", tt.reason, tt.state, err, finishOut)
+			}
+
+			var artifact map[string]any
+			unmarshalJSON(t, finishOut, &artifact)
+			terminal, ok := artifact["terminal"].(map[string]any)
+			if !ok {
+				t.Fatalf("terminal missing: %+v", artifact)
+			}
+			if got, _ := terminal["reason"].(string); got != tt.reason {
+				t.Fatalf("terminal.reason = %q, want %q", got, tt.reason)
+			}
+		})
+	}
+}
+
+func TestAdapterRgdNextResumeScript_FinishFailsClosedWhenFreshContextUnavailable(t *testing.T) {
+	t.Parallel()
+
+	// Issue #132: without fresh observation the resumable-wait guard cannot be verified;
+	// allowed_stop with cannot_proceed / tooling_session_limit must fail closed rather than
+	// silently bless the terminalization.
+	script := scriptPath(t, "adapter-rgd-next-resume.sh")
+	repo := setupLocalReviewRepo(t)
+	renameBranch(t, repo, "feature/132")
+
+	startOut, err := runBashScript(t, repo, script, nil,
+		"start",
+		"--branch", "feature/132",
+		"--issue", "132",
+		"--state-id", "working_no_pr",
+		"--route-id", "user-implement",
+		"--ordered-remainder", "implement -> change-inspect -> pr-create",
+		"--completion-condition", "Per-unit Definition of Done",
+	)
+	if err != nil {
+		t.Fatalf("start: %v\n%s", err, startOut)
+	}
+	approveOut, err := runBashScript(t, repo, script, nil, "approve")
+	if err != nil {
+		t.Fatalf("approve: %v\n%s", err, approveOut)
+	}
+
+	// No REINGUARD_RGD_NEXT_CONTEXT_BUILD_FILE override and the minimal test repo has no
+	// cmd/rgd/main.go, so build_resume_context_json fails -> guard must fail closed.
+	finishOut, err := runBashScript(t, repo, script, nil,
+		"finish",
+		"--status", "allowed_stop",
+		"--reason", "cannot_proceed",
+		"--summary", "unverifiable block",
+	)
+	if err == nil {
+		t.Fatalf("expected fail-closed finish without fresh context, got success:\n%s", finishOut)
+	}
+	if !strings.Contains(finishOut, "fresh 'rgd context build --compact' unavailable") {
+		t.Fatalf("expected refusal to reference unavailable fresh context, got:\n%s", finishOut)
+	}
+	if !strings.Contains(finishOut, "--reason hard_stop") {
+		t.Fatalf("expected refusal to reference hard_stop escape hatch, got:\n%s", finishOut)
+	}
+}
+
 func runResumeLifecycleStatus(t *testing.T, repo, script string) resumeScriptStatus {
 	t.Helper()
 
@@ -828,8 +1106,8 @@ func runResumeLifecycleStatus(t *testing.T, repo, script string) resumeScriptSta
 	finishOut, err := runBashScript(t, repo, script, nil,
 		"finish",
 		"--status", "allowed_stop",
-		"--reason", "tooling_session_limit",
-		"--summary", "context limit reached",
+		"--reason", "hard_stop",
+		"--summary", "github unreachable from runner",
 	)
 	if err != nil {
 		t.Fatalf("finish: %v\n%s", err, finishOut)


### PR DESCRIPTION
## Summary

- Tighten `rgd-next` Execute **allowed_stop** contract: `waiting_ci` and `waiting_bot_*` (resumable retry paths) must not be closed as `allowed_stop` with `cannot_proceed` or `tooling_session_limit`; `adapter-rgd-next-resume.sh finish` enforces this fail-closed using fresh `rgd context build --compact`.
- Semantics: `.reinguard/procedure/next-orchestration.md`, ADR-0015, thin pointer in `.cursor/commands/rgd-next.md`; regression tests in `adapter_rgd_next_resume_script_test.go`.

## Traceability

Closes #132

Refs: #124

Refs: #133

## Definition of Done

- [x] Tests added or updated (`go test ./... -race`)
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. `bash .reinguard/scripts/with-repo-local-state.sh -- go test ./... -race`
2. `go run ./cmd/rgd config validate`
3. `bash -n .reinguard/scripts/adapter-rgd-next-resume.sh`

## Risk / Impact

- Adapter-local resume artifact `finish` behavior: calls that tried to terminalize resumable waits with `cannot_proceed` / `tooling_session_limit` now fail with exit code 2 and must use `hard_stop` with evidence or continue the wait procedure.

## Rollback Plan

- Revert this PR; restore previous `finish_cmd` and procedure/ADR text if needed.

## Note

Local CodeRabbit CLI (`check-local-review.sh`) may hit org rate limits; PR-side review is the primary path for this change.