### PR TITLE
fix(review): keep paused CodeRabbit reviews blocked

### DIFF
--- a/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
+++ b/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
@@ -39,16 +39,14 @@ wins** among matching rules (ADR-0004). `state_id` values:
 
 - **Reviewed (success path):**
   - `completed` - bot finished review; review findings may or may not have been reported.
-  - `completed_clean` - all of the following are true:
-    1. The bot finished review.
-    2. The bot emitted an explicit clean marker recognized by the observation/provider implementation for that bot (see `docs/cli.md` signal notes for the current enrichment contract).
-    3. A corresponding GitHub review entry for the same bot login is observable.
-  - Timing rule: if the clean marker is observed before the matching
-    GitHub review entry appears in the observation pass, classify as
-    `completed` on that pass and upgrade to `completed_clean` on a later
-    observation pass once both are visible. If the GitHub review entry
-    appears first, remain `completed` until the clean marker is also
-    observed.
+  - `completed_clean` - the bot emitted an explicit clean marker recognized by
+    the observation/provider implementation for that bot (see `docs/cli.md`
+    signal notes for the current enrichment contract). A matching GitHub review
+    entry is sufficient but not required when the provider reports the clean
+    result through a selected status comment, such as CodeRabbit's "no
+    actionable comments" summary.
+  - Timing rule: if a GitHub review entry appears before the clean marker,
+    remain `completed` until the clean marker is also observed.
 - **Blocked:** `rate_limited`, `review_paused`. A required bot remains blocked
   and non-terminal when the selected status comment has a `review_paused`
   marker, even if the same comment also contains a clean review summary.

--- a/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
+++ b/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
@@ -49,7 +49,11 @@ wins** among matching rules (ADR-0004). `state_id` values:
     observation pass once both are visible. If the GitHub review entry
     appears first, remain `completed` until the clean marker is also
     observed.
-- **Blocked:** `rate_limited`, `review_paused`
+- **Blocked:** `rate_limited`, `review_paused`. A required bot remains blocked
+  and non-terminal when the selected status comment has a `review_paused`
+  marker, even if the same comment also contains a clean review summary.
+  Comment selection and marker recognition rules are defined by the observation
+  contract in `docs/cli.md`.
 - **Failed:** `review_failed`
 - **In progress:** `pending`, `not_triggered`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -341,13 +341,38 @@ Each element of `review_inbox` represents one unresolved GitHub review thread.
 Each element of `bot_reviewer_status` includes:
 
 - **Identity and requirement:** `id`, `login`, `required`.
