### PR TITLE
feat(cli): add --trace-rules flag for rule-level resolution trace

### DIFF
--- a/cmd/rgd/main_test.go
+++ b/cmd/rgd/main_test.go
@@ -223,6 +223,47 @@ rules:
 	}
 }
 
+func TestCLIStateEval_traceRulesWithFailOnNonResolved_keepsTraceOnStdout(t *testing.T) {
+	t.Parallel()
+
+	// Given: ambiguous state rules so --fail-on-non-resolved trips, plus --trace-rules
+	cfgDir := t.TempDir()
+	writeTestFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte("schema_version: \"0.8.0\"\ndefault_branch: main\nproviders: []\n"))
+	writeTestFile(t, filepath.Join(cfgDir, "control", "states", "rules.yaml"), []byte(`schema_version: "0.8.0"
+rules:
+  - type: state
+    id: a
+    priority: 1
+    state_id: A
+    when: {op: eq, path: git.branch, value: feat}
+  - type: state
+    id: b
+    priority: 1
+    state_id: B
+    when: {op: eq, path: git.branch, value: feat}
+`))
+	obsPath := filepath.Join(t.TempDir(), "observation.json")
+	writeTestFile(t, obsPath, []byte(`{"schema_version":"0.8.0","signals":{"git":{"branch":"feat"}},"degraded":false}`))
+
+	// When: state eval runs with both --trace-rules and --fail-on-non-resolved
+	stdout, stderr, exitCode := runRGDBinary(t, "state", "eval", "--config-dir", cfgDir, "--observation-file", obsPath, "--trace-rules", "--fail-on-non-resolved")
+	// Then: exit code is 2 and stdout JSON still includes rule_trace alongside ambiguous kind
+	if exitCode != 2 {
+		t.Fatalf("expected exit 2, got %d stderr=%q", exitCode, stderr)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("invalid JSON: %v raw=%s", err, stdout)
+	}
+	if out["kind"] != "ambiguous" {
+		t.Fatalf("expected ambiguous kind, got %v", out["kind"])
+	}
+	traceAny, ok := out["rule_trace"].([]any)
+	if !ok || len(traceAny) != 2 {
+		t.Fatalf("expected 2 rule_trace entries, got %v", out["rule_trace"])
+	}
+}
+
 func TestCLIGateRecord_checksFileFromStdin(t *testing.T) {
 	t.Parallel()
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -436,6 +436,8 @@ Evaluates `type: route` rules using:
   `2` when `kind` is `ambiguous`, `degraded`, or `unsupported`.
 - `--trace-rules` adds an optional `rule_trace[]` array to the JSON output
   recording every evaluated `type: route` rule (see [Rule trace](#rule-trace)).
+  Composes with `--fail-on-non-resolved`: stdout still includes `rule_trace`
+  before the non-zero exit.
 
 ### Output
 
@@ -664,6 +666,8 @@ guard steps use that flat map; they do not see route/guard outcomes inside
   used to derive `routes[0]`). Each `rule_trace[]` is scoped to its own
   `rule_type`; guard-rule traces are out of scope for this flag (use the
   matching `rgd state eval` / `rgd route select` invocations for finer scope).
+  Composes with `--fail-on-non-resolved`: stdout still includes
+  `state.rule_trace` and `routes[0].rule_trace` before the non-zero exit.
   See [Rule trace](#rule-trace).
 
 The `knowledge` object in the output has **`entries`** (same shape as

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,7 @@ body or README.
 | `-o`, `--output` | — | Reserved for future file output (optional) |
 | `--serial` | — | Run observation providers sequentially (default: parallel) |
 | `--fail-on-non-resolved` | — | Exit code `2` when a supported evaluation outcome is `ambiguous`, `degraded`, or `unsupported` |
+| `--trace-rules` | — | (`state eval`, `route select`, `context build`) include a rule-level evaluation trace (`rule_trace[]`) in the JSON output. Default off; default output is unchanged. |
 
 With **urfave/cli v2**, place flags that must apply to a **nested** subcommand
 **after** the subcommand name (e.g. `rgd state eval --config-dir DIR`), not only
@@ -372,6 +373,10 @@ Committed workflow `state_id` priorities for this repository are documented in *
   the evaluation signal map as `gates.<gate-id>.*` before state resolution.
 - `--fail-on-non-resolved` writes the normal JSON result to stdout, then exits
   `2` when `kind` is `ambiguous`, `degraded`, or `unsupported`.
+- `--trace-rules` adds an optional `rule_trace[]` array to the JSON output
+  recording every evaluated `type: state` rule (see [Rule trace](#rule-trace)).
+  Composes with `--fail-on-non-resolved`: stdout still includes `rule_trace`
+  before the non-zero exit.
 
 ### Output
 
@@ -386,8 +391,36 @@ JSON object:
 | `reason` | Human-readable summary when not `resolved`, or details for `unsupported` |
 | `missing_evidence` | Present for `unsupported`: machine-oriented tags (e.g. `when_evaluation`, `rule_id:…`) |
 | `re_entry_hint` | Present for `unsupported`: what to do next (re-entry contract per ADR-0007) |
+| `rule_trace` | **Only with `--trace-rules`.** Array of evaluated state rules; see [Rule trace](#rule-trace). |
 
 **`degraded` vs `unsupported`:** `degraded` means evaluation ran but no trustworthy winner (no match, all suppressed by `depends_on`, etc.). `unsupported` means the substrate refused to interpret inputs safely (invalid `when` shape, wrong `rule_type` to `Resolve`, or a winning rule missing `state_id` / `route_id`).
+
+### Rule trace
+
+The optional `rule_trace[]` array is populated only when `--trace-rules` is set
+on `rgd state eval`, `rgd route select`, or `rgd context build`. It records
+**rule-level** evaluation outcomes (one entry per evaluated rule of the
+relevant `rule_type`, in evaluation order). It is intentionally **not** an
+expression-level trace of the `when` AST.
+
+Each entry has the following fields (see
+`pkg/schema/operational-context.json` `resolutionResult.rule_trace`):
+
+| Field | Description |
+|-------|-------------|
+| `rule_id` | Rule id from configuration. |
+| `rule_type` | `state` \| `route` \| `guard`. Always equal to the resolution scope; e.g. `rgd state eval --trace-rules` only emits `state` entries. |
+| `priority` | Numeric priority of the rule. |
+| `target_id` | The `state_id` (state rules), `route_id` (route rules), or `guard_id` (guard rules) declared on the rule. |
+| `matched` | `true` when the rule's `when` evaluated to true for the supplied signals; `false` otherwise. |
+| `suppressed` | Optional. `true` when the rule matched but was suppressed by a `depends_on` chain (omitted when false). |
+| `suppressed_by` | Optional. Rule ids that caused this rule to be suppressed via `depends_on` (omitted when empty). |
+
+Default output (without `--trace-rules`) is unchanged: `rule_trace` is omitted
+from stdout. Out-of-scope for this flag: per-expression match diagnostics, AST
+traces, and guard-rule traces inside `rgd context build` — those remain
+available only via direct `rgd guard eval` / `rgd state eval` / `rgd route select`
+invocations.
 
 ## `rgd route select`
 
@@ -401,10 +434,12 @@ Evaluates `type: route` rules using:
   `gates.<gate-id>.*` before route evaluation)
 - `--fail-on-non-resolved` writes the normal JSON result to stdout, then exits
   `2` when `kind` is `ambiguous`, `degraded`, or `unsupported`.
+- `--trace-rules` adds an optional `rule_trace[]` array to the JSON output
+  recording every evaluated `type: route` rule (see [Rule trace](#rule-trace)).
 
 ### Output
 
-Same shape as state eval with `route_id` instead of `state_id` when resolved, including `unsupported` and handoff fields.
+Same shape as state eval with `route_id` instead of `state_id` when resolved, including `unsupported` and handoff fields. With `--trace-rules`, the optional `rule_trace[]` array is included as documented in [Rule trace](#rule-trace).
 
 `route_candidates` is always present when at least one matching route rule has a
 non-empty `route_id` after `depends_on` suppression. It lists **all** such
@@ -623,6 +658,13 @@ guard steps use that flat map; they do not see route/guard outcomes inside
 - **`--fail-on-non-resolved`**: writes the operational-context JSON to stdout,
   then exits `2` when either the embedded `state` result or `routes[0]` result
   is `ambiguous`, `degraded`, or `unsupported`.
+- **`--trace-rules`**: include the rule-level evaluation trace in the
+  operational-context JSON. Adds `state.rule_trace[]` (state-rule evaluations
+  used to derive `state`) and `routes[0].rule_trace[]` (route-rule evaluations
+  used to derive `routes[0]`). Each `rule_trace[]` is scoped to its own
+  `rule_type`; guard-rule traces are out of scope for this flag (use the
+  matching `rgd state eval` / `rgd route select` invocations for finer scope).
+  See [Rule trace](#rule-trace).
 
 The `knowledge` object in the output has **`entries`** (same shape as
 `rgd knowledge pack` stdout), not `paths` (ADR-0010).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -409,7 +409,7 @@ Each entry has the following fields (see
 | Field | Description |
 |-------|-------------|
 | `rule_id` | Rule id from configuration. |
-| `rule_type` | `state` \| `route` \| `guard`. Always equal to the resolution scope; e.g. `rgd state eval --trace-rules` only emits `state` entries. |
+| `rule_type` | `state` \| `route`. Always equal to the resolution scope; e.g. `rgd state eval --trace-rules` only emits `state` entries. The schema reserves `guard` for the substrate-level `ResolveGuardTrace` API; `--trace-rules` itself never emits guard entries (out-of-scope note below). |
 | `priority` | Numeric priority of the rule. |
 | `target_id` | The `state_id` (state rules), `route_id` (route rules), or `guard_id` (guard rules) declared on the rule. |
 | `matched` | `true` when the rule's `when` evaluated to true for the supplied signals; `false` otherwise. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -418,9 +418,10 @@ Each entry has the following fields (see
 
 Default output (without `--trace-rules`) is unchanged: `rule_trace` is omitted
 from stdout. Out-of-scope for this flag: per-expression match diagnostics, AST
-traces, and guard-rule traces inside `rgd context build` — those remain
-available only via direct `rgd guard eval` / `rgd state eval` / `rgd route select`
-invocations.
+traces, and guard-rule traces — `--trace-rules` emits only `state` / `route`
+rule traces. Guard-rule tracing is not exposed by any current `rgd` CLI command
+or output; the substrate keeps `ResolveGuardTrace` as an internal API for
+future use.
 
 ## `rgd route select`
 

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -48,14 +48,17 @@ const (
 
 // Result is the outcome of resolving among matching rules of one type.
 type Result struct {
-	Kind            OutcomeKind      `json:"kind"`
-	StateID         string           `json:"state_id,omitempty"`
-	RouteID         string           `json:"route_id,omitempty"`
-	GuardID         string           `json:"guard_id,omitempty"`
-	TargetID        string           `json:"target_id,omitempty"`
-	RuleID          string           `json:"rule_id,omitempty"`
-	Reason          string           `json:"reason,omitempty"`
-	ReEntryHint     string           `json:"re_entry_hint,omitempty"`
+	Kind        OutcomeKind `json:"kind"`
+	StateID     string      `json:"state_id,omitempty"`
+	RouteID     string      `json:"route_id,omitempty"`
+	GuardID     string      `json:"guard_id,omitempty"`
+	TargetID    string      `json:"target_id,omitempty"`
+	RuleID      string      `json:"rule_id,omitempty"`
+	Reason      string      `json:"reason,omitempty"`
+	ReEntryHint string      `json:"re_entry_hint,omitempty"`
+	// RuleTrace is the optional rule-level evaluation trace; populated only by *Trace
+	// entry points so default Result JSON stays unchanged. See RuleTrace.
+	RuleTrace       []RuleTrace      `json:"rule_trace,omitempty"`
 	Candidates      []string         `json:"candidates,omitempty"`
 	RouteCandidates []RouteCandidate `json:"route_candidates,omitempty"`
 	MissingEvidence []string         `json:"missing_evidence,omitempty"`
@@ -67,6 +70,27 @@ type RouteCandidate struct {
 	RuleID   string  `json:"rule_id"`
 	RouteID  string  `json:"route_id"`
 	Priority float64 `json:"priority"`
+}
+
+// RuleTrace is one rule-level entry in an optional resolution trace (Issue #143). It records
+// rule_id, rule_type, priority, target_id (state_id / route_id / guard_id depending on rule_type),
+// whether the rule's when-clause matched, and dependency suppression for matched rules.
+//
+// Trace entries are recorded for every rule of the requested type that the resolver evaluated,
+// in evaluation order. They do not include the "and" / "or" / "any" / "all" sub-clauses of
+// match expressions; rule_trace is intentionally rule-level only (no expression-level tracing).
+//
+// Suppressed and SuppressedBy are populated only for rules whose when-clause matched but whose
+// declared depends_on entries include at least one degraded provider. SuppressedBy lists the
+// degraded provider IDs that caused the suppression.
+type RuleTrace struct {
+	RuleID       string   `json:"rule_id"`
+	RuleType     string   `json:"rule_type"`
+	TargetID     string   `json:"target_id"`
+	SuppressedBy []string `json:"suppressed_by,omitempty"`
+	Priority     float64  `json:"priority"`
+	Matched      bool     `json:"matched"`
+	Suppressed   bool     `json:"suppressed,omitempty"`
 }
 
 // StateRules filters rules to type state.
@@ -180,23 +204,61 @@ func unsupportedMissingGuardID(ruleID string) Result {
 // OutcomeUnsupported (ADR-0007) with Reason and optional handoff fields.
 //
 // For ruleType "guard", rules must share one logical guard_id (or use [ResolveGuard], which filters).
+//
+// Resolve never populates Result.RuleTrace; use [ResolveTrace] when callers need a rule-level
+// evaluation trace (Issue #143). Resolve and ResolveTrace agree on every other field.
 func Resolve(rules []config.Rule, signals map[string]any, degraded map[string]struct{}, ruleType string) (Result, error) {
+	return resolveCore(rules, signals, degraded, ruleType, false)
+}
+
+// ResolveTrace is the trace-aware variant of [Resolve]: in addition to the standard Result fields,
+// it populates Result.RuleTrace with one entry per evaluated rule of the requested type, in
+// evaluation order, including non-matching rules and matched-but-suppressed rules.
+//
+// Trace coverage matches [Resolve]'s evaluation: rules whose when-clause panics with an evaluation
+// error stop the walk and are reported as OutcomeUnsupported (the failing rule appears in
+// Result.Reason / Result.MissingEvidence). Rules evaluated before that point still appear in
+// Result.RuleTrace; the failing rule itself is not appended because evaluation never finished.
+func ResolveTrace(rules []config.Rule, signals map[string]any, degraded map[string]struct{}, ruleType string) (Result, error) {
+	return resolveCore(rules, signals, degraded, ruleType, true)
+}
+
+func resolveCore(rules []config.Rule, signals map[string]any, degraded map[string]struct{}, ruleType string, withTrace bool) (Result, error) {
 	p, err := profileForRuleType(ruleType)
 	if err != nil {
 		return unsupportedRuleType(ruleType, err.Error()), nil
 	}
-	candidates, err := matchingRules(filterType(rules, p.ruleType), signals)
-	if err != nil {
-		return unsupportedMatchError(err), nil
+	evals, evalErr := evaluateRules(filterType(rules, p.ruleType), signals, degraded)
+	if evalErr != nil {
+		res := unsupportedMatchError(evalErr)
+		if withTrace {
+			res.RuleTrace = traceFromEvals(evals)
+		}
+		return res, nil
 	}
-	if len(candidates) == 0 {
-		return Result{Kind: OutcomeDegraded, Reason: p.noMatchReason}, nil
+	candidates, active := splitMatchedRules(evals)
+	res := selectFromActive(p, candidates, active)
+	if withTrace {
+		res.RuleTrace = traceFromEvals(evals)
 	}
-	active := suppressDependsOn(candidates, degraded)
-	if len(active) == 0 {
-		return Result{Kind: OutcomeDegraded, Reason: p.allSuppressedReason}, nil
-	}
+	return res, nil
+}
 
+// ruleEval captures one rule's evaluation outcome so the same data can drive both selection and
+// optional rule-level tracing without re-walking match.Eval.
+type ruleEval struct {
+	suppressedBy []string
+	rule         config.Rule
+	matched      bool
+}
+
+func selectFromActive(p resolveProfile, candidates, active []config.Rule) Result {
+	if len(candidates) == 0 {
+		return Result{Kind: OutcomeDegraded, Reason: p.noMatchReason}
+	}
+	if len(active) == 0 {
+		return Result{Kind: OutcomeDegraded, Reason: p.allSuppressedReason}
+	}
 	ordered, routeCandidates := orderRulesForResolve(active, p.routeStyle)
 	best := minPriority(ordered)
 	var atBest []config.Rule
@@ -206,9 +268,9 @@ func Resolve(rules []config.Rule, signals map[string]any, degraded map[string]st
 		}
 	}
 	if len(atBest) > 1 {
-		return ambiguousResolveResult(best, atBest, p, routeCandidates), nil
+		return ambiguousResolveResult(best, atBest, p, routeCandidates)
 	}
-	return singleRuleResolveResult(atBest[0], p, routeCandidates), nil
+	return singleRuleResolveResult(atBest[0], p, routeCandidates)
 }
 
 // orderRulesForResolve returns rules in evaluation order; for routes, copies, sorts, and builds routeCandidates.
@@ -308,56 +370,120 @@ func ResolveState(rules []config.Rule, signals map[string]any, degraded map[stri
 	return Resolve(rules, signals, degraded, "state")
 }
 
+// ResolveStateTrace is the trace-aware variant of [ResolveState] (Issue #143).
+func ResolveStateTrace(rules []config.Rule, signals map[string]any, degraded map[string]struct{}) (Result, error) {
+	return ResolveTrace(rules, signals, degraded, "state")
+}
+
 // ResolveRoute selects route rules with the same priority and depends_on semantics as state rules.
 func ResolveRoute(rules []config.Rule, signals map[string]any, degraded map[string]struct{}) (Result, error) {
 	return Resolve(rules, signals, degraded, "route")
+}
+
+// ResolveRouteTrace is the trace-aware variant of [ResolveRoute] (Issue #143).
+func ResolveRouteTrace(rules []config.Rule, signals map[string]any, degraded map[string]struct{}) (Result, error) {
+	return ResolveTrace(rules, signals, degraded, "route")
 }
 
 // ResolveGuard selects among guard rules that declare the given guard_id using the same priority
 // and depends_on semantics as ResolveState (ADR-0004). It is the supported entry point for guard
 // resolution; callers should not mix multiple guard_id values in one Resolve(..., "guard") call.
 func ResolveGuard(rules []config.Rule, signals map[string]any, degraded map[string]struct{}, guardID string) (Result, error) {
+	return Resolve(scopeGuardRules(rules, guardID), signals, degraded, "guard")
+}
+
+// ResolveGuardTrace is the trace-aware variant of [ResolveGuard] (Issue #143). The trace covers
+// only rules scoped to guardID; rules with a different guard_id are filtered before evaluation
+// and never appear in Result.RuleTrace.
+func ResolveGuardTrace(rules []config.Rule, signals map[string]any, degraded map[string]struct{}, guardID string) (Result, error) {
+	return ResolveTrace(scopeGuardRules(rules, guardID), signals, degraded, "guard")
+}
+
+func scopeGuardRules(rules []config.Rule, guardID string) []config.Rule {
 	var scoped []config.Rule
 	for _, r := range rules {
 		if r.Type == "guard" && r.GuardID == guardID {
 			scoped = append(scoped, r)
 		}
 	}
-	return Resolve(scoped, signals, degraded, "guard")
+	return scoped
 }
 
-func matchingRules(rules []config.Rule, signals map[string]any) ([]config.Rule, error) {
-	var out []config.Rule
+// evaluateRules walks the typed rule slice once, recording match.Eval outcome and depends_on
+// suppression per rule. The first match.Eval failure aborts the walk and returns the rules
+// evaluated so far together with the wrapped error.
+func evaluateRules(rules []config.Rule, signals map[string]any, degraded map[string]struct{}) ([]ruleEval, error) {
+	out := make([]ruleEval, 0, len(rules))
 	for _, r := range rules {
 		ok, err := match.Eval(r.When, signals)
 		if err != nil {
-			return nil, fmt.Errorf("rule %s: %w", r.ID, err)
+			return out, fmt.Errorf("rule %s: %w", r.ID, err)
 		}
-		if ok {
-			out = append(out, r)
+		re := ruleEval{rule: r, matched: ok}
+		if ok && len(degraded) > 0 {
+			for _, d := range r.DependsOn {
+				if _, isDeg := degraded[d]; isDeg {
+					re.suppressedBy = append(re.suppressedBy, d)
+				}
+			}
 		}
+		out = append(out, re)
 	}
 	return out, nil
 }
 
-func suppressDependsOn(rules []config.Rule, degraded map[string]struct{}) []config.Rule {
-	if len(degraded) == 0 {
-		return rules
+// splitMatchedRules separates evaluated rules into (matched, matched-and-not-suppressed) preserving
+// the original evaluation order.
+func splitMatchedRules(evals []ruleEval) (candidates, active []config.Rule) {
+	for _, e := range evals {
+		if !e.matched {
+			continue
+		}
+		candidates = append(candidates, e.rule)
+		if len(e.suppressedBy) == 0 {
+			active = append(active, e.rule)
+		}
 	}
-	var out []config.Rule
-	for _, r := range rules {
-		skip := false
-		for _, d := range r.DependsOn {
-			if _, ok := degraded[d]; ok {
-				skip = true
-				break
-			}
+	return candidates, active
+}
+
+// traceFromEvals projects ruleEval entries into the public RuleTrace shape. Suppressed and
+// SuppressedBy are populated only for matched rules with degraded dependencies.
+func traceFromEvals(evals []ruleEval) []RuleTrace {
+	if len(evals) == 0 {
+		return nil
+	}
+	out := make([]RuleTrace, 0, len(evals))
+	for _, e := range evals {
+		entry := RuleTrace{
+			RuleID:   e.rule.ID,
+			RuleType: e.rule.Type,
+			Priority: e.rule.Priority,
+			TargetID: ruleTargetID(e.rule),
+			Matched:  e.matched,
 		}
-		if !skip {
-			out = append(out, r)
+		if len(e.suppressedBy) > 0 {
+			entry.Suppressed = true
+			entry.SuppressedBy = append([]string(nil), e.suppressedBy...)
 		}
+		out = append(out, entry)
 	}
 	return out
+}
+
+// ruleTargetID returns the rule's logical target identifier (state_id / route_id / guard_id) per
+// rule type. Empty strings are preserved so callers can distinguish "no target" from "missing".
+func ruleTargetID(r config.Rule) string {
+	switch r.Type {
+	case "state":
+		return r.StateID
+	case "route":
+		return r.RouteID
+	case "guard":
+		return r.GuardID
+	default:
+		return ""
+	}
 }
 
 // NearlyEqual reports floating-point equality for duplicate-priority warnings (ADR-0004).

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -500,3 +500,206 @@ func TestDuplicatePriorityWarnings_crossKindOnly(t *testing.T) {
 		t.Fatalf("%v", w)
 	}
 }
+
+func TestResolve_doesNotPopulateRuleTrace(t *testing.T) {
+	t.Parallel()
+	// Given: one matching state rule and one non-matching state rule
+	// When: Resolve runs (without trace)
+	rules := []config.Rule{
+		{Type: "state", ID: "miss", Priority: 30, StateID: "M", When: map[string]any{"op": "eq", "path": "x", "value": 0}},
+		{Type: "state", ID: "hit", Priority: 10, StateID: "H", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+	}
+	res, err := Resolve(rules, map[string]any{"x": 1}, nil, "state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Then: default Resolve never populates RuleTrace (back-compat boundary for Issue #143)
+	if res.RuleTrace != nil {
+		t.Fatalf("default Resolve must not populate RuleTrace, got %+v", res.RuleTrace)
+	}
+}
+
+func TestResolveStateTrace_includesNonMatchingAndMatchingRules(t *testing.T) {
+	t.Parallel()
+	// Given: two matching state rules at different priorities and one non-matching rule
+	rules := []config.Rule{
+		{Type: "state", ID: "low", Priority: 10, StateID: "Low", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+		{Type: "state", ID: "high", Priority: 30, StateID: "High", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+		{Type: "state", ID: "off", Priority: 5, StateID: "Off", When: map[string]any{"op": "eq", "path": "x", "value": 0}},
+	}
+	// When: ResolveStateTrace runs against signals where "off" is non-matching
+	res, err := ResolveStateTrace(rules, map[string]any{"x": 1}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Then: lower-priority "low" wins; trace lists every state rule in evaluation order with matched flags.
+	if res.Kind != OutcomeResolved || res.RuleID != "low" || res.StateID != "Low" {
+		t.Fatalf("winner: %+v", res)
+	}
+	want := []RuleTrace{
+		{RuleID: "low", RuleType: "state", Priority: 10, TargetID: "Low", Matched: true},
+		{RuleID: "high", RuleType: "state", Priority: 30, TargetID: "High", Matched: true},
+		{RuleID: "off", RuleType: "state", Priority: 5, TargetID: "Off", Matched: false},
+	}
+	if !reflect.DeepEqual(res.RuleTrace, want) {
+		t.Fatalf("rule_trace mismatch:\n got:  %+v\n want: %+v", res.RuleTrace, want)
+	}
+}
+
+func TestResolveStateTrace_ambiguousIncludesAllTiedRules(t *testing.T) {
+	t.Parallel()
+	// Given: two matching state rules at the same best priority
+	rules := []config.Rule{
+		{Type: "state", ID: "a", Priority: 10, StateID: "A", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+		{Type: "state", ID: "b", Priority: 10, StateID: "B", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+	}
+	// When: ResolveStateTrace runs
+	res, err := ResolveStateTrace(rules, map[string]any{"x": 1}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Then: ambiguous outcome; both rules appear in trace as matched without suppression
+	if res.Kind != OutcomeAmbiguous {
+		t.Fatalf("kind: %+v", res)
+	}
+	if len(res.RuleTrace) != 2 {
+		t.Fatalf("trace len=%d want 2: %+v", len(res.RuleTrace), res.RuleTrace)
+	}
+	for _, e := range res.RuleTrace {
+		if !e.Matched {
+			t.Fatalf("expected matched=true for %s, got %+v", e.RuleID, e)
+		}
+		if e.Suppressed || len(e.SuppressedBy) > 0 {
+			t.Fatalf("expected unsuppressed entry for %s, got %+v", e.RuleID, e)
+		}
+		if e.TargetID == "" {
+			t.Fatalf("expected non-empty target_id for %s, got %+v", e.RuleID, e)
+		}
+	}
+}
+
+func TestResolveStateTrace_suppressedByDependsOn(t *testing.T) {
+	t.Parallel()
+	// Given: a matching state rule that depends_on a degraded provider, plus a matching active rule
+	rules := []config.Rule{
+		{Type: "state", ID: "needs_github", Priority: 5, StateID: "Blocked", When: map[string]any{"op": "eq", "path": "x", "value": 1}, DependsOn: []string{"github"}},
+		{Type: "state", ID: "fallback", Priority: 20, StateID: "Fallback", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+	}
+	deg := map[string]struct{}{"github": {}}
+	// When: ResolveStateTrace runs with github degraded
+	res, err := ResolveStateTrace(rules, map[string]any{"x": 1}, deg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Then: fallback wins; trace marks the suppressed rule with suppressed_by
+	if res.Kind != OutcomeResolved || res.RuleID != "fallback" {
+		t.Fatalf("winner: %+v", res)
+	}
+	if len(res.RuleTrace) != 2 {
+		t.Fatalf("trace len: %+v", res.RuleTrace)
+	}
+	suppressed := res.RuleTrace[0]
+	if suppressed.RuleID != "needs_github" || !suppressed.Matched || !suppressed.Suppressed {
+		t.Fatalf("suppressed entry: %+v", suppressed)
+	}
+	wantSuppBy := []string{"github"}
+	if !reflect.DeepEqual(suppressed.SuppressedBy, wantSuppBy) {
+		t.Fatalf("suppressed_by: %+v want %+v", suppressed.SuppressedBy, wantSuppBy)
+	}
+	winner := res.RuleTrace[1]
+	if winner.RuleID != "fallback" || !winner.Matched || winner.Suppressed || len(winner.SuppressedBy) > 0 {
+		t.Fatalf("winner trace: %+v", winner)
+	}
+}
+
+func TestResolveStateTrace_noMatchKeepsTrace(t *testing.T) {
+	t.Parallel()
+	// Given: state rules that do not match the supplied signals
+	rules := []config.Rule{
+		{Type: "state", ID: "off", Priority: 5, StateID: "Off", When: map[string]any{"op": "eq", "path": "x", "value": 0}},
+	}
+	// When: ResolveStateTrace runs
+	res, err := ResolveStateTrace(rules, map[string]any{"x": 1}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Then: degraded outcome with the non-matching rule still recorded in the trace
+	if res.Kind != OutcomeDegraded {
+		t.Fatalf("kind: %+v", res)
+	}
+	if len(res.RuleTrace) != 1 || res.RuleTrace[0].RuleID != "off" || res.RuleTrace[0].Matched {
+		t.Fatalf("trace: %+v", res.RuleTrace)
+	}
+}
+
+func TestResolveRouteTrace_ignoresOtherRuleTypes(t *testing.T) {
+	t.Parallel()
+	// Given: route and state rules where the route rule matches; trace must include only routes
+	rules := []config.Rule{
+		{Type: "state", ID: "s_skip", Priority: 1, StateID: "S", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+		{Type: "route", ID: "r_hit", Priority: 10, RouteID: "next", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+	}
+	// When: ResolveRouteTrace runs
+	res, err := ResolveRouteTrace(rules, map[string]any{"x": 1}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Then: only the route rule is in the trace and the state rule is filtered out before walking
+	if res.Kind != OutcomeResolved || res.RouteID != "next" {
+		t.Fatalf("winner: %+v", res)
+	}
+	if len(res.RuleTrace) != 1 || res.RuleTrace[0].RuleID != "r_hit" || res.RuleTrace[0].RuleType != "route" {
+		t.Fatalf("trace: %+v", res.RuleTrace)
+	}
+	if res.RuleTrace[0].TargetID != "next" {
+		t.Fatalf("target_id: %+v", res.RuleTrace[0])
+	}
+}
+
+func TestResolveGuardTrace_scopesToRequestedGuardID(t *testing.T) {
+	t.Parallel()
+	// Given: guard rules for two different guard_id values
+	rules := []config.Rule{
+		{Type: "guard", ID: "other", Priority: 5, GuardID: "other-guard", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+		{Type: "guard", ID: "merge_a", Priority: 20, GuardID: "merge-readiness", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+		{Type: "guard", ID: "merge_b", Priority: 10, GuardID: "merge-readiness", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+	}
+	// When: ResolveGuardTrace runs for merge-readiness
+	res, err := ResolveGuardTrace(rules, map[string]any{"x": 1}, nil, "merge-readiness")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Then: only the two merge-readiness rules appear in the trace
+	if res.Kind != OutcomeResolved || res.GuardID != "merge-readiness" || res.RuleID != "merge_b" {
+		t.Fatalf("winner: %+v", res)
+	}
+	if len(res.RuleTrace) != 2 {
+		t.Fatalf("trace len=%d want 2: %+v", len(res.RuleTrace), res.RuleTrace)
+	}
+	for _, e := range res.RuleTrace {
+		if e.RuleType != "guard" || e.TargetID != "merge-readiness" {
+			t.Fatalf("trace entry leaked other guard scope: %+v", e)
+		}
+	}
+}
+
+func TestResolveStateTrace_evalErrorReportsTraceUpToFailingRule(t *testing.T) {
+	t.Parallel()
+	// Given: one valid rule followed by a rule with an unsupported when-clause shape
+	rules := []config.Rule{
+		{Type: "state", ID: "ok", Priority: 30, StateID: "OK", When: map[string]any{"op": "eq", "path": "x", "value": 1}},
+		{Type: "state", ID: "boom", Priority: 5, StateID: "Boom", When: map[string]any{"op": "bogus"}},
+	}
+	// When: ResolveStateTrace runs
+	res, err := ResolveStateTrace(rules, map[string]any{"x": 1}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Then: unsupported outcome; trace contains the rule(s) evaluated before the failing rule
+	if res.Kind != OutcomeUnsupported || !strings.Contains(res.Reason, "rule boom:") {
+		t.Fatalf("res: %+v", res)
+	}
+	if len(res.RuleTrace) != 1 || res.RuleTrace[0].RuleID != "ok" {
+		t.Fatalf("trace: %+v", res.RuleTrace)
+	}
+}

--- a/internal/rgdcli/flag_factories.go
+++ b/internal/rgdcli/flag_factories.go
@@ -40,6 +40,17 @@ func newFailOnNonResolvedFlag() *cli.BoolFlag {
 	}
 }
 
+// newTraceRulesFlag returns a fresh --trace-rules flag for state/route/context resolution
+// commands (Issue #143). When set, the JSON output gains an optional rule_trace array (or
+// state.rule_trace / routes[0].rule_trace for context build) listing every evaluated rule.
+// Default output without --trace-rules is unchanged.
+func newTraceRulesFlag() *cli.BoolFlag {
+	return &cli.BoolFlag{
+		Name:  "trace-rules",
+		Usage: "include rule-level trace of evaluated rules in the JSON output",
+	}
+}
+
 func newObservationFileFlag() *cli.StringFlag {
 	return &cli.StringFlag{Name: "observation-file"}
 }

--- a/internal/rgdcli/rgdcli.go
+++ b/internal/rgdcli/rgdcli.go
@@ -111,7 +111,27 @@ func resolveEvalOutputMap(res resolve.Result) map[string]any {
 	if res.ReEntryHint != "" {
 		out["re_entry_hint"] = res.ReEntryHint
 	}
+	if len(res.RuleTrace) > 0 {
+		out["rule_trace"] = res.RuleTrace
+	}
 	return out
+}
+
+// resolveStateForCommand picks ResolveState or ResolveStateTrace based on --trace-rules so
+// callers do not have to branch on the flag at every call site (Issue #143).
+func resolveStateForCommand(c *cli.Context, rules []config.Rule, signals map[string]any, deg map[string]struct{}) (resolve.Result, error) {
+	if c.Bool("trace-rules") {
+		return resolve.ResolveStateTrace(rules, signals, deg)
+	}
+	return resolve.ResolveState(rules, signals, deg)
+}
+
+// resolveRouteForCommand mirrors resolveStateForCommand for route resolution (Issue #143).
+func resolveRouteForCommand(c *cli.Context, rules []config.Rule, signals map[string]any, deg map[string]struct{}) (resolve.Result, error) {
+	if c.Bool("trace-rules") {
+		return resolve.ResolveRouteTrace(rules, signals, deg)
+	}
+	return resolve.ResolveRoute(rules, signals, deg)
 }
 
 func contextBuildStateOutput(stateRes resolve.Result, routeRes resolve.Result, loaded *config.LoadResult) map[string]any {
@@ -222,7 +242,7 @@ func RunStateEval(c *cli.Context) error {
 		return mergeErr
 	}
 	degSet := observation.DegradedSet(diags, deg)
-	res, err := resolve.ResolveState(loaded.Rules(), flat, degSet)
+	res, err := resolveStateForCommand(c, loaded.Rules(), flat, degSet)
 	if err != nil {
 		return err
 	}
@@ -263,7 +283,7 @@ func RunRouteSelect(c *cli.Context) error {
 		return mergeErr
 	}
 	degSet := observation.DegradedSet(diags, deg)
-	res, err := resolve.ResolveRoute(loaded.Rules(), flat, degSet)
+	res, err := resolveRouteForCommand(c, loaded.Rules(), flat, degSet)
 	if err != nil {
 		return err
 	}
@@ -350,7 +370,7 @@ func RunContextBuild(c *cli.Context) error {
 		return mergeErr
 	}
 	degSet := observation.DegradedSet(diags, deg)
-	stateRes, err := resolve.ResolveState(loaded.Rules(), flat, degSet)
+	stateRes, err := resolveStateForCommand(c, loaded.Rules(), flat, degSet)
 	if err != nil {
 		return err
 	}
@@ -364,7 +384,7 @@ func RunContextBuild(c *cli.Context) error {
 		flat[k] = v
 	}
 	kEntries, kWarns := filterContextKnowledge(loaded, flat)
-	routeRes, err := resolve.ResolveRoute(loaded.Rules(), flat, degSet)
+	routeRes, err := resolveRouteForCommand(c, loaded.Rules(), flat, degSet)
 	if err != nil {
 		return err
 	}
@@ -1040,6 +1060,7 @@ func NewApp(version string) *cli.App {
 						newCwdFlag(),
 						newConfigDirFlag(),
 						newFailOnNonResolvedFlag(),
+						newTraceRulesFlag(),
 					},
 					Action: RunStateEval,
 				},
@@ -1061,6 +1082,7 @@ func NewApp(version string) *cli.App {
 						newCwdFlag(),
 						newConfigDirFlag(),
 						newFailOnNonResolvedFlag(),
+						newTraceRulesFlag(),
 					},
 					Action: RunRouteSelect,
 				},
@@ -1107,6 +1129,7 @@ func NewApp(version string) *cli.App {
 						newPRNumberFlag(),
 						newCompactFlag(),
 						newFailOnNonResolvedFlag(),
+						newTraceRulesFlag(),
 					},
 					Action: RunContextBuild,
 				},

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -251,6 +251,103 @@ applies_to:
 	}
 }
 
+func TestRunContextBuild_traceRulesAttachesTraceToStateAndRoute(t *testing.T) {
+	t.Parallel()
+	// Given: minimal config and observation, with --trace-rules
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+	writeFile(t, filepath.Join(cfgDir, "control", "states", "default.yaml"), []byte(testFixtureRulesStateIdle))
+	writeFile(t, filepath.Join(cfgDir, "control", "routes", "default.yaml"), []byte(testFixtureControlRoutesNext))
+	if err := os.Mkdir(filepath.Join(cfgDir, "knowledge"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cfgDir, "knowledge", "manifest.json"), []byte(`{"schema_version":"0.8.0","entries":[]}`))
+	obsPath := filepath.Join(t.TempDir(), "obs.json")
+	writeFile(t, obsPath, []byte(`{"schema_version":"0.8.0","signals":{"git":{"branch":"main","working_tree_clean":true}},"degraded":false}`))
+
+	var buf bytes.Buffer
+	app := NewApp("test")
+	app.Writer = &buf
+	// When: context build runs with --trace-rules
+	if err := app.Run([]string{
+		"rgd", "context", "build",
+		"--config-dir", cfgDir,
+		"--observation-file", obsPath,
+		"--trace-rules",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	// Then: state.rule_trace and routes[0].rule_trace are present and target only their own rule_type
+	state := mustMap(t, out["state"], "state")
+	stateTrace, ok := state["rule_trace"].([]any)
+	if !ok || len(stateTrace) == 0 {
+		t.Fatalf("state.rule_trace missing: %+v", state)
+	}
+	for _, e := range stateTrace {
+		em := mustMap(t, e, "state.rule_trace[]")
+		if em["rule_type"] != "state" {
+			t.Fatalf("state.rule_trace contains non-state rule: %+v", em)
+		}
+	}
+	routes := mustSlice(t, out["routes"], "routes")
+	r0 := mustMap(t, routes[0], "routes[0]")
+	routeTrace, ok := r0["rule_trace"].([]any)
+	if !ok || len(routeTrace) == 0 {
+		t.Fatalf("routes[0].rule_trace missing: %+v", r0)
+	}
+	for _, e := range routeTrace {
+		em := mustMap(t, e, "routes[0].rule_trace[]")
+		if em["rule_type"] != "route" {
+			t.Fatalf("routes[0].rule_trace contains non-route rule: %+v", em)
+		}
+	}
+}
+
+func TestRunContextBuild_defaultOmitsRuleTraceInStateAndRoutes(t *testing.T) {
+	t.Parallel()
+	// Given: minimal config and observation, no --trace-rules
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+	writeFile(t, filepath.Join(cfgDir, "control", "states", "default.yaml"), []byte(testFixtureRulesStateIdle))
+	writeFile(t, filepath.Join(cfgDir, "control", "routes", "default.yaml"), []byte(testFixtureControlRoutesNext))
+	if err := os.Mkdir(filepath.Join(cfgDir, "knowledge"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(cfgDir, "knowledge", "manifest.json"), []byte(`{"schema_version":"0.8.0","entries":[]}`))
+	obsPath := filepath.Join(t.TempDir(), "obs.json")
+	writeFile(t, obsPath, []byte(`{"schema_version":"0.8.0","signals":{"git":{"branch":"main","working_tree_clean":true}},"degraded":false}`))
+
+	var buf bytes.Buffer
+	app := NewApp("test")
+	app.Writer = &buf
+	// When: context build runs without --trace-rules
+	if err := app.Run([]string{
+		"rgd", "context", "build",
+		"--config-dir", cfgDir,
+		"--observation-file", obsPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	// Then: neither state nor routes[0] include rule_trace
+	state := mustMap(t, out["state"], "state")
+	if _, ok := state["rule_trace"]; ok {
+		t.Fatalf("default context build must omit state.rule_trace, got %+v", state)
+	}
+	routes := mustSlice(t, out["routes"], "routes")
+	r0 := mustMap(t, routes[0], "routes[0]")
+	if _, ok := r0["rule_trace"]; ok {
+		t.Fatalf("default context build must omit routes[0].rule_trace, got %+v", r0)
+	}
+}
+
 func TestRunContextBuild_rejectsScopeFlagsWithObservationFile(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/rgdcli/rgdcli_route_test.go
+++ b/internal/rgdcli/rgdcli_route_test.go
@@ -42,6 +42,118 @@ func TestRunRouteSelect_stateFileFlattensStateDottedKeys(t *testing.T) {
 	}
 }
 
+func TestRunRouteSelect_traceRulesIncludesRuleTrace(t *testing.T) {
+	t.Parallel()
+	// Given: route rules where one matches state.kind=resolved and one does not
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+	writeFile(t, filepath.Join(cfgDir, "control", "routes", "r.yaml"), []byte(`schema_version: "0.8.0"
+rules:
+  - type: route
+    id: r1
+    priority: 10
+    route_id: next
+    when:
+      op: eq
+      path: state.kind
+      value: resolved
+  - type: route
+    id: r2
+    priority: 5
+    route_id: other
+    when:
+      op: eq
+      path: state.kind
+      value: degraded
+`))
+	obsDir := t.TempDir()
+	writeFile(t, filepath.Join(obsDir, "o.json"), []byte(`{"signals":{"git":{"branch":"main"}},"degraded":false}`))
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(stateDir, "s.json"), []byte(`{"kind":"resolved","state_id":"Idle"}`))
+
+	var buf bytes.Buffer
+	app := NewApp("t")
+	app.Writer = &buf
+	// When: route select runs with --trace-rules
+	if err := app.Run([]string{
+		"rgd", "route", "select",
+		"--config-dir", cfgDir,
+		"--observation-file", filepath.Join(obsDir, "o.json"),
+		"--state-file", filepath.Join(stateDir, "s.json"),
+		"--trace-rules",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v; raw=%s", err, buf.String())
+	}
+	if out["route_id"] != "next" {
+		t.Fatalf("route_id=%v, want next", out["route_id"])
+	}
+	traceAny, ok := out["rule_trace"].([]any)
+	if !ok || len(traceAny) != 2 {
+		t.Fatalf("expected 2 trace entries, got %v", out["rule_trace"])
+	}
+	// Then: matched flag agrees with route resolution
+	for _, e := range traceAny {
+		em, ok := e.(map[string]any)
+		if !ok {
+			t.Fatalf("trace entry has unexpected type %T: %v", e, e)
+		}
+		if em["rule_type"] != "route" {
+			t.Fatalf("rule_type=%v, want route", em["rule_type"])
+		}
+		switch em["rule_id"] {
+		case "r1":
+			if em["matched"] != true {
+				t.Fatalf("r1.matched=%v, want true", em["matched"])
+			}
+			if em["target_id"] != "next" {
+				t.Fatalf("r1.target_id=%v", em["target_id"])
+			}
+		case "r2":
+			if em["matched"] != false {
+				t.Fatalf("r2.matched=%v, want false", em["matched"])
+			}
+		default:
+			t.Fatalf("unexpected rule_id %v", em["rule_id"])
+		}
+	}
+}
+
+func TestRunRouteSelect_defaultOmitsRuleTrace(t *testing.T) {
+	t.Parallel()
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+	writeFile(t, filepath.Join(cfgDir, "control", "routes", "r.yaml"), []byte(testFixtureControlRoutesNext))
+	obsDir := t.TempDir()
+	writeFile(t, filepath.Join(obsDir, "o.json"), []byte(`{"signals":{"git":{"branch":"main"}},"degraded":false}`))
+	stateDir := t.TempDir()
+	writeFile(t, filepath.Join(stateDir, "s.json"), []byte(`{"kind":"resolved","state_id":"Idle"}`))
+
+	var buf bytes.Buffer
+	app := NewApp("t")
+	app.Writer = &buf
+	// When: route select runs without --trace-rules
+	if err := app.Run([]string{
+		"rgd", "route", "select",
+		"--config-dir", cfgDir,
+		"--observation-file", filepath.Join(obsDir, "o.json"),
+		"--state-file", filepath.Join(stateDir, "s.json"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	// Then: rule_trace must be absent
+	if _, ok := out["rule_trace"]; ok {
+		t.Fatalf("default route select must omit rule_trace, got %+v", out)
+	}
+}
+
 func TestRunRouteSelect_relativeObservationAndStateFileWithCwd(t *testing.T) {
 	t.Parallel()
 	// Given: data dir with relative observation/state files and --cwd

--- a/internal/rgdcli/rgdcli_state_test.go
+++ b/internal/rgdcli/rgdcli_state_test.go
@@ -191,6 +191,7 @@ func TestRunStateEval_traceRulesAmbiguousIncludesAllMatchedRules(t *testing.T) {
 	if !ok || len(traceAny) != 2 {
 		t.Fatalf("expected 2 trace entries, got %v", out["rule_trace"])
 	}
+	seen := map[string]bool{}
 	for _, e := range traceAny {
 		em, ok := e.(map[string]any)
 		if !ok {
@@ -199,6 +200,11 @@ func TestRunStateEval_traceRulesAmbiguousIncludesAllMatchedRules(t *testing.T) {
 		if em["matched"] != true {
 			t.Fatalf("ambiguous trace entry must be matched=true, got %+v", em)
 		}
+		id, _ := em["rule_id"].(string)
+		if id == "" || seen[id] {
+			t.Fatalf("expected distinct non-empty rule_id, got %v (seen=%v)", em["rule_id"], seen)
+		}
+		seen[id] = true
 	}
 }
 

--- a/internal/rgdcli/rgdcli_state_test.go
+++ b/internal/rgdcli/rgdcli_state_test.go
@@ -45,6 +45,163 @@ func TestRunStateEval_observationFile(t *testing.T) {
 	}
 }
 
+func TestRunStateEval_traceRulesIncludesRuleTrace(t *testing.T) {
+	t.Parallel()
+	// Given: two state rules where only one matches; --trace-rules requested
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+	writeFile(t, filepath.Join(cfgDir, "control", "states", "r.yaml"), []byte(`schema_version: "0.8.0"
+rules:
+  - type: state
+    id: idle
+    priority: 10
+    state_id: Idle
+    when:
+      op: eq
+      path: git.branch
+      value: main
+  - type: state
+    id: feat
+    priority: 10
+    state_id: Working
+    when:
+      op: eq
+      path: git.branch
+      value: feat
+`))
+	obsDir := t.TempDir()
+	writeFile(t, filepath.Join(obsDir, "o.json"), []byte(`{
+  "schema_version": "0.8.0",
+  "signals": {"git": {"branch": "main"}},
+  "degraded": false
+}`))
+
+	var buf bytes.Buffer
+	app := NewApp("t")
+	app.Writer = &buf
+	// When: state eval runs with --trace-rules
+	if err := app.Run([]string{
+		"rgd", "state", "eval",
+		"--config-dir", cfgDir,
+		"--observation-file", filepath.Join(obsDir, "o.json"),
+		"--trace-rules",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v; raw=%s", err, buf.String())
+	}
+	if out["kind"] != "resolved" || out["state_id"] != "Idle" {
+		t.Fatalf("expected resolved Idle, got %+v", out)
+	}
+	// Then: rule_trace contains both evaluated rules in order with matched flags
+	traceAny, ok := out["rule_trace"].([]any)
+	if !ok {
+		t.Fatalf("rule_trace missing or wrong type: %T (%v)", out["rule_trace"], out["rule_trace"])
+	}
+	if len(traceAny) != 2 {
+		t.Fatalf("expected 2 trace entries, got %d: %+v", len(traceAny), traceAny)
+	}
+	for _, e := range traceAny {
+		em, ok := e.(map[string]any)
+		if !ok {
+			t.Fatalf("trace entry has unexpected type %T: %v", e, e)
+		}
+		if em["rule_type"] != "state" {
+			t.Fatalf("rule_type=%v, want state", em["rule_type"])
+		}
+		switch em["rule_id"] {
+		case "idle":
+			if em["matched"] != true {
+				t.Fatalf("idle.matched=%v, want true", em["matched"])
+			}
+			if em["target_id"] != "Idle" {
+				t.Fatalf("idle.target_id=%v", em["target_id"])
+			}
+		case "feat":
+			if em["matched"] != false {
+				t.Fatalf("feat.matched=%v, want false", em["matched"])
+			}
+		default:
+			t.Fatalf("unexpected rule_id %v", em["rule_id"])
+		}
+	}
+}
+
+func TestRunStateEval_defaultOmitsRuleTrace(t *testing.T) {
+	t.Parallel()
+	// Given: same fixture as the trace test, but no --trace-rules flag
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+	writeFile(t, filepath.Join(cfgDir, "control", "states", "r.yaml"), []byte(testFixtureRulesStateIdle))
+	obsDir := t.TempDir()
+	writeFile(t, filepath.Join(obsDir, "o.json"), []byte(`{"schema_version":"0.8.0","signals":{"git":{"branch":"main"}},"degraded":false}`))
+	var buf bytes.Buffer
+	app := NewApp("t")
+	app.Writer = &buf
+	// When: state eval runs without --trace-rules
+	if err := app.Run([]string{
+		"rgd", "state", "eval",
+		"--config-dir", cfgDir,
+		"--observation-file", filepath.Join(obsDir, "o.json"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	// Then: rule_trace must be absent
+	if _, ok := out["rule_trace"]; ok {
+		t.Fatalf("default output must omit rule_trace, got %+v", out)
+	}
+}
+
+func TestRunStateEval_traceRulesAmbiguousIncludesAllMatchedRules(t *testing.T) {
+	t.Parallel()
+	// Given: two same-priority state rules that both match the same observation
+	cfgDir := t.TempDir()
+	writeFile(t, filepath.Join(cfgDir, "reinguard.yaml"), []byte(testFixtureReinguardRoot))
+	writeFile(t, filepath.Join(cfgDir, "control", "states", "r.yaml"), []byte(testFixtureRulesStateAmbiguous))
+	obsDir := t.TempDir()
+	writeFile(t, filepath.Join(obsDir, "o.json"), []byte(`{"schema_version":"0.8.0","signals":{"git":{"branch":"feat"}},"degraded":false}`))
+
+	var buf bytes.Buffer
+	app := NewApp("t")
+	app.Writer = &buf
+	// When: state eval runs with --trace-rules but without --fail-on-non-resolved
+	if err := app.Run([]string{
+		"rgd", "state", "eval",
+		"--config-dir", cfgDir,
+		"--observation-file", filepath.Join(obsDir, "o.json"),
+		"--trace-rules",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v; raw=%s", err, buf.String())
+	}
+	// Then: ambiguous outcome and both rules appear matched in rule_trace
+	if out["kind"] != "ambiguous" {
+		t.Fatalf("kind=%v, want ambiguous", out["kind"])
+	}
+	traceAny, ok := out["rule_trace"].([]any)
+	if !ok || len(traceAny) != 2 {
+		t.Fatalf("expected 2 trace entries, got %v", out["rule_trace"])
+	}
+	for _, e := range traceAny {
+		em, ok := e.(map[string]any)
+		if !ok {
+			t.Fatalf("trace entry has unexpected type %T: %v", e, e)
+		}
+		if em["matched"] != true {
+			t.Fatalf("ambiguous trace entry must be matched=true, got %+v", em)
+		}
+	}
+}
+
 func TestRunStateEval_unsupportedJSONOmitsEmptyFields(t *testing.T) {
 	t.Parallel()
 	// Given: same when as TestRunStateEval_failOnUnsupported (valid at config load; fails at match eval)

--- a/pkg/schema/operational-context.json
+++ b/pkg/schema/operational-context.json
@@ -38,6 +38,50 @@
           "items": { "type": "string" }
         },
         "re_entry_hint": { "type": "string" },
+        "rule_trace": {
+          "type": "array",
+          "description": "Optional rule-level evaluation trace populated only when --trace-rules is set on rgd state eval / route select / context build. Contains one entry per evaluated rule of the requested rule_type, in evaluation order.",
+          "items": {
+            "type": "object",
+            "required": ["rule_id", "rule_type", "priority", "target_id", "matched"],
+            "properties": {
+              "rule_id": { "type": "string" },
+              "rule_type": {
+                "type": "string",
+                "enum": ["state", "route", "guard"]
+              },
+              "priority": { "type": "number" },
+              "target_id": { "type": "string" },
+              "matched": { "type": "boolean" },
+              "suppressed": { "type": "boolean" },
+              "suppressed_by": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            },
+            "additionalProperties": false,
+            "allOf": [
+              {
+                "if": {
+                  "required": ["suppressed"],
+                  "properties": {
+                    "suppressed": { "const": true }
+                  }
+                },
+                "then": {
+                  "required": ["suppressed_by"],
+                  "properties": {
+                    "suppressed_by": {
+                      "type": "array",
+                      "items": { "type": "string" },
+                      "minItems": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
         "procedure_hint": {
           "type": "object",
           "description": "Optional advisory mapping from resolved state_id to a procedure file (front matter SSOT). Omitted when state.kind is not resolved.",


### PR DESCRIPTION
## Summary

- Add an opt-in `--trace-rules` flag to `rgd state eval`, `rgd route select`, and `rgd context build` that surfaces a rule-level `rule_trace[]` (one entry per evaluated rule of the relevant type) so agents can debug why a state or route resolved without re-deriving observation. Default output stays unchanged.
- Each trace entry records `rule_id`, `rule_type`, `priority`, `target_id`, `matched`, plus `suppressed` / `suppressed_by` for matched-but-degraded-dependency cases. Coverage spans non-matching, matching, same-priority ambiguity, depends_on suppression, and failed `when` evaluation.
- Extend `pkg/schema/operational-context.json` with the optional `rule_trace[]` shape (with a conditional `suppressed -> suppressed_by` constraint) and document the flag, output shape, and out-of-scope boundaries (no expression-level tracing; guard rules out of scope for this flag) in `docs/cli.md`.

## Traceability

Closes #143

Refs: #143

## Definition of Done

- [x] Tests added or updated (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. `bash .reinguard/scripts/with-repo-local-state.sh -- go test ./... -race` — passes (resolve tests cover trace for non-match / match / ambiguity / suppression / evaluation error; rgdcli tests cover all three commands and assert default omits `rule_trace`; binary integration test covers `--trace-rules` + `--fail-on-non-resolved` exit-2 path with trace still on stdout).
2. `bash .reinguard/scripts/with-repo-local-state.sh -- go vet ./...` — clean.
3. `bash .reinguard/scripts/with-repo-local-state.sh -- golangci-lint run` — `0 issues.`
4. `bash .reinguard/scripts/with-repo-local-state.sh -- pre-commit run markdownlint-cli2 --all-files` — passes.
5. `go run ./cmd/rgd config validate` — `config OK`.
6. `go run ./cmd/rgd context build --compact --trace-rules` — emits `state.rule_trace` and `routes[0].rule_trace`; `go run ./cmd/rgd context build --compact` (no flag) — output unchanged (golden fixtures intact).
7. CodeRabbit local review (`bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- bash .reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit`) — 8 nitpick/minor findings, all addressed in the same commit (safer type assertions and default cases in tests, `NewApp("test")` consistency in `rgdcli_context_test.go`, and a JSON Schema conditional that requires `suppressed_by` to be a non-empty array when `suppressed: true`).

## Risk / Impact

- New flag is opt-in and gated entirely on `--trace-rules`. Default JSON output of `rgd state eval`, `rgd route select`, and `rgd context build` is byte-for-byte unchanged (existing golden fixtures still match), so existing agents and adapters are unaffected.
- Schema change is additive: `rule_trace` is optional with `additionalProperties: false` for the new entry shape, plus a conditional that requires `suppressed_by` when `suppressed: true`. Existing producers without trace data still validate.
- Substrate boundary (ADR-0001) preserved: rule-level only, no expression-level tracing, no new FSM states, no new match operators, no `explain` command, no guard-rule trace via this flag.

## Rollback Plan

- Revert this PR. The change is self-contained (one commit) and has no migrations or runtime state. Adapters that already opt into `--trace-rules` will simply lose the optional `rule_trace` field after revert.