### PR TITLE
fix(local-review): handle CodeRabbit quota guidance

### DIFF
--- a/.reinguard/knowledge/review--local-coderabbit-cli.md
+++ b/.reinguard/knowledge/review--local-coderabbit-cli.md
@@ -80,11 +80,18 @@ depending on `~/.coderabbit`.
   (default buffer **30s**). PR-side CodeRabbit recovery uses the same
   **`cooldown + 30s`** rule before `@coderabbitai review`; see
   `review--bot-operations.md` § Rate-Limit Recovery.
+- If CodeRabbit emits usage-based/hourly-cap guidance without a parseable
+  retry-after duration, `--retry-on-rate-limit` uses the repository fallback
+  `workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds` from
+  `.reinguard/reinguard.yaml` for the one automatic retry. Explicit cooldown
+  hints take precedence over this fallback; generic CLI failures still fail
+  closed.
 - Sparse **stdout** from the CLI while it works is **normal**; heartbeats go to
   **stderr** so transcripts stay readable.
 - Only terminal outcomes change control flow: success, explicit CLI failure,
-  supervisor timeout, auth/tooling failure, cooldown parse failure, or a failed
-  second attempt after the one automatic retry (per policy).
+  supervisor timeout, auth/tooling failure, cooldown parse failure, missing or
+  invalid unknown-quota fallback config, or a failed second attempt after the
+  one automatic retry (per policy).
 - Do not kill the subprocess without positive evidence of hang beyond the
   supervisor limit; the supervisor already bounds worst-case wait.
 - This is a **foreground wait**: a long run or cooldown sleep is **not** failure

--- a/.reinguard/policy/coding--preflight.md
+++ b/.reinguard/policy/coding--preflight.md
@@ -62,15 +62,16 @@ bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- \
   cooldown from the **latest line that contains an explicit backoff hint**
   (`try again in`, `try after`, or `retry in`) in that run (so earlier log text
   and unrelated footers such as `finished in N seconds` do not affect the
-  wait). Retry wait selection is:
-  - explicit backoff hint: sleep the parsed cooldown plus the small **safety
-    buffer** (default 30s; override with `RATE_LIMIT_RETRY_BUFFER_SEC`);
-  - usage-based/hourly-cap guidance without a parseable retry-after duration:
-    sleep the repository fallback
-    `workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds` from
-    `.reinguard/reinguard.yaml`;
-  - no applicable wait, or a failed second attempt after the one automatic
-    retry: treat the gate as failed.
+  wait). Retry wait selection:
+  1. Explicit backoff hint — sleep the parsed cooldown plus the small **safety
+     buffer** (default 30s; override with `RATE_LIMIT_RETRY_BUFFER_SEC`).
+  2. Usage-based/hourly-cap guidance without a parseable retry-after duration —
+     sleep the repository fallback
+     `workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds` from
+     `.reinguard/reinguard.yaml`.
+  3. No applicable wait or failed retry — treat the gate as failed when there
+     is no wait guidance or when the second attempt fails after the one
+     automatic retry.
 - The script supervises each `coderabbit review` attempt: stderr **heartbeat**
   every **30 seconds** (default `LOCAL_CR_HEARTBEAT_SEC=30`) and a **20-minute**
   wall-clock maximum per attempt (default `LOCAL_CR_MAX_WAIT_SEC=1200`), aligned

--- a/.reinguard/policy/coding--preflight.md
+++ b/.reinguard/policy/coding--preflight.md
@@ -75,9 +75,10 @@ bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- \
 - The script supervises each `coderabbit review` attempt: stderr **heartbeat**
   every **30 seconds** (default `LOCAL_CR_HEARTBEAT_SEC=30`) and a **20-minute**
   wall-clock maximum per attempt (default `LOCAL_CR_MAX_WAIT_SEC=1200`), aligned
-  with PR-side bot wait cadence in `review--bot-operations.md`. Sparse **stdout**
-  while the CLI works, or a long cooldown sleep, is not a failure by itself and
-  must not be treated as a hang without positive evidence.
+  with PR-side bot wait cadence in
+  `.reinguard/knowledge/review--bot-operations.md`. Sparse **stdout** while the
+  CLI works, or a long cooldown sleep, is not a failure by itself and must not
+  be treated as a hang without positive evidence.
 - If the script cannot run (CLI missing, auth missing, rate limit or
   usage-based/hourly-cap quota block whose retry attempt also fails, execution
   error), treat that as a failed gate and do not proceed to `pr-create`.

--- a/.reinguard/policy/coding--preflight.md
+++ b/.reinguard/policy/coding--preflight.md
@@ -63,9 +63,13 @@ bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- \
   (`try again in`, `try after`, or `retry in`) in that run (so earlier log text
   and unrelated footers such as `finished in N seconds` do not affect the
   wait). It adds a small **safety buffer** (default 30s; override with
-  `RATE_LIMIT_RETRY_BUFFER_SEC`) before the retry. If no parseable cooldown is
-  found on that line, or the review still fails after that single automatic
-  retry, treat the gate as failed.
+  `RATE_LIMIT_RETRY_BUFFER_SEC`) before the retry. When CodeRabbit emits
+  usage-based/hourly-cap guidance without a parseable retry-after duration,
+  the same `--retry-on-rate-limit` path may instead sleep the repository
+  fallback `workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds`
+  from `.reinguard/reinguard.yaml` before the one retry. If no parseable
+  cooldown or configured fallback applies, or the review still fails after
+  that single automatic retry, treat the gate as failed.
 - The script supervises each `coderabbit review` attempt: stderr **heartbeat**
   every **30 seconds** (default `LOCAL_CR_HEARTBEAT_SEC=30`) and a **20-minute**
   wall-clock maximum per attempt (default `LOCAL_CR_MAX_WAIT_SEC=1200`), aligned