-- **`status`:** classified string — `not_triggered`, `pending`, `completed`, `completed_clean`, `rate_limited`, `review_paused`, `review_failed`. `completed_clean` applies when an enrichment can prove a terminal clean result (e.g. CodeRabbit “No issues found” / “no actionable comments” in issue comments), with or without a `latestReviews` entry. For **CodeRabbit** (`enrich` includes `coderabbit`), `rate_limited` is set only when **`rate_limit_remaining_seconds` > 0** after the age adjustment below (active cooldown), not merely because the selected status comment body contains the words “rate limit” (stale quota text can coexist with a terminal-clean summary in one comment). When the selected CodeRabbit rate-limit notice has expired, `status` remains `pending` until a newer decisive status marker supersedes that selected notice marker; a `latestReviews` entry alone does not force `completed`.
-- **`status_class_basis` (CodeRabbit enrich only):** machine-readable string naming which signal decided `status` (e.g. `review_completed_clean`, `active_rate_limit_cooldown`, `review_rate_limit_notice`, `github_pull_request_review`, `issue_comments_pending`). Omitted when `enrich` does not include `coderabbit`.
+- **`status`:** classified string — `not_triggered`, `pending`, `completed`, `completed_clean`, `rate_limited`, `review_paused`, `review_failed`.
+  - `completed_clean` applies when an enrichment can prove a terminal clean
+    result (e.g. CodeRabbit “No issues found” / “no actionable comments” in
+    issue comments), with or without a `latestReviews` entry.
+  - For **CodeRabbit** (`enrich` includes `coderabbit`), a `review_paused`
+    marker in the selected status comment takes precedence over a clean marker
+    in that same comment because paused review is blocked and non-terminal.
+  - `rate_limited` is set only when **`rate_limit_remaining_seconds` > 0** after
+    the age adjustment below (active cooldown), not merely because the selected
+    status comment body contains the words “rate limit” (stale quota text can
+    coexist with a terminal-clean summary in one comment). An active cooldown
+    takes precedence over a clean marker in the same selected comment.
+  - When the selected CodeRabbit rate-limit notice has expired, `status` remains
+    `pending` until a newer decisive status marker supersedes that selected
+    notice marker; a `latestReviews` entry alone does not force `completed`.
+- **`status_class_basis` (CodeRabbit enrich only):** machine-readable string naming which signal decided `status` (e.g. `review_paused`, `review_completed_clean`, `active_rate_limit_cooldown`, `review_rate_limit_notice`, `github_pull_request_review`, `issue_comments_pending`). Omitted when `enrich` does not include `coderabbit`.
 - **Review linkage:** `has_review`, `review_state` (from `latestReviews`, empty if none), `review_commit_sha` (OID from the latest review by this bot when present; enrichments may fill it from a provider-neutral `reviewed_head_sha` parsed from comment bodies when the bot reports review scope without a `latestReviews` node). When GraphQL exposes it, `review_submitted_at` repeats the **`submittedAt`** of the selected `latestReviews` node for this login (ISO8601).
 - **Re-review triggers (when `review_triggers` is configured):** `latest_review_trigger_at` (ISO8601 `updatedAt` of the newest non-bot-authored comment matching any pattern, or omitted when none). `review_trigger_awaiting_ack` is **true** when that timestamp is **strictly newer** than the greater of `status_comment_at` and `review_submitted_at` (both may be empty). Classifiers treat `review_trigger_awaiting_ack` as **pending** before any `has_review` ⇒ `completed` fallback (CodeRabbit: `status_class_basis` `review_triggered_awaiting_ack`).
 - **Comment window:** `latest_comment_at` (ISO8601 from the **newest** matching PR issue comment by `updatedAt` in the fetched `comments(last: 100)` window, or empty).
 - **Status source:** `status_comment_at` (ISO8601) and `status_comment_source` (`status_marker` \| `fallback_latest`) identify which issue comment body was used for substring flags and issue-comment enrichment. The builder first picks the highest semantic **tier**; for CodeRabbit, decisive status bodies (terminal clean/completed, rate limit, paused, failed, in-progress) share the top tier, and the newest `updatedAt` wins within that tier. This keeps an edited Review Status comment from being shadowed by a later short acknowledgment while still letting a newer rate-limit body supersede an older clean body, or a newer terminal-clean body supersede an older rate-limit body.
-- **Body substring flags (case-insensitive):** `contains_rate_limit`, `contains_review_paused`, `contains_review_failed`. These flags are computed from the **selected status comment** body above, not from `latest_comment_at` alone. They are **diagnostic** (substring presence). For CodeRabbit, **`status`** uses structured markers and **`rate_limit_remaining_seconds`** for `rate_limited`; do not treat `contains_rate_limit` alone as proof of an active quota. `contains_rate_limit` false does not prove quota cleared globally; it means the selected status body no longer contains the substring (e.g. superseded by a higher-tier completion comment).
+- **Body substring flags (case-insensitive):** `contains_rate_limit`, `contains_review_paused`, `contains_review_failed`.
+  These flags are computed from the **selected status comment** body above, not
+  from `latest_comment_at` alone. They are substring presence indicators.
+  - For CodeRabbit, **`status`** uses structured markers and
+    **`rate_limit_remaining_seconds`** for `rate_limited`; do not treat
+    `contains_rate_limit` alone as proof of an active quota.
+  - `contains_review_paused=true` also drives classification because it is
+    stronger than a clean marker from the same selected comment and classifies
+    the status as `review_paused`.
+  - `contains_rate_limit=false` does not prove quota cleared globally; it means
+    the selected status body no longer contains the substring (e.g. superseded
+    by a higher-tier completion comment).
 - **Optional enrich fields** include provider-neutral status helpers such as `review_processing`, `walkthrough_present`, `review_completed_clean`, `reviewed_head_sha`, and finding counters such as `duplicate_findings_count`, `actionable_findings_count`, `outside_diff_findings_count`, and `finding_conversation_comments_count`. Provider-specific enrichments may also expose legacy vendor keys in parallel for compatibility (for example current `coderabbit`-prefixed fields).
 - **`rate_limit_remaining_seconds` (PR / `rgd observe`):** first, seconds are parsed from the **selected status comment** body (same patterns as the local CLI cooldown parser). Then **`max(0, parsed_seconds − elapsed_seconds)`** where **`elapsed_seconds`** is the wall time from **`status_comment_at`** (the selected comment’s `updatedAt`) to the **observation time** when `rgd` built the signal. So a body that says “wait 19 minutes and 47 seconds” is interpreted as that much time **from the comment update**, not from an arbitrary later read. If CodeRabbit **edits** that issue comment in place, GitHub advances `updatedAt`; the next fetch uses the new body and new **`status_comment_at`**, so the cooldown **re-anchors** to the edit time.
 - **PR recovery after `rate_limited`:** before posting `@coderabbitai review`, wait **`cooldown_sec + 30`** where **`cooldown_sec`** is **`rate_limit_remaining_seconds`** from the observation JSON (already age-adjusted as above when enrichment is enabled), or else seconds parsed from the **selected status comment** body and aged manually using **`status_comment_at`** the same way. The **30**-second tail matches the local CLI default **`RATE_LIMIT_RETRY_BUFFER_SEC`** in `.reinguard/scripts/check-local-review.sh` (same contract as `--retry-on-rate-limit`). Normative detail: `.reinguard/knowledge/review--bot-operations.md` § Rate-Limit Recovery.

--- a/internal/observe/github/prquery/enrichment_coderabbit.go
+++ b/internal/observe/github/prquery/enrichment_coderabbit.go
@@ -224,9 +224,12 @@ func (coderabbitEnrichment) CommentMaxTier(body string) int {
 	return CoderabbitIssueCommentMaxTier(body)
 }
 
-// ClassifyStatus applies CodeRabbit-aware rules. Rate limiting is derived from
-// age-adjusted rate_limit_remaining_seconds (not raw "rate limit" substrings), so stale
-// quota text in the same comment as a terminal-clean summary does not override completed_clean.
+// ClassifyStatus applies CodeRabbit-aware rules. Review-paused markers and
+// active rate-limit cooldowns are blockers even when a selected status comment
+// also includes a clean summary. Rate limiting is derived from age-adjusted
+// rate_limit_remaining_seconds (not raw "rate limit" substrings), so stale quota
+// text in the same comment as a terminal-clean summary does not override
+// completed_clean.
 func (coderabbitEnrichment) ClassifyStatus(m map[string]any) string {
 	s, _ := classifyCoderabbitStatusWithBasis(m)
 	return s
@@ -241,6 +244,12 @@ func classifyCoderabbitStatusWithBasis(m map[string]any) (status string, basis s
 	if signalBool(m, "review_trigger_awaiting_ack") {
 		return BotStatusPending, "review_triggered_awaiting_ack"
 	}
+	if signalBool(m, "contains_review_paused") {
+		return BotStatusReviewPaused, "review_paused"
+	}
+	if n, ok := intFromStatusMapAny(m, "rate_limit_remaining_seconds"); ok && n > 0 {
+		return BotStatusRateLimited, "active_rate_limit_cooldown"
+	}
 	// Terminal clean from issue-comment markers (e.g. "no actionable comments") — wins over stale rate-limit wording.
 	if statusMapBoolAny(m, true, "cr_review_completed_clean", "review_completed_clean") {
 		return BotStatusCompletedClean, "review_completed_clean"
@@ -248,14 +257,8 @@ func classifyCoderabbitStatusWithBasis(m map[string]any) (status string, basis s
 	if statusMapBoolAny(m, false, "cr_review_processing", "review_processing") {
 		return BotStatusCompleted, "review_completed"
 	}
-	if signalBool(m, "contains_review_paused") {
-		return BotStatusReviewPaused, "review_paused"
-	}
 	if signalBool(m, "contains_review_failed") {
 		return BotStatusReviewFailed, "review_failed"
-	}
-	if n, ok := intFromStatusMapAny(m, "rate_limit_remaining_seconds"); ok && n > 0 {
-		return BotStatusRateLimited, "active_rate_limit_cooldown"
 	}
 	if signalBool(m, "cr_review_rate_limit_notice") || signalBool(m, "review_rate_limit_notice") {
 		return BotStatusPending, "review_rate_limit_notice"

--- a/internal/observe/github/prquery/enrichment_coderabbit_test.go
+++ b/internal/observe/github/prquery/enrichment_coderabbit_test.go
@@ -486,40 +486,68 @@ func TestCoderabbitEnrichment_ClassifyStatus_order(t *testing.T) {
 	}
 }
 
-func TestCoderabbitEnrichment_ClassifyStatus_staleRateLimitTextDoesNotOverrideClean(t *testing.T) {
+func TestCoderabbitEnrichment_ClassifyStatus_cleanMarkerPrecedence(t *testing.T) {
 	t.Parallel()
 	e := coderabbitEnrichment{}
-	// Same issue-comment body can mention "rate limit" historically while reporting a terminal clean summary.
-	m := map[string]any{
-		"contains_rate_limit":          true,
-		"review_completed_clean":       true,
-		"rate_limit_remaining_seconds": 0,
-		"latest_comment_at":            "2026-04-06T00:31:05Z",
+	// Given/When/Then: clean-marker precedence cases distinguish active pause markers from
+	// stale wording that can coexist with a valid terminal-clean summary.
+	tests := []struct {
+		name       string
+		signals    map[string]any
+		wantStatus string
+		wantBasis  string
+	}{
+		{
+			name: "paused_blocks_clean",
+			signals: map[string]any{
+				"contains_review_paused": true,
+				"review_completed_clean": true,
+			},
+			wantStatus: BotStatusReviewPaused,
+			wantBasis:  "review_paused",
+		},
+		{
+			name: "active_rate_limit_blocks_clean",
+			signals: map[string]any{
+				"rate_limit_remaining_seconds": 300,
+				"review_completed_clean":       true,
+			},
+			wantStatus: BotStatusRateLimited,
+			wantBasis:  "active_rate_limit_cooldown",
+		},
+		{
+			name: "stale_rate_limit_does_not_override_clean",
+			signals: map[string]any{
+				"contains_rate_limit":          true,
+				"review_completed_clean":       true,
+				"rate_limit_remaining_seconds": 0,
+				"latest_comment_at":            "2026-04-06T00:31:05Z",
+			},
+			wantStatus: BotStatusCompletedClean,
+			wantBasis:  "review_completed_clean",
+		},
+		{
+			name: "failed_text_does_not_override_clean",
+			signals: map[string]any{
+				"contains_review_failed": true,
+				"review_completed_clean": true,
+				"latest_comment_at":      "2026-04-08T06:29:17Z",
+			},
+			wantStatus: BotStatusCompletedClean,
+			wantBasis:  "review_completed_clean",
+		},
 	}
-	if g := e.ClassifyStatus(m); g != BotStatusCompletedClean {
-		t.Fatalf("got %q want completed_clean", g)
-	}
-	s, basis := classifyCoderabbitStatusWithBasis(m)
-	if s != BotStatusCompletedClean || basis != "review_completed_clean" {
-		t.Fatalf("basis got %q %q", s, basis)
-	}
-}
-
-func TestCoderabbitEnrichment_ClassifyStatus_stalePausedOrFailedTextDoesNotOverrideClean(t *testing.T) {
-	t.Parallel()
-	e := coderabbitEnrichment{}
-	m := map[string]any{
-		"contains_review_paused": true,
-		"contains_review_failed": true,
-		"review_completed_clean": true,
-		"latest_comment_at":      "2026-04-08T06:29:17Z",
-	}
-	if g := e.ClassifyStatus(m); g != BotStatusCompletedClean {
-		t.Fatalf("got %q want completed_clean", g)
-	}
-	s, basis := classifyCoderabbitStatusWithBasis(m)
-	if s != BotStatusCompletedClean || basis != "review_completed_clean" {
-		t.Fatalf("basis got %q %q", s, basis)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := e.ClassifyStatus(tt.signals); got != tt.wantStatus {
+				t.Fatalf("ClassifyStatus() = %q, want %q", got, tt.wantStatus)
+			}
+			s, basis := classifyCoderabbitStatusWithBasis(tt.signals)
+			if s != tt.wantStatus || basis != tt.wantBasis {
+				t.Fatalf("basis got %q %q, want %q %q", s, basis, tt.wantStatus, tt.wantBasis)
+			}
+		})
 	}
 }
 

--- a/internal/observe/github/prquery/prquery_test.go
+++ b/internal/observe/github/prquery/prquery_test.go
@@ -1487,6 +1487,93 @@ func TestCollect_botReviewer_commentOnlyNoReviewClean(t *testing.T) {
 	}
 }
 
+func TestCollect_botReviewer_pausedCleanCommentBlocked(t *testing.T) {
+	t.Parallel()
+	// Given: CodeRabbit selects a status comment whose pause wrapper coexists with a clean summary.
+	// When: Collect runs with coderabbit enrichment for a required bot.
+	// Then: review_paused wins over completed_clean and aggregate diagnostics remain blocked/non-terminal.
+	head := "abc1234567890abcdef1234567890abcdef1234"
+	commentBody := "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n" +
+		"<!-- This is an auto-generated comment: review paused by coderabbit.ai -->\n\n" +
+		"> [!NOTE]\n> ## Reviews paused\n\n" +
+		"No actionable comments were generated in the recent review.\n\n" +
+		"Reviewing files that changed from the base of the PR and between [1111111111111111111111111111111111111111](https://example.com/a) " +
+		"and [" + head + "](https://example.com/b).\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"pullRequest": map[string]any{
+						"state": "OPEN", "isDraft": false, "title": "t",
+						"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN",
+						"baseRefName": "main", "headRefOid": head,
+						"labels":                  map[string]any{"nodes": []any{}},
+						"closingIssuesReferences": map[string]any{"nodes": []any{}},
+						"latestReviews": map[string]any{
+							"pageInfo": map[string]any{"hasNextPage": false},
+							"nodes":    []any{},
+						},
+						"comments": map[string]any{
+							"nodes": []map[string]any{
+								{
+									"author":    map[string]any{"login": "coderabbitai"},
+									"body":      commentBody,
+									"updatedAt": "2026-03-28T12:00:00Z",
+								},
+							},
+						},
+						"reviewThreads": map[string]any{"pageInfo": map[string]any{"hasNextPage": false}, "nodes": []any{}},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c := &githubapi.Client{HTTP: srv.Client(), Token: "t", BaseURL: srv.URL}
+	bots := []BotReviewer{{ID: "cr", Login: "coderabbitai[bot]", Required: true, Enrich: []string{"coderabbit"}}}
+	_, rev, err := Collect(context.Background(), c, "o", "r", 1, bots)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := rev["bot_reviewer_status"].([]any)
+	if len(st) != 1 {
+		t.Fatalf("status len: %v", st)
+	}
+	m := st[0].(map[string]any)
+	if m["status"].(string) != BotStatusReviewPaused {
+		t.Fatalf("status: %+v", m)
+	}
+	if basis := m["status_class_basis"].(string); basis != "review_paused" {
+		t.Fatalf("status_class_basis: want review_paused, got %q in %+v", basis, m)
+	}
+	if paused, ok := m["contains_review_paused"].(bool); !ok || !paused {
+		t.Fatalf("want contains_review_paused=true, got %+v", m)
+	}
+	if clean, ok := m["review_completed_clean"].(bool); !ok || !clean {
+		t.Fatalf("want review_completed_clean diagnostic=true, got %+v", m)
+	}
+	diag := rev["bot_review_diagnostics"].(map[string]any)
+	if diag["bot_review_completed"].(bool) {
+		t.Fatalf("want bot_review_completed=false, got %+v", diag)
+	}
+	if diag["bot_review_terminal"].(bool) {
+		t.Fatalf("want bot_review_terminal=false, got %+v", diag)
+	}
+	if !diag["bot_review_blocked"].(bool) {
+		t.Fatalf("want bot_review_blocked=true, got %+v", diag)
+	}
+	if got := diag["bot_review_block_reason"].(string); got != BotStatusReviewPaused {
+		t.Fatalf("bot_review_block_reason: want %q, got %q in %+v", BotStatusReviewPaused, got, diag)
+	}
+	if diag["bot_review_failed"].(bool) {
+		t.Fatalf("want bot_review_failed=false, got %+v", diag)
+	}
+}
+
 func TestCollect_botReviewer_enrichedHeadOverridesStaleGraphQLReview(t *testing.T) {
 	t.Parallel()
 	// Given: latestReviews still references an older review commit, but the selected CodeRabbit


### PR DESCRIPTION
## Summary

- Fixes CodeRabbit status classification so paused selected comments stay blocked even when they also contain a clean review summary.
- Keeps stale rate-limit text from overriding valid clean completion while making active cooldowns blocked.
- Adds regression coverage and documents the precedence in CLI docs and ADR-0013.

## Traceability

Closes #148

Refs: #148

## Definition of Done

- [x] Tests added or updated (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. `bash .reinguard/scripts/with-repo-local-state.sh -- go test ./... -race`
2. `bash .reinguard/scripts/with-repo-local-state.sh -- go vet ./...`
3. `bash .reinguard/scripts/with-repo-local-state.sh -- golangci-lint run`
4. `go run ./cmd/rgd config validate`
5. `bash .reinguard/scripts/with-repo-local-state.sh -- pre-commit run markdownlint-cli2 --all-files`
6. `bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- bash .reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit`

## Risk / Impact

- Affects CodeRabbit observation status precedence. Paused or actively rate-limited review state now blocks merge readiness instead of being masked by clean markers in the same selected status comment.

## Rollback Plan

- Revert this PR to restore the previous CodeRabbit status classification order and documentation.

## Exception

- Type: N/A
- Justification: N/A