@@ -73,8 +77,8 @@ bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- \
   while the CLI works, or a long cooldown sleep, is not a failure by itself and
   must not be treated as a hang without positive evidence.
 - If the script cannot run (CLI missing, auth missing, second consecutive
-  rate limit after retry, execution error), treat that as a failed gate and
-  do not proceed to `pr-create`.
+  rate limit or usage-based/hourly-cap quota block after retry, execution
+  error), treat that as a failed gate and do not proceed to `pr-create`.
 - When the local CLI gate succeeds on the current HEAD, record a fresh runtime
   proof for the configured **pre-PR AI review** gate role
   (`workflow.runtime_gate_roles.pre_pr_ai_review`; default gate id:

--- a/.reinguard/policy/coding--preflight.md
+++ b/.reinguard/policy/coding--preflight.md
@@ -78,8 +78,8 @@ bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- \
   with PR-side bot wait cadence in `review--bot-operations.md`. Sparse **stdout**
   while the CLI works, or a long cooldown sleep, is not a failure by itself and
   must not be treated as a hang without positive evidence.
-- If the script cannot run (CLI missing, auth missing, second consecutive
-  rate limit or usage-based/hourly-cap quota block after retry, execution
+- If the script cannot run (CLI missing, auth missing, rate limit or
+  usage-based/hourly-cap quota block whose retry attempt also fails, execution
   error), treat that as a failed gate and do not proceed to `pr-create`.
 - When the local CLI gate succeeds on the current HEAD, record a fresh runtime
   proof for the configured **pre-PR AI review** gate role

--- a/.reinguard/policy/coding--preflight.md
+++ b/.reinguard/policy/coding--preflight.md
@@ -62,14 +62,15 @@ bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- \
   cooldown from the **latest line that contains an explicit backoff hint**
   (`try again in`, `try after`, or `retry in`) in that run (so earlier log text
   and unrelated footers such as `finished in N seconds` do not affect the
-  wait). It adds a small **safety buffer** (default 30s; override with
-  `RATE_LIMIT_RETRY_BUFFER_SEC`) before the retry. When CodeRabbit emits
-  usage-based/hourly-cap guidance without a parseable retry-after duration,
-  the same `--retry-on-rate-limit` path may instead sleep the repository
-  fallback `workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds`
-  from `.reinguard/reinguard.yaml` before the one retry. If no parseable
-  cooldown or configured fallback applies, or the review still fails after
-  that single automatic retry, treat the gate as failed.
+  wait). Retry wait selection is:
+  - explicit backoff hint: sleep the parsed cooldown plus the small **safety
+    buffer** (default 30s; override with `RATE_LIMIT_RETRY_BUFFER_SEC`);
+  - usage-based/hourly-cap guidance without a parseable retry-after duration:
+    sleep the repository fallback
+    `workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds` from
+    `.reinguard/reinguard.yaml`;
+  - no applicable wait, or a failed second attempt after the one automatic
+    retry: treat the gate as failed.
 - The script supervises each `coderabbit review` attempt: stderr **heartbeat**
   every **30 seconds** (default `LOCAL_CR_HEARTBEAT_SEC=30`) and a **20-minute**
   wall-clock maximum per attempt (default `LOCAL_CR_MAX_WAIT_SEC=1200`), aligned

--- a/.reinguard/procedure/review-address.md
+++ b/.reinguard/procedure/review-address.md
@@ -75,6 +75,18 @@ you need evidence outside the surfaced inbox (see `review--github-thread-api.md`
 
 ## Act
 
+### Active-signal preconditions
+
+Before any review-trigger action, check active bot-review signals from
+`observation.signals.github.reviews`. When one of these preconditions is true,
+complete the linked recovery or wait action before proceeding with Step 0 or
+posting `@coderabbitai review`.
+
+| Active signal | Required action |
+|---|---|
+| `github.reviews.bot_review_diagnostics.bot_review_blocked == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Rate-Limit Recovery**; sleep for `rate_limit_remaining_seconds + 30s` before any `@coderabbitai review` trigger. |
+| `bot_review_trigger_awaiting_ack == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Trigger**; wait for bot acknowledgement before retrying a trigger or proceeding as though review state is settled. |
+
 ### 0. Local work gate (uncommitted changes)
 
 If `observation.signals.git.working_tree_clean` is `false` (from `rgd context build --compact` or `rgd observe`):

--- a/.reinguard/procedure/review-address.md
+++ b/.reinguard/procedure/review-address.md
@@ -84,7 +84,7 @@ retrying a trigger, or posting `@coderabbitai review`.
 
 | Active signal | Required action |
 |---|---|
-| `observation.signals.github.reviews.bot_review_diagnostics.bot_review_blocked == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Rate-Limit Recovery**; sleep for `bot_review_diagnostics.rate_limit_remaining_seconds + 30s` before any `@coderabbitai review` trigger. |
+| `observation.signals.github.reviews.bot_review_diagnostics.bot_review_blocked == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Rate-Limit Recovery**; sleep for the required bot's `bot_reviewer_status[].rate_limit_remaining_seconds + 30s` before any `@coderabbitai review` trigger. |
 | `observation.signals.github.reviews.bot_review_trigger_awaiting_ack == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Trigger**; wait for bot acknowledgement before retrying a trigger or proceeding as though review state is settled. |
 
 ### 0. Local work gate (uncommitted changes)

--- a/.reinguard/procedure/review-address.md
+++ b/.reinguard/procedure/review-address.md
@@ -77,10 +77,10 @@ you need evidence outside the surfaced inbox (see `review--github-thread-api.md`
 
 ### Active-signal preconditions
 
-Before any review-trigger action, check active bot-review signals from
+Before any review-address action, check active bot-review signals from
 `observation.signals.github.reviews`. When one of these preconditions is true,
-complete the linked recovery or wait action before proceeding with Step 0 or
-posting `@coderabbitai review`.
+complete the linked recovery or wait action before proceeding with Step 0,
+retrying a trigger, or posting `@coderabbitai review`.
 
 | Active signal | Required action |
 |---|---|

--- a/.reinguard/procedure/review-address.md
+++ b/.reinguard/procedure/review-address.md
@@ -84,7 +84,7 @@ retrying a trigger, or posting `@coderabbitai review`.
 
 | Active signal | Required action |
 |---|---|
-| `observation.signals.github.reviews.bot_review_diagnostics.bot_review_blocked == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Rate-Limit Recovery**; sleep for `rate_limit_remaining_seconds + 30s` before any `@coderabbitai review` trigger. |
+| `observation.signals.github.reviews.bot_review_diagnostics.bot_review_blocked == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Rate-Limit Recovery**; sleep for `bot_review_diagnostics.rate_limit_remaining_seconds + 30s` before any `@coderabbitai review` trigger. |
 | `observation.signals.github.reviews.bot_review_trigger_awaiting_ack == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Trigger**; wait for bot acknowledgement before retrying a trigger or proceeding as though review state is settled. |
 
 ### 0. Local work gate (uncommitted changes)

--- a/.reinguard/procedure/review-address.md
+++ b/.reinguard/procedure/review-address.md
@@ -84,8 +84,8 @@ posting `@coderabbitai review`.
 
 | Active signal | Required action |
 |---|---|
-| `github.reviews.bot_review_diagnostics.bot_review_blocked == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Rate-Limit Recovery**; sleep for `rate_limit_remaining_seconds + 30s` before any `@coderabbitai review` trigger. |
-| `bot_review_trigger_awaiting_ack == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Trigger**; wait for bot acknowledgement before retrying a trigger or proceeding as though review state is settled. |
+| `observation.signals.github.reviews.bot_review_diagnostics.bot_review_blocked == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Rate-Limit Recovery**; sleep for `rate_limit_remaining_seconds + 30s` before any `@coderabbitai review` trigger. |
+| `observation.signals.github.reviews.bot_review_trigger_awaiting_ack == true` | Follow [`../knowledge/review--bot-operations.md`](../knowledge/review--bot-operations.md) § **Trigger**; wait for bot acknowledgement before retrying a trigger or proceeding as though review state is settled. |
 
 ### 0. Local work gate (uncommitted changes)
 

--- a/.reinguard/reinguard.yaml
+++ b/.reinguard/reinguard.yaml
@@ -2,6 +2,9 @@
 schema_version: "0.8.0"
 default_branch: main
 workflow:
+  local_ai_review:
+    coderabbit:
+      unknown_quota_wait_seconds: 1860
   runtime_gate_roles:
     local_verification:
       gate_id: local-verification

--- a/.reinguard/scripts/check-local-review.sh
+++ b/.reinguard/scripts/check-local-review.sh
@@ -199,6 +199,88 @@ extract_rate_limit_seconds() {
   printf '%s\n' "$total"
 }
 
+has_unknown_quota_guidance() {
+	local text="$1"
+	grep -qiE 'usage-based add-?on|hourly cap|additional reviews beyond the hourly cap|reviews running without waiting' <<< "$text"
+}
+
+read_unknown_quota_wait_seconds() {
+	local cfg=".reinguard/reinguard.yaml"
+	require_file "$cfg" "$cfg is required to read workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds." 2
+	awk '
+function indentation(s) {
+	match(s, /^ */)
+	return RLENGTH
+}
+function reset_local() {
+	in_local = 0
+	in_coderabbit = 0
+	local_indent = -1
+	coderabbit_indent = -1
+}
+BEGIN {
+	in_workflow = 0
+	reset_local()
+	workflow_indent = -1
+	found = 0
+}
+/^[[:space:]]*($|#)/ { next }
+{
+	line = $0
+	sub(/[[:space:]]+#.*/, "", line)
+	trimmed = line
+	sub(/^[[:space:]]*/, "", trimmed)
+	sub(/[[:space:]]*$/, "", trimmed)
+	indent = indentation(line)
+
+	if (in_coderabbit && indent <= coderabbit_indent) {
+		in_coderabbit = 0
+		coderabbit_indent = -1
+	}
+	if (in_local && indent <= local_indent) {
+		reset_local()
+	}
+	if (in_workflow && indent <= workflow_indent) {
+		in_workflow = 0
+		workflow_indent = -1
+		reset_local()
+	}
+
+	if (trimmed == "workflow:") {
+		in_workflow = 1
+		workflow_indent = indent
+		next
+	}
+	if (in_workflow && trimmed == "local_ai_review:") {
+		in_local = 1
+		local_indent = indent
+		next
+	}
+	if (in_local && trimmed == "coderabbit:") {
+		in_coderabbit = 1
+		coderabbit_indent = indent
+		next
+	}
+	if (in_coderabbit && trimmed ~ /^unknown_quota_wait_seconds:/) {
+		value = trimmed
+		sub(/^unknown_quota_wait_seconds:[[:space:]]*/, "", value)
+		if (value !~ /^[0-9]+$/) {
+			printf("invalid unknown_quota_wait_seconds: %s\n", value) > "/dev/stderr"
+			exit 3
+		}
+		print value
+		found = 1
+		exit 0
+	}
+}
+END {
+	if (!found) {
+		exit 1
+	}
+}
+' "$cfg"
+}
+
 # Run one `coderabbit review` with wall-clock cap and periodic stderr heartbeats.
 # Does not restart the CLI on an interval; one subprocess per attempt (same contract as before).
 heartbeat_pause() {
@@ -302,6 +384,28 @@ while true; do
     echo "ERROR: CodeRabbit CLI output included a cooldown hint but duration could not be parsed from the latest cooldown instruction line in this CLI run. Re-run after cooldown or check CLI output." >&2
     exit 2
   fi
+
+	if has_unknown_quota_guidance "$REVIEW_OUTPUT_CLEAN"; then
+		if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -lt $max_attempts ]]; then
+			if ! wait_seconds="$(read_unknown_quota_wait_seconds)" || ! [[ "$wait_seconds" =~ ^[0-9]+$ ]]; then
+				echo "ERROR: CodeRabbit CLI reported usage-based/hourly-cap quota guidance without a parseable cooldown, but workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds is missing or invalid." >&2
+				exit 2
+			fi
+			echo "" >&2
+			echo "CodeRabbit usage-based/hourly-cap quota guidance detected without a retry-after duration." >&2
+			echo "Configured fallback wait: ${wait_seconds}s from workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds; sleeping before one automatic retry..." >&2
+			sleep "$wait_seconds"
+			echo "Retrying CodeRabbit local review (attempt $((attempt + 1))/${max_attempts})..." >&2
+			attempt=$((attempt + 1))
+			continue
+		fi
+		if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -eq $max_attempts ]]; then
+			echo "ERROR: CodeRabbit CLI reported usage-based/hourly-cap quota guidance again after automatic retry. Wait for quota refill or enable the usage-based add-on, then rerun manually." >&2
+		else
+			echo "ERROR: CodeRabbit CLI reported usage-based/hourly-cap quota guidance without a retry-after duration. Pass --retry-on-rate-limit to use the configured fallback wait, or rerun after quota refill." >&2
+		fi
+		exit 2
+	fi
 
   if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -eq $max_attempts ]]; then
     echo "ERROR: CodeRabbit local review failed again after automatic retry. Wait for any reported cooldown and rerun manually." >&2

--- a/.reinguard/scripts/check-local-review.sh
+++ b/.reinguard/scripts/check-local-review.sh
@@ -200,83 +200,83 @@ extract_rate_limit_seconds() {
 }
 
 has_unknown_quota_guidance() {
-	local text="$1"
-	grep -qiE 'usage-based add-?on|hourly cap|additional reviews beyond the hourly cap|reviews running without waiting' <<< "$text"
+  local text="$1"
+  grep -qiE 'usage-based add-?on|hourly cap|additional reviews beyond the hourly cap|reviews running without waiting' <<< "$text"
 }
 
 read_unknown_quota_wait_seconds() {
-	local cfg=".reinguard/reinguard.yaml"
-	require_file "$cfg" "$cfg is required to read workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds." 2
-	awk '
+  local cfg=".reinguard/reinguard.yaml"
+  require_file "$cfg" "$cfg is required to read workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds." 2
+  awk '
 function indentation(s) {
-	match(s, /^ */)
-	return RLENGTH
+  match(s, /^ */)
+  return RLENGTH
 }
 function reset_local() {
-	in_local = 0
-	in_coderabbit = 0
-	local_indent = -1
-	coderabbit_indent = -1
+  in_local = 0
+  in_coderabbit = 0
+  local_indent = -1
+  coderabbit_indent = -1
 }
 BEGIN {
-	in_workflow = 0
-	reset_local()
-	workflow_indent = -1
-	found = 0
+  in_workflow = 0
+  reset_local()
+  workflow_indent = -1
+  found = 0
 }
 /^[[:space:]]*($|#)/ { next }
 {
-	line = $0
-	sub(/[[:space:]]+#.*/, "", line)
-	trimmed = line
-	sub(/^[[:space:]]*/, "", trimmed)
-	sub(/[[:space:]]*$/, "", trimmed)
-	indent = indentation(line)
+  line = $0
+  sub(/[[:space:]]+#.*/, "", line)
+  trimmed = line
+  sub(/^[[:space:]]*/, "", trimmed)
+  sub(/[[:space:]]*$/, "", trimmed)
+  indent = indentation(line)
 
-	if (in_coderabbit && indent <= coderabbit_indent) {
-		in_coderabbit = 0
-		coderabbit_indent = -1
-	}
-	if (in_local && indent <= local_indent) {
-		reset_local()
-	}
-	if (in_workflow && indent <= workflow_indent) {
-		in_workflow = 0
-		workflow_indent = -1
-		reset_local()
-	}
+  if (in_coderabbit && indent <= coderabbit_indent) {
+    in_coderabbit = 0
+    coderabbit_indent = -1
+  }
+  if (in_local && indent <= local_indent) {
+    reset_local()
+  }
+  if (in_workflow && indent <= workflow_indent) {
+    in_workflow = 0
+    workflow_indent = -1
+    reset_local()
+  }
 
-	if (trimmed == "workflow:") {
-		in_workflow = 1
-		workflow_indent = indent
-		next
-	}
-	if (in_workflow && trimmed == "local_ai_review:") {
-		in_local = 1
-		local_indent = indent
-		next
-	}
-	if (in_local && trimmed == "coderabbit:") {
-		in_coderabbit = 1
-		coderabbit_indent = indent
-		next
-	}
-	if (in_coderabbit && trimmed ~ /^unknown_quota_wait_seconds:/) {
-		value = trimmed
-		sub(/^unknown_quota_wait_seconds:[[:space:]]*/, "", value)
-		if (value !~ /^[0-9]+$/) {
-			printf("invalid unknown_quota_wait_seconds: %s\n", value) > "/dev/stderr"
-			exit 3
-		}
-		print value
-		found = 1
-		exit 0
-	}
+  if (trimmed == "workflow:") {
+    in_workflow = 1
+    workflow_indent = indent
+    next
+  }
+  if (in_workflow && trimmed == "local_ai_review:") {
+    in_local = 1
+    local_indent = indent
+    next
+  }
+  if (in_local && trimmed == "coderabbit:") {
+    in_coderabbit = 1
+    coderabbit_indent = indent
+    next
+  }
+  if (in_coderabbit && trimmed ~ /^unknown_quota_wait_seconds:/) {
+    value = trimmed
+    sub(/^unknown_quota_wait_seconds:[[:space:]]*/, "", value)
+    if (value !~ /^[0-9]+$/) {
+      printf("invalid unknown_quota_wait_seconds: %s\n", value) > "/dev/stderr"
+      exit 3
+    }
+    print value
+    found = 1
+    exit 0
+  }
 }
 END {
-	if (!found) {
-		exit 1
-	}
+  if (!found) {
+    exit 1
+  }
 }
 ' "$cfg"
 }
@@ -385,27 +385,27 @@ while true; do
     exit 2
   fi
 
-	if has_unknown_quota_guidance "$REVIEW_OUTPUT_CLEAN"; then
-		if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -lt $max_attempts ]]; then
-			if ! wait_seconds="$(read_unknown_quota_wait_seconds)" || ! [[ "$wait_seconds" =~ ^[0-9]+$ ]]; then
-				echo "ERROR: CodeRabbit CLI reported usage-based/hourly-cap quota guidance without a parseable cooldown, but workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds is missing or invalid." >&2
-				exit 2
-			fi
-			echo "" >&2
-			echo "CodeRabbit usage-based/hourly-cap quota guidance detected without a retry-after duration." >&2
-			echo "Configured fallback wait: ${wait_seconds}s from workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds; sleeping before one automatic retry..." >&2
-			sleep "$wait_seconds"
-			echo "Retrying CodeRabbit local review (attempt $((attempt + 1))/${max_attempts})..." >&2
-			attempt=$((attempt + 1))
-			continue
-		fi
-		if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -eq $max_attempts ]]; then
-			echo "ERROR: CodeRabbit CLI reported usage-based/hourly-cap quota guidance again after automatic retry. Wait for quota refill or enable the usage-based add-on, then rerun manually." >&2
-		else
-			echo "ERROR: CodeRabbit CLI reported usage-based/hourly-cap quota guidance without a retry-after duration. Pass --retry-on-rate-limit to use the configured fallback wait, or rerun after quota refill." >&2
-		fi
-		exit 2
-	fi
+  if has_unknown_quota_guidance "$REVIEW_OUTPUT_CLEAN"; then
+    if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -lt $max_attempts ]]; then
+      if ! wait_seconds="$(read_unknown_quota_wait_seconds)" || ! [[ "$wait_seconds" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: CodeRabbit CLI reported usage-based/hourly-cap quota guidance without a parseable cooldown, but workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds is missing or invalid." >&2
+        exit 2
+      fi
+      echo "" >&2
+      echo "CodeRabbit usage-based/hourly-cap quota guidance detected without a retry-after duration." >&2
+      echo "Configured fallback wait: ${wait_seconds}s from workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds; sleeping before one automatic retry..." >&2
+      sleep "$wait_seconds"
+      echo "Retrying CodeRabbit local review (attempt $((attempt + 1))/${max_attempts})..." >&2
+      attempt=$((attempt + 1))
+      continue
+    fi
+    if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -eq $max_attempts ]]; then
+      echo "ERROR: CodeRabbit CLI reported usage-based/hourly-cap quota guidance again after automatic retry. Wait for quota refill or enable the usage-based add-on, then rerun manually." >&2
+    else
+      echo "ERROR: CodeRabbit CLI reported usage-based/hourly-cap quota guidance without a retry-after duration. Pass --retry-on-rate-limit to use the configured fallback wait, or rerun after quota refill." >&2
+    fi
+    exit 2
+  fi
 
   if [[ $RETRY_ON_RATE_LIMIT -eq 1 && $attempt -eq $max_attempts ]]; then
     echo "ERROR: CodeRabbit local review failed again after automatic retry. Wait for any reported cooldown and rerun manually." >&2

--- a/.reinguard/scripts/check-local-review.sh
+++ b/.reinguard/scripts/check-local-review.sh
@@ -264,6 +264,7 @@ BEGIN {
   if (in_coderabbit && trimmed ~ /^unknown_quota_wait_seconds:/) {
     value = trimmed
     sub(/^unknown_quota_wait_seconds:[[:space:]]*/, "", value)
+    gsub(/^["'\''"]|["'\''"]$/, "", value)
     if (value !~ /^[0-9]+$/) {
       printf("invalid unknown_quota_wait_seconds: %s\n", value) > "/dev/stderr"
       exit 3

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,6 +90,16 @@ Issue/PR **policy enforcement** and related repository tooling scripts live unde
 
 Deterministic policy validators (`check-pr-policy.sh`, `check-issue-policy.sh`, `check-commit-msg.sh`) are the only current candidates for future Go-backed `rgd` migration. External-CLI and repository-maintenance scripts (`check-local-review.sh`, `sync-issue-templates.sh`, `check-coverage-threshold.sh`) remain repository-local shell tooling. The shell script suite is exercised by Go integration tests under `internal/scripttest/` and `internal/labels/`.
 
+### Workflow local review options (`reinguard.yaml`)
+
+`workflow.local_ai_review` configures repository-local pre-PR AI review tooling
+that remains outside the shipped `rgd` binary but is still validated by
+`rgd config validate`.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds` | integer, `>= 0` | Fallback wait used by `.reinguard/scripts/check-local-review.sh --retry-on-rate-limit` when CodeRabbit emits usage-based/hourly-cap guidance without a parseable retry-after duration. Explicit `try again in` / `try after` / `retry in` cooldown hints still take precedence. |
+
 ## Provider IDs ↔ commands
 
 | Provider `id` in `reinguard.yaml` | Collected by |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,7 +98,7 @@ that remains outside the shipped `rgd` binary but is still validated by
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds` | integer, `>= 0` | Fallback wait used by `.reinguard/scripts/check-local-review.sh --retry-on-rate-limit` when CodeRabbit emits usage-based/hourly-cap guidance without a parseable retry-after duration. Explicit `try again in` / `try after` / `retry in` cooldown hints still take precedence. |
+| `workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds` | integer, `0..86400` | Fallback wait, in seconds, used by `.reinguard/scripts/check-local-review.sh --retry-on-rate-limit` when CodeRabbit emits usage-based/hourly-cap guidance without a parseable retry-after duration. If omitted, that unknown-quota condition fails closed instead of inventing a wait; `0` means retry immediately. Explicit `try again in` / `try after` / `retry in` cooldown hints still take precedence. This repository uses `1860` to cover the documented OSS 2/hour refilling-bucket interval plus buffer. |
 
 ## Provider IDs ↔ commands
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Root struct {
 
 // WorkflowSpec is top-level workflow-specific config that still belongs to repo-owned Semantics.
 type WorkflowSpec struct {
+	LocalAIReview    LocalAIReviewSpec    `yaml:"local_ai_review,omitempty" json:"local_ai_review,omitempty"`
 	RuntimeGateRoles RuntimeGateRolesSpec `yaml:"runtime_gate_roles,omitempty" json:"runtime_gate_roles,omitempty"`
 }
 
@@ -46,6 +47,16 @@ type RuntimeGateRoleSpec struct {
 	GateID             string    `yaml:"gate_id,omitempty" json:"gate_id,omitempty"`
 	ProducerProcedures []string  `yaml:"producer_procedures,omitempty" json:"producer_procedures,omitempty"`
 	PassCheckIDs       []string  `yaml:"pass_check_ids,omitempty" json:"pass_check_ids,omitempty"`
+}
+
+// LocalAIReviewSpec configures repository-local pre-PR AI review tooling.
+type LocalAIReviewSpec struct {
+	CodeRabbit CodeRabbitLocalReviewSpec `yaml:"coderabbit,omitempty" json:"coderabbit,omitempty"`
+}
+
+// CodeRabbitLocalReviewSpec configures the repository-local CodeRabbit CLI gate.
+type CodeRabbitLocalReviewSpec struct {
+	UnknownQuotaWaitSeconds *int `yaml:"unknown_quota_wait_seconds,omitempty" json:"unknown_quota_wait_seconds,omitempty"`
 }
 
 // ProviderSpec is one observation provider entry.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,10 @@ type LocalAIReviewSpec struct {
 
 // CodeRabbitLocalReviewSpec configures the repository-local CodeRabbit CLI gate.
 type CodeRabbitLocalReviewSpec struct {
+	// UnknownQuotaWaitSeconds is the fallback wait before one local CodeRabbit retry when
+	// the CLI reports usage-based/hourly-cap quota guidance without a retry-after duration.
+	// The repository config currently uses 1860 seconds for the OSS 2/hour refill floor;
+	// 0 means retry immediately, and values above 86400 seconds are rejected.
 	UnknownQuotaWaitSeconds *int `yaml:"unknown_quota_wait_seconds,omitempty" json:"unknown_quota_wait_seconds,omitempty"`
 }
 
@@ -191,6 +195,20 @@ func validateRulesMatchControlKind(kind string, rules []Rule, pathHint string) e
 		if ru.Type != want {
 			return fmt.Errorf("config: rule[%d] in %s has type %q, expected %q for control/%s/", i, pathHint, ru.Type, want, kind)
 		}
+	}
+	return nil
+}
+
+func validateLocalAIReview(root *Root, pathHint string) error {
+	wait := root.Workflow.LocalAIReview.CodeRabbit.UnknownQuotaWaitSeconds
+	if wait == nil {
+		return nil
+	}
+	if *wait < 0 {
+		return fmt.Errorf("config: workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds in %s must be >= 0, got %d", pathHint, *wait)
+	}
+	if *wait > 86400 {
+		return fmt.Errorf("config: workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds in %s must be <= 86400, got %d", pathHint, *wait)
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,20 +199,6 @@ func validateRulesMatchControlKind(kind string, rules []Rule, pathHint string) e
 	return nil
 }
 
-func validateLocalAIReview(root *Root, pathHint string) error {
-	wait := root.Workflow.LocalAIReview.CodeRabbit.UnknownQuotaWaitSeconds
-	if wait == nil {
-		return nil
-	}
-	if *wait < 0 {
-		return fmt.Errorf("config: workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds in %s must be >= 0, got %d", pathHint, *wait)
-	}
-	if *wait > 86400 {
-		return fmt.Errorf("config: workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds in %s must be <= 86400, got %d", pathHint, *wait)
-	}
-	return nil
-}
-
 func validateDoc(sch *jsonschema.Schema, doc any, pathHint string) error {
 	if err := sch.Validate(doc); err != nil {
 		return fmt.Errorf("config: schema validation %s: %w", pathHint, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -712,6 +712,28 @@ providers: []
 	}
 }
 
+func TestLoadRoot_localAIReviewRejectsTooLargeUnknownQuotaWait(t *testing.T) {
+	t.Parallel()
+	// Given: reinguard.yaml with an excessive CodeRabbit unknown-quota fallback.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+default_branch: main
+workflow:
+  local_ai_review:
+    coderabbit:
+      unknown_quota_wait_seconds: 86401
+providers: []
+`, schema.CurrentSchemaVersion)))
+
+	// When: LoadRoot is called.
+	_, err := LoadRoot(dir)
+
+	// Then: validation rejects the value.
+	if err == nil || !strings.Contains(err.Error(), "unknown_quota_wait_seconds") {
+		t.Fatalf("got err=%v", err)
+	}
+}
+
 func TestLoadRoot_runtimeGateRolesDuplicateGateID(t *testing.T) {
 	t.Parallel()
 	// Given: reinguard.yaml with two runtime gate roles sharing the same gate_id

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -664,6 +664,54 @@ providers: []
 	}
 }
 
+func TestLoadRoot_localAIReviewCodeRabbitUnknownQuotaWait(t *testing.T) {
+	t.Parallel()
+	// Given: reinguard.yaml with CodeRabbit local review unknown-quota fallback configured.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+default_branch: main
+workflow:
+  local_ai_review:
+    coderabbit:
+      unknown_quota_wait_seconds: 1860
+providers: []
+`, schema.CurrentSchemaVersion)))
+
+	// When: LoadRoot is called.
+	root, err := LoadRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Then: the typed config preserves the configured wait.
+	got := root.Workflow.LocalAIReview.CodeRabbit.UnknownQuotaWaitSeconds
+	if got == nil || *got != 1860 {
+		t.Fatalf("unknown_quota_wait_seconds=%v, want 1860", got)
+	}
+}
+
+func TestLoadRoot_localAIReviewRejectsNegativeUnknownQuotaWait(t *testing.T) {
+	t.Parallel()
+	// Given: reinguard.yaml with an invalid negative CodeRabbit unknown-quota fallback.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+default_branch: main
+workflow:
+  local_ai_review:
+    coderabbit:
+      unknown_quota_wait_seconds: -1
+providers: []
+`, schema.CurrentSchemaVersion)))
+
+	// When: LoadRoot is called.
+	_, err := LoadRoot(dir)
+
+	// Then: JSON Schema rejects the value.
+	if err == nil || !strings.Contains(err.Error(), "unknown_quota_wait_seconds") {
+		t.Fatalf("got err=%v", err)
+	}
+}
+
 func TestLoadRoot_runtimeGateRolesDuplicateGateID(t *testing.T) {
 	t.Parallel()
 	// Given: reinguard.yaml with two runtime gate roles sharing the same gate_id

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -666,71 +666,65 @@ providers: []
 
 func TestLoadRoot_localAIReviewCodeRabbitUnknownQuotaWait(t *testing.T) {
 	t.Parallel()
-	// Given: reinguard.yaml with CodeRabbit local review unknown-quota fallback configured.
-	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "reinguard.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+	tests := []struct {
+		name          string
+		wantErrSubstr string
+		value         int
+		wantValue     int
+		wantErr       bool
+	}{
+		{
+			name:      "valid value",
+			value:     1860,
+			wantValue: 1860,
+		},
+		{
+			name:          "negative rejected",
+			value:         -1,
+			wantErr:       true,
+			wantErrSubstr: "unknown_quota_wait_seconds",
+		},
+		{
+			name:          "exceeds max rejected",
+			value:         86401,
+			wantErr:       true,
+			wantErrSubstr: "unknown_quota_wait_seconds",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Given: reinguard.yaml with a CodeRabbit local review unknown-quota fallback.
+			dir := t.TempDir()
+			writeFile(t, filepath.Join(dir, "reinguard.yaml"), []byte(fmt.Sprintf(`schema_version: %q
 default_branch: main
 workflow:
   local_ai_review:
     coderabbit:
-      unknown_quota_wait_seconds: 1860
+      unknown_quota_wait_seconds: %d
 providers: []
-`, schema.CurrentSchemaVersion)))
+`, schema.CurrentSchemaVersion, tt.value)))
 
-	// When: LoadRoot is called.
-	root, err := LoadRoot(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+			// When: LoadRoot is called.
+			root, err := LoadRoot(dir)
 
-	// Then: the typed config preserves the configured wait.
-	got := root.Workflow.LocalAIReview.CodeRabbit.UnknownQuotaWaitSeconds
-	if got == nil || *got != 1860 {
-		t.Fatalf("unknown_quota_wait_seconds=%v, want 1860", got)
-	}
-}
-
-func TestLoadRoot_localAIReviewRejectsNegativeUnknownQuotaWait(t *testing.T) {
-	t.Parallel()
-	// Given: reinguard.yaml with an invalid negative CodeRabbit unknown-quota fallback.
-	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "reinguard.yaml"), []byte(fmt.Sprintf(`schema_version: %q
-default_branch: main
-workflow:
-  local_ai_review:
-    coderabbit:
-      unknown_quota_wait_seconds: -1
-providers: []
-`, schema.CurrentSchemaVersion)))
-
-	// When: LoadRoot is called.
-	_, err := LoadRoot(dir)
-
-	// Then: JSON Schema rejects the value.
-	if err == nil || !strings.Contains(err.Error(), "unknown_quota_wait_seconds") {
-		t.Fatalf("got err=%v", err)
-	}
-}
-
-func TestLoadRoot_localAIReviewRejectsTooLargeUnknownQuotaWait(t *testing.T) {
-	t.Parallel()
-	// Given: reinguard.yaml with an excessive CodeRabbit unknown-quota fallback.
-	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "reinguard.yaml"), []byte(fmt.Sprintf(`schema_version: %q
-default_branch: main
-workflow:
-  local_ai_review:
-    coderabbit:
-      unknown_quota_wait_seconds: 86401
-providers: []
-`, schema.CurrentSchemaVersion)))
-
-	// When: LoadRoot is called.
-	_, err := LoadRoot(dir)
-
-	// Then: validation rejects the value.
-	if err == nil || !strings.Contains(err.Error(), "unknown_quota_wait_seconds") {
-		t.Fatalf("got err=%v", err)
+			// Then: validation preserves valid values and rejects invalid bounds.
+			if tt.wantErr {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrSubstr) {
+					t.Fatalf("got err=%v, want substring %q", err, tt.wantErrSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := root.Workflow.LocalAIReview.CodeRabbit.UnknownQuotaWaitSeconds
+			if got == nil || *got != tt.wantValue {
+				t.Fatalf("unknown_quota_wait_seconds=%v, want %d", got, tt.wantValue)
+			}
+		})
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -737,6 +737,64 @@ providers: []
 	}
 }
 
+func intPtr(v int) *int {
+	return &v
+}
+
+func TestValidateLocalAIReview(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		wait          *int
+		wantErrSubstr string
+	}{
+		{
+			name: "nil wait allowed",
+		},
+		{
+			name: "zero wait allowed",
+			wait: intPtr(0),
+		},
+		{
+			name: "max wait allowed",
+			wait: intPtr(maxUnknownQuotaWaitSeconds),
+		},
+		{
+			name:          "negative rejected",
+			wait:          intPtr(-1),
+			wantErrSubstr: "must be >= 0",
+		},
+		{
+			name:          "over max rejected",
+			wait:          intPtr(maxUnknownQuotaWaitSeconds + 1),
+			wantErrSubstr: "must be <= 86400",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Given: a root with the local CodeRabbit fallback wait configured for this case.
+			root := Root{}
+			root.Workflow.LocalAIReview.CodeRabbit.UnknownQuotaWaitSeconds = tt.wait
+
+			// When: local AI review validation runs.
+			err := validateLocalAIReview(&root, "reinguard.yaml")
+
+			// Then: each branch preserves the intended bound behavior.
+			if tt.wantErrSubstr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrSubstr) {
+					t.Fatalf("got err=%v, want substring %q", err, tt.wantErrSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestLoadRoot_runtimeGateRolesDuplicateGateID(t *testing.T) {
 	t.Parallel()
 	// Given: reinguard.yaml with two runtime gate roles sharing the same gate_id

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -679,6 +679,16 @@ func TestLoadRoot_localAIReviewCodeRabbitUnknownQuotaWait(t *testing.T) {
 			wantValue: 1860,
 		},
 		{
+			name:      "minimum valid",
+			value:     0,
+			wantValue: 0,
+		},
+		{
+			name:      "maximum valid",
+			value:     86400,
+			wantValue: 86400,
+		},
+		{
 			name:          "negative rejected",
 			value:         -1,
 			wantErr:       true,
@@ -693,7 +703,6 @@ func TestLoadRoot_localAIReviewCodeRabbitUnknownQuotaWait(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			// Given: reinguard.yaml with a CodeRabbit local review unknown-quota fallback.

--- a/internal/config/load_bundle.go
+++ b/internal/config/load_bundle.go
@@ -76,6 +76,9 @@ func readAndValidateRoot(dir string, rootSch *jsonschema.Schema) (Root, error) {
 	if err = validateRuntimeGateRoles(&root, rootPath); err != nil {
 		return Root{}, err
 	}
+	if err = validateLocalAIReview(&root, rootPath); err != nil {
+		return Root{}, err
+	}
 	if err := rejectLegacyRulesDir(dir); err != nil {
 		return Root{}, err
 	}

--- a/internal/config/load_bundle.go
+++ b/internal/config/load_bundle.go
@@ -85,6 +85,20 @@ func readAndValidateRoot(dir string, rootSch *jsonschema.Schema) (Root, error) {
 	return root, nil
 }
 
+func validateLocalAIReview(root *Root, pathHint string) error {
+	wait := root.Workflow.LocalAIReview.CodeRabbit.UnknownQuotaWaitSeconds
+	if wait == nil {
+		return nil
+	}
+	if *wait < 0 {
+		return fmt.Errorf("config: workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds in %s must be >= 0, got %d", pathHint, *wait)
+	}
+	if *wait > 86400 {
+		return fmt.Errorf("config: workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds in %s must be <= 86400, got %d", pathHint, *wait)
+	}
+	return nil
+}
+
 func rejectLegacyRulesDir(dir string) error {
 	legacyRulesDir := filepath.Join(dir, "rules")
 	entries, lerr := os.ReadDir(legacyRulesDir)

--- a/internal/config/load_bundle.go
+++ b/internal/config/load_bundle.go
@@ -18,6 +18,8 @@ import (
 	"github.com/k-shibuki/reinguard/pkg/schema"
 )
 
+const maxUnknownQuotaWaitSeconds = 86400
+
 // loadSchemaSet holds compiled JSON Schema handles for one Load invocation.
 type loadSchemaSet struct {
 	root   *jsonschema.Schema
@@ -93,8 +95,8 @@ func validateLocalAIReview(root *Root, pathHint string) error {
 	if *wait < 0 {
 		return fmt.Errorf("config: workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds in %s must be >= 0, got %d", pathHint, *wait)
 	}
-	if *wait > 86400 {
-		return fmt.Errorf("config: workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds in %s must be <= 86400, got %d", pathHint, *wait)
+	if *wait > maxUnknownQuotaWaitSeconds {
+		return fmt.Errorf("config: workflow.local_ai_review.coderabbit.unknown_quota_wait_seconds in %s must be <= %d, got %d", pathHint, maxUnknownQuotaWaitSeconds, *wait)
 	}
 	return nil
 }

--- a/internal/observe/github/prquery/diagnostics.go
+++ b/internal/observe/github/prquery/diagnostics.go
@@ -100,6 +100,12 @@ func nonThreadFindingsPresentForRequiredBots(statusList []any) bool {
 // bot's status map is positive (actionable, outside-diff, duplicate, or finding-shaped
 // conversation comments).
 func nonThreadFindingsPresentForStatus(m map[string]any) bool {
+	if status, _ := m["status"].(string); status == BotStatusCompletedClean {
+		return false
+	}
+	if statusMapBoolAny(m, true, "cr_review_completed_clean", "review_completed_clean") {
+		return false
+	}
 	a := intFromStatusMapOrZeroAny(m, "actionable_findings_count", "cr_actionable_comments_count")
 	o := intFromStatusMapOrZeroAny(m, "outside_diff_findings_count", "cr_outside_diff_comments_count")
 	d := intFromStatusMapOrZeroAny(m, "duplicate_findings_count", "cr_duplicate_findings_count")

--- a/internal/observe/github/prquery/status_test.go
+++ b/internal/observe/github/prquery/status_test.go
@@ -213,6 +213,19 @@ func TestComputeBotReviewDiagnostics_cleanCompletionClearsStaleNonThreadFindings
 	if got["non_thread_findings_present"].(bool) {
 		t.Fatalf("want non_thread_findings_present=false after clean completion: %+v", got)
 	}
+
+	gotAlias := ComputeBotReviewDiagnostics([]any{
+		map[string]any{
+			"required":                  true,
+			"status":                    BotStatusCompleted,
+			"review_commit_sha":         "abc123",
+			"cr_review_completed_clean": true,
+			"actionable_findings_count": 1,
+		},
+	}, "abc123", false)
+	if gotAlias["non_thread_findings_present"].(bool) {
+		t.Fatalf("want non_thread_findings_present=false when cr_review_completed_clean=true: %+v", gotAlias)
+	}
 }
 
 func TestComputeBotReviewDiagnostics_nonThreadFindingsOptionalOnly(t *testing.T) {

--- a/internal/observe/github/prquery/status_test.go
+++ b/internal/observe/github/prquery/status_test.go
@@ -195,6 +195,26 @@ func TestComputeBotReviewDiagnostics_nonThreadFindingsRequired(t *testing.T) {
 	}
 }
 
+func TestComputeBotReviewDiagnostics_cleanCompletionClearsStaleNonThreadFindings(t *testing.T) {
+	t.Parallel()
+	// Given: CodeRabbit status is clean for the current head, while older review-body counts remain on the status map.
+	got := ComputeBotReviewDiagnostics([]any{
+		map[string]any{
+			"required":                    true,
+			"status":                      BotStatusCompletedClean,
+			"review_commit_sha":           "abc123",
+			"review_completed_clean":      true,
+			"actionable_findings_count":   1,
+			"outside_diff_findings_count": 1,
+		},
+	}, "abc123", false)
+
+	// Then: stale non-thread finding counts do not block merge readiness after a clean bot completion.
+	if got["non_thread_findings_present"].(bool) {
+		t.Fatalf("want non_thread_findings_present=false after clean completion: %+v", got)
+	}
+}
+
 func TestComputeBotReviewDiagnostics_nonThreadFindingsOptionalOnly(t *testing.T) {
 	t.Parallel()
 	// Given: optional-only bot with outside-diff findings signal

--- a/internal/scripttest/local_review_script_test.go
+++ b/internal/scripttest/local_review_script_test.go
@@ -382,6 +382,60 @@ printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
 	}
 }
 
+func TestCheckLocalReviewScript_UnknownQuotaGuidanceRejectsInvalidFallback(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "check-local-review.sh")
+	// Given: CodeRabbit emits usage-based/hourly-cap guidance, but repo config has an invalid fallback wait.
+	repo := setupLocalReviewRepo(t)
+	writeLocalReviewReinguardConfig(t, repo, "not-a-number")
+
+	stubDir := t.TempDir()
+	sleepFile := filepath.Join(stubDir, "sleep.log")
+	writeExecutable(t, stubDir, "coderabbit", `#!/usr/bin/env bash
+set -euo pipefail
+subcmd="$1"; shift
+case "$subcmd" in
+  auth) echo "Authentication: logged in" ;;
+  review)
+    echo "ERROR: To keep reviews running without waiting, you can enable usage-based add-on for your organization. This allows additional reviews beyond the hourly cap."
+    exit 1
+    ;;
+  *) exit 1 ;;
+esac
+`)
+	writeExecutable(t, stubDir, "sleep", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
+`)
+
+	env := []string{
+		"PATH=" + stubDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"TEST_SLEEP_FILE=" + sleepFile,
+	}
+
+	// When: automatic retry is enabled.
+	out, err := runBashScript(t, repo, script, env, "--base", "main", "--retry-on-rate-limit")
+
+	// Then: the script fails closed instead of sleeping with an invalid fallback.
+	if err == nil {
+		t.Fatalf("expected failure, got success:\n%s", out)
+	}
+	requireExitCode(t, err, 2, out)
+	if !strings.Contains(out, "unknown_quota_wait_seconds is missing or invalid") {
+		t.Fatalf("expected invalid fallback diagnostic, got:\n%s", out)
+	}
+	if _, err := os.Stat(sleepFile); err == nil {
+		sleepLog, readErr := os.ReadFile(sleepFile)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		t.Fatalf("expected fail-closed behavior without sleep, got sleep log:\n%s", sleepLog)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error checking sleep file: %v", err)
+	}
+}
+
 func TestCheckLocalReviewScript_ExplicitCooldownPrecedesUnknownQuotaFallback(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scripttest/local_review_script_test.go
+++ b/internal/scripttest/local_review_script_test.go
@@ -35,6 +35,24 @@ func setupLocalReviewRepo(t *testing.T) string {
 	return repo
 }
 
+func writeLocalReviewReinguardConfig(t *testing.T, repo, waitSeconds string) {
+	t.Helper()
+	cfgDir := filepath.Join(repo, ".reinguard")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "reinguard.yaml"), []byte(`schema_version: "0.8.0"
+default_branch: main
+workflow:
+  local_ai_review:
+    coderabbit:
+      unknown_quota_wait_seconds: `+waitSeconds+`
+providers: []
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCheckLocalReviewScript_RetryUsesLatestRateLimitLine(t *testing.T) {
 	t.Parallel()
 
@@ -239,6 +257,237 @@ printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
 		t.Fatalf("expected fail-closed without sleep; footer must not supply cooldown, got:\n%s", sleepLog)
 	} else if !os.IsNotExist(err) {
 		t.Fatalf("unexpected error checking sleep file: %v", err)
+	}
+}
+
+func TestCheckLocalReviewScript_UnknownQuotaGuidanceUsesConfiguredFallback(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "check-local-review.sh")
+	// Given: CodeRabbit emits usage-based/hourly-cap guidance without retry-after, and repo config supplies fallback wait.
+	repo := setupLocalReviewRepo(t)
+	writeLocalReviewReinguardConfig(t, repo, "1860")
+
+	stubDir := t.TempDir()
+	sleepFile := filepath.Join(stubDir, "sleep.log")
+	countFile := filepath.Join(stubDir, "coderabbit-count.txt")
+	writeExecutable(t, stubDir, "coderabbit", `#!/usr/bin/env bash
+set -euo pipefail
+subcmd="$1"; shift
+case "$subcmd" in
+  auth) echo "Authentication: logged in" ;;
+  review)
+    count=0; [[ -f "${TEST_COUNT_FILE:?}" ]] && count=$(cat "${TEST_COUNT_FILE:?}")
+    count=$((count + 1)); printf '%s\n' "$count" >"${TEST_COUNT_FILE:?}"
+    if [[ $count -eq 1 ]]; then
+      echo "ERROR: To keep reviews running without waiting, you can enable usage-based add-on for your organization. This allows additional reviews beyond the hourly cap."
+      exit 1
+    fi
+    echo "Review completed: 0 findings"
+    ;;
+  *) exit 1 ;;
+esac
+`)
+	writeExecutable(t, stubDir, "sleep", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
+`)
+
+	env := []string{
+		"PATH=" + stubDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"TEST_SLEEP_FILE=" + sleepFile,
+		"TEST_COUNT_FILE=" + countFile,
+	}
+
+	// When: automatic retry is enabled.
+	out, err := runBashScript(t, repo, script, env, "--base", "main", "--retry-on-rate-limit")
+	if err != nil {
+		t.Fatalf("check-local-review: %v\n%s", err, out)
+	}
+
+	// Then: the configured fallback wait is used before the one retry.
+	sleepLog, err := os.ReadFile(sleepFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(sleepLog)); got != "1860" {
+		t.Fatalf("sleep seconds = %q, want 1860", got)
+	}
+	if !strings.Contains(out, "CodeRabbit local review completed.") {
+		t.Fatalf("expected completion message, got:\n%s", out)
+	}
+}
+
+func TestCheckLocalReviewScript_UnknownQuotaGuidanceRequiresConfiguredFallback(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "check-local-review.sh")
+	// Given: CodeRabbit emits usage-based/hourly-cap guidance, but repo config has no fallback wait.
+	repo := setupLocalReviewRepo(t)
+
+	stubDir := t.TempDir()
+	sleepFile := filepath.Join(stubDir, "sleep.log")
+	writeExecutable(t, stubDir, "coderabbit", `#!/usr/bin/env bash
+set -euo pipefail
+subcmd="$1"; shift
+case "$subcmd" in
+  auth) echo "Authentication: logged in" ;;
+  review)
+    echo "ERROR: To keep reviews running without waiting, you can enable usage-based add-on for your organization. This allows additional reviews beyond the hourly cap."
+    exit 1
+    ;;
+  *) exit 1 ;;
+esac
+`)
+	writeExecutable(t, stubDir, "sleep", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
+`)
+
+	env := []string{
+		"PATH=" + stubDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"TEST_SLEEP_FILE=" + sleepFile,
+	}
+
+	// When: automatic retry is enabled.
+	out, err := runBashScript(t, repo, script, env, "--base", "main", "--retry-on-rate-limit")
+
+	// Then: the script fails closed instead of inventing a wait.
+	if err == nil {
+		t.Fatalf("expected failure, got success:\n%s", out)
+	}
+	requireExitCode(t, err, 2, out)
+	if !strings.Contains(out, "unknown_quota_wait_seconds is missing or invalid") {
+		t.Fatalf("expected missing fallback diagnostic, got:\n%s", out)
+	}
+	if _, err := os.Stat(sleepFile); err == nil {
+		sleepLog, readErr := os.ReadFile(sleepFile)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		t.Fatalf("expected fail-closed behavior without sleep, got sleep log:\n%s", sleepLog)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error checking sleep file: %v", err)
+	}
+}
+
+func TestCheckLocalReviewScript_ExplicitCooldownPrecedesUnknownQuotaFallback(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "check-local-review.sh")
+	// Given: CodeRabbit output includes billing guidance and a parseable cooldown line.
+	repo := setupLocalReviewRepo(t)
+	writeLocalReviewReinguardConfig(t, repo, "1860")
+
+	stubDir := t.TempDir()
+	sleepFile := filepath.Join(stubDir, "sleep.log")
+	countFile := filepath.Join(stubDir, "coderabbit-count.txt")
+	writeExecutable(t, stubDir, "coderabbit", `#!/usr/bin/env bash
+set -euo pipefail
+subcmd="$1"; shift
+case "$subcmd" in
+  auth) echo "Authentication: logged in" ;;
+  review)
+    count=0; [[ -f "${TEST_COUNT_FILE:?}" ]] && count=$(cat "${TEST_COUNT_FILE:?}")
+    count=$((count + 1)); printf '%s\n' "$count" >"${TEST_COUNT_FILE:?}"
+    if [[ $count -eq 1 ]]; then
+      echo "usage-based add-on notice"
+      echo "Rate limit exceeded, retry in 1 seconds"
+      exit 1
+    fi
+    echo "Review completed: 0 findings"
+    ;;
+  *) exit 1 ;;
+esac
+`)
+	writeExecutable(t, stubDir, "sleep", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
+`)
+
+	env := []string{
+		"PATH=" + stubDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"TEST_SLEEP_FILE=" + sleepFile,
+		"TEST_COUNT_FILE=" + countFile,
+		"RATE_LIMIT_RETRY_BUFFER_SEC=30",
+	}
+
+	// When: automatic retry is enabled.
+	out, err := runBashScript(t, repo, script, env, "--base", "main", "--retry-on-rate-limit")
+	if err != nil {
+		t.Fatalf("check-local-review: %v\n%s", err, out)
+	}
+
+	// Then: explicit cooldown plus buffer wins over the configured unknown-quota fallback.
+	sleepLog, err := os.ReadFile(sleepFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(sleepLog)); got != "31" {
+		t.Fatalf("sleep seconds = %q, want 31", got)
+	}
+}
+
+func TestCheckLocalReviewScript_UnknownQuotaGuidanceSecondHitFails(t *testing.T) {
+	t.Parallel()
+
+	script := scriptPath(t, "check-local-review.sh")
+	// Given: CodeRabbit emits usage-based/hourly-cap guidance on both attempts.
+	repo := setupLocalReviewRepo(t)
+	writeLocalReviewReinguardConfig(t, repo, "1860")
+
+	stubDir := t.TempDir()
+	sleepFile := filepath.Join(stubDir, "sleep.log")
+	countFile := filepath.Join(stubDir, "coderabbit-count.txt")
+	writeExecutable(t, stubDir, "coderabbit", `#!/usr/bin/env bash
+set -euo pipefail
+subcmd="$1"; shift
+case "$subcmd" in
+  auth) echo "Authentication: logged in" ;;
+  review)
+    count=0; [[ -f "${TEST_COUNT_FILE:?}" ]] && count=$(cat "${TEST_COUNT_FILE:?}")
+    count=$((count + 1)); printf '%s\n' "$count" >"${TEST_COUNT_FILE:?}"
+    echo "ERROR: To keep reviews running without waiting, you can enable usage-based add-on for your organization. This allows additional reviews beyond the hourly cap."
+    exit 1
+    ;;
+  *) exit 1 ;;
+esac
+`)
+	writeExecutable(t, stubDir, "sleep", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
+`)
+
+	env := []string{
+		"PATH=" + stubDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"TEST_SLEEP_FILE=" + sleepFile,
+		"TEST_COUNT_FILE=" + countFile,
+	}
+
+	// When: automatic retry is enabled.
+	out, err := runBashScript(t, repo, script, env, "--base", "main", "--retry-on-rate-limit")
+
+	// Then: the script retries once and then fails with a quota-specific diagnostic.
+	if err == nil {
+		t.Fatalf("expected failure, got success:\n%s", out)
+	}
+	requireExitCode(t, err, 2, out)
+	if !strings.Contains(out, "usage-based/hourly-cap quota guidance again after automatic retry") {
+		t.Fatalf("expected second quota hit diagnostic, got:\n%s", out)
+	}
+	sleepLog, err := os.ReadFile(sleepFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(sleepLog)); got != "1860" {
+		t.Fatalf("sleep seconds = %q, want one 1860 wait", got)
+	}
+	reviewCount, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(reviewCount)); got != "2" {
+		t.Fatalf("review attempts = %q, want 2", got)
 	}
 }
 

--- a/internal/scripttest/local_review_script_test.go
+++ b/internal/scripttest/local_review_script_test.go
@@ -2,11 +2,14 @@ package scripttest
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/k-shibuki/reinguard/pkg/schema"
 )
 
 func requireExitCode(t *testing.T, err error, want int, out string) {
@@ -41,14 +44,15 @@ func writeLocalReviewReinguardConfig(t *testing.T, repo, waitSeconds string) {
 	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(cfgDir, "reinguard.yaml"), []byte(`schema_version: "0.8.0"
+	cfg := fmt.Sprintf(`schema_version: %q
 default_branch: main
 workflow:
   local_ai_review:
     coderabbit:
-      unknown_quota_wait_seconds: `+waitSeconds+`
+      unknown_quota_wait_seconds: %s
 providers: []
-`), 0o644); err != nil {
+`, schema.CurrentSchemaVersion, waitSeconds)
+	if err := os.WriteFile(filepath.Join(cfgDir, "reinguard.yaml"), []byte(cfg), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/scripttest/local_review_script_test.go
+++ b/internal/scripttest/local_review_script_test.go
@@ -317,6 +317,13 @@ printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
 	if got := strings.TrimSpace(string(sleepLog)); got != "1860" {
 		t.Fatalf("sleep seconds = %q, want 1860", got)
 	}
+	reviewCount, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(reviewCount)); got != "2" {
+		t.Fatalf("review attempts = %q, want 2", got)
+	}
 	if !strings.Contains(out, "CodeRabbit local review completed.") {
 		t.Fatalf("expected completion message, got:\n%s", out)
 	}
@@ -429,6 +436,13 @@ printf '%s\n' "$1" >>"${TEST_SLEEP_FILE:?}"
 	}
 	if got := strings.TrimSpace(string(sleepLog)); got != "31" {
 		t.Fatalf("sleep seconds = %q, want 31", got)
+	}
+	reviewCount, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(reviewCount)); got != "2" {
+		t.Fatalf("review attempts = %q, want 2", got)
 	}
 }
 

--- a/pkg/schema/reinguard-config.json
+++ b/pkg/schema/reinguard-config.json
@@ -33,7 +33,7 @@
                   "type": "integer",
                   "minimum": 0,
                   "maximum": 86400,
-                  "description": "Fallback wait before one retry when CodeRabbit emits usage-based/hourly-cap guidance without a parseable retry-after duration."
+                  "description": "Fallback wait before one retry when CodeRabbit emits usage-based/hourly-cap guidance without a parseable retry-after duration. Zero is allowed and means retry immediately."
                 }
               }
             }

--- a/pkg/schema/reinguard-config.json
+++ b/pkg/schema/reinguard-config.json
@@ -32,6 +32,7 @@
                 "unknown_quota_wait_seconds": {
                   "type": "integer",
                   "minimum": 0,
+                  "maximum": 86400,
                   "description": "Fallback wait before one retry when CodeRabbit emits usage-based/hourly-cap guidance without a parseable retry-after duration."
                 }
               }

--- a/pkg/schema/reinguard-config.json
+++ b/pkg/schema/reinguard-config.json
@@ -19,6 +19,25 @@
       "description": "Optional workflow overlay: runtime gate role bindings and related PR readiness wiring (see ADR-0014).",
       "additionalProperties": false,
       "properties": {
+        "local_ai_review": {
+          "type": "object",
+          "description": "Repository-local pre-PR AI review tooling policy.",
+          "additionalProperties": false,
+          "properties": {
+            "coderabbit": {
+              "type": "object",
+              "description": "Repository-local CodeRabbit CLI gate policy.",
+              "additionalProperties": false,
+              "properties": {
+                "unknown_quota_wait_seconds": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Fallback wait before one retry when CodeRabbit emits usage-based/hourly-cap guidance without a parseable retry-after duration."
+                }
+              }
+            }
+          }
+        },
         "runtime_gate_roles": {
           "type": "object",
           "additionalProperties": false,


### PR DESCRIPTION
## Summary

- Add active bot-review signal preconditions to the review-address procedure.
- Add a configured CodeRabbit local CLI fallback for hourly-cap guidance without retry-after, including schema/config validation and hermetic script tests.
- Document the local review retry contract and clarify related preflight behavior.

## Traceability

Closes #130

Refs: #133

## Definition of Done

- [x] Tests added or updated (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. `bash .reinguard/scripts/with-repo-local-state.sh -- go test ./... -race`
2. `bash .reinguard/scripts/with-repo-local-state.sh -- go vet ./...`
3. `bash .reinguard/scripts/with-repo-local-state.sh -- golangci-lint run`
4. `bash .reinguard/scripts/with-repo-local-state.sh -- pre-commit run markdownlint-cli2 --all-files`
5. `go run ./cmd/rgd config validate`
6. `bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- bash .reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit`

## Risk / Impact

- Affects local pre-PR CodeRabbit review gating and repository workflow documentation. The fallback applies only to recognized hourly-cap guidance without a parseable cooldown; generic CLI failures still fail closed.

## Rollback Plan

- Revert this PR if the local review gate behavior causes unexpected retry handling or schema/config validation regressions.

## Exception

- Type: N/A
- Justification: N/A
