### PR TITLE
feat(knowledge): tighten review bot knowledge predicates

### DIFF
--- a/.reinguard/knowledge/manifest.json
+++ b/.reinguard/knowledge/manifest.json
@@ -173,9 +173,38 @@
         "rate limit recovery"
       ],
       "when": {
-        "op": "eq",
-        "path": "github.pull_requests.pr_exists_for_branch",
-        "value": true
+        "or": [
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.bot_review_blocked",
+            "value": true
+          },
+          {
+            "op": "ne",
+            "path": "github.reviews.bot_review_diagnostics.bot_review_block_reason",
+            "value": ""
+          },
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.bot_review_trigger_awaiting_ack",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.bot_review_pending",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.bot_review_failed",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.bot_review_stale",
+            "value": true
+          }
+        ]
       }
     },
     {
@@ -215,9 +244,18 @@
         "gh api graphql"
       ],
       "when": {
-        "op": "eq",
-        "path": "github.pull_requests.pr_exists_for_branch",
-        "value": true
+        "or": [
+          {
+            "op": "gt",
+            "path": "github.reviews.review_threads_unresolved",
+            "value": 0
+          },
+          {
+            "op": "gt",
+            "path": "github.reviews.review_decisions_changes_requested",
+            "value": 0
+          }
+        ]
       }
     },
     {
@@ -233,9 +271,37 @@
         "batch review fixes"
       ],
       "when": {
-        "op": "eq",
-        "path": "github.pull_requests.pr_exists_for_branch",
-        "value": true
+        "and": [
+          {
+            "op": "eq",
+            "path": "github.pull_requests.pr_exists_for_branch",
+            "value": true
+          },
+          {
+            "or": [
+              {
+                "op": "eq",
+                "path": "git.working_tree_clean",
+                "value": false
+              },
+              {
+                "op": "gt",
+                "path": "github.reviews.review_threads_unresolved",
+                "value": 0
+              },
+              {
+                "op": "gt",
+                "path": "github.reviews.review_decisions_changes_requested",
+                "value": 0
+              },
+              {
+                "op": "eq",
+                "path": "github.reviews.bot_review_diagnostics.non_thread_findings_present",
+                "value": true
+              }
+            ]
+          }
+        ]
       }
     },
     {
@@ -285,9 +351,48 @@
         "review signal priority"
       ],
       "when": {
-        "op": "eq",
-        "path": "github.pull_requests.pr_exists_for_branch",
-        "value": true
+        "or": [
+          {
+            "op": "gt",
+            "path": "github.reviews.review_threads_unresolved",
+            "value": 0
+          },
+          {
+            "op": "gt",
+            "path": "github.reviews.review_decisions_changes_requested",
+            "value": 0
+          },
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.non_thread_findings_present",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.duplicate_findings_detected",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.bot_review_blocked",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.bot_review_pending",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.bot_review_failed",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "path": "github.reviews.bot_review_diagnostics.bot_review_stale",
+            "value": true
+          }
+        ]
       }
     },
     {

--- a/.reinguard/knowledge/manifest.json
+++ b/.reinguard/knowledge/manifest.json
@@ -180,11 +180,6 @@
             "value": true
           },
           {
-            "op": "ne",
-            "path": "github.reviews.bot_review_diagnostics.bot_review_block_reason",
-            "value": ""
-          },
-          {
             "op": "eq",
             "path": "github.reviews.bot_review_diagnostics.bot_review_trigger_awaiting_ack",
             "value": true

--- a/.reinguard/knowledge/manifest.json
+++ b/.reinguard/knowledge/manifest.json
@@ -173,31 +173,40 @@
         "rate limit recovery"
       ],
       "when": {
-        "or": [
+        "and": [
           {
             "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.bot_review_blocked",
+            "path": "github.pull_requests.pr_exists_for_branch",
             "value": true
           },
           {
-            "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.bot_review_trigger_awaiting_ack",
-            "value": true
-          },
-          {
-            "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.bot_review_pending",
-            "value": true
-          },
-          {
-            "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.bot_review_failed",
-            "value": true
-          },
-          {
-            "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.bot_review_stale",
-            "value": true
+            "or": [
+              {
+                "op": "eq",
+                "path": "github.reviews.bot_review_diagnostics.bot_review_blocked",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "path": "github.reviews.bot_review_diagnostics.bot_review_trigger_awaiting_ack",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "path": "github.reviews.bot_review_diagnostics.bot_review_pending",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "path": "github.reviews.bot_review_diagnostics.bot_review_failed",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "path": "github.reviews.bot_review_diagnostics.bot_review_stale",
+                "value": true
+              }
+            ]
           }
         ]
       }
@@ -239,16 +248,25 @@
         "gh api graphql"
       ],
       "when": {
-        "or": [
+        "and": [
           {
-            "op": "gt",
-            "path": "github.reviews.review_threads_unresolved",
-            "value": 0
+            "op": "eq",
+            "path": "github.pull_requests.pr_exists_for_branch",
+            "value": true
           },
           {
-            "op": "gt",
-            "path": "github.reviews.review_decisions_changes_requested",
-            "value": 0
+            "or": [
+              {
+                "op": "gt",
+                "path": "github.reviews.review_threads_unresolved",
+                "value": 0
+              },
+              {
+                "op": "gt",
+                "path": "github.reviews.review_decisions_changes_requested",
+                "value": 0
+              }
+            ]
           }
         ]
       }
@@ -346,46 +364,35 @@
         "review signal priority"
       ],
       "when": {
-        "or": [
-          {
-            "op": "gt",
-            "path": "github.reviews.review_threads_unresolved",
-            "value": 0
-          },
-          {
-            "op": "gt",
-            "path": "github.reviews.review_decisions_changes_requested",
-            "value": 0
-          },
+        "and": [
           {
             "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.non_thread_findings_present",
+            "path": "github.pull_requests.pr_exists_for_branch",
             "value": true
           },
           {
-            "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.duplicate_findings_detected",
-            "value": true
-          },
-          {
-            "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.bot_review_blocked",
-            "value": true
-          },
-          {
-            "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.bot_review_pending",
-            "value": true
-          },
-          {
-            "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.bot_review_failed",
-            "value": true
-          },
-          {
-            "op": "eq",
-            "path": "github.reviews.bot_review_diagnostics.bot_review_stale",
-            "value": true
+            "or": [
+              {
+                "op": "gt",
+                "path": "github.reviews.review_threads_unresolved",
+                "value": 0
+              },
+              {
+                "op": "gt",
+                "path": "github.reviews.review_decisions_changes_requested",
+                "value": 0
+              },
+              {
+                "op": "eq",
+                "path": "github.reviews.bot_review_diagnostics.non_thread_findings_present",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "path": "github.reviews.bot_review_diagnostics.duplicate_findings_detected",
+                "value": true
+              }
+            ]
           }
         ]
       }

--- a/.reinguard/knowledge/manifest.json
+++ b/.reinguard/knowledge/manifest.json
@@ -248,27 +248,9 @@
         "gh api graphql"
       ],
       "when": {
-        "and": [
-          {
-            "op": "eq",
-            "path": "github.pull_requests.pr_exists_for_branch",
-            "value": true
-          },
-          {
-            "or": [
-              {
-                "op": "gt",
-                "path": "github.reviews.review_threads_unresolved",
-                "value": 0
-              },
-              {
-                "op": "gt",
-                "path": "github.reviews.review_decisions_changes_requested",
-                "value": 0
-              }
-            ]
-          }
-        ]
+        "op": "eq",
+        "path": "github.pull_requests.pr_exists_for_branch",
+        "value": true
       }
     },
     {
@@ -292,11 +274,6 @@
           },
           {
             "or": [
-              {
-                "op": "eq",
-                "path": "git.working_tree_clean",
-                "value": false
-              },
               {
                 "op": "gt",
                 "path": "github.reviews.review_threads_unresolved",

--- a/.reinguard/knowledge/review--bot-operations.md
+++ b/.reinguard/knowledge/review--bot-operations.md
@@ -36,6 +36,11 @@ Operational reference for **PR-side** bot review (after a PR exists):
 CodeRabbit and Codex on GitHub — trigger, detection, timing, rate limits,
 re-review, and polling cadence for `wait-bot-review` / `review-address`.
 
+This card is selected by active bot-review diagnostics rather than by PR
+existence alone. Use keyword retrieval (for example `rgd knowledge pack
+--query 'CodeRabbit trigger'`) when you need the general reference outside a
+bot-review wait or re-review situation.
+
 **Pre-PR** local CodeRabbit CLI (`check-local-review.sh`) is **not** covered
 here; see `.reinguard/knowledge/review--local-coderabbit-cli.md`.
 

--- a/.reinguard/knowledge/review--bot-operations.md
+++ b/.reinguard/knowledge/review--bot-operations.md
@@ -16,9 +16,6 @@ when:
     - op: eq
       path: github.reviews.bot_review_diagnostics.bot_review_blocked
       value: true
-    - op: ne
-      path: github.reviews.bot_review_diagnostics.bot_review_block_reason
-      value: ""
     - op: eq
       path: github.reviews.bot_review_diagnostics.bot_review_trigger_awaiting_ack
       value: true

--- a/.reinguard/knowledge/review--bot-operations.md
+++ b/.reinguard/knowledge/review--bot-operations.md
@@ -12,9 +12,25 @@ triggers:
   - "@codex review"
   - rate limit recovery
 when:
-  op: eq
-  path: github.pull_requests.pr_exists_for_branch
-  value: true
+  or:
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.bot_review_blocked
+      value: true
+    - op: ne
+      path: github.reviews.bot_review_diagnostics.bot_review_block_reason
+      value: ""
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.bot_review_trigger_awaiting_ack
+      value: true
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.bot_review_pending
+      value: true
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.bot_review_failed
+      value: true
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.bot_review_stale
+      value: true
 ---
 
 # Bot Review Operations (PR-side)

--- a/.reinguard/knowledge/review--bot-operations.md
+++ b/.reinguard/knowledge/review--bot-operations.md
@@ -40,8 +40,8 @@ Operational reference for **PR-side** bot review (after a PR exists):
 CodeRabbit and Codex on GitHub — trigger, detection, timing, rate limits,
 re-review, and polling cadence for `wait-bot-review` / `review-address`.
 
-This card is selected by active bot-review diagnostics rather than by PR
-existence alone: `bot_review_blocked`,
+This card is selected when a PR exists and active bot-review diagnostics are
+present: `bot_review_blocked`,
 `bot_review_trigger_awaiting_ack`, `bot_review_pending`,
 `bot_review_failed`, or `bot_review_stale`. Use keyword retrieval (for
 example `rgd knowledge pack --query 'CodeRabbit trigger'`) when you need the

--- a/.reinguard/knowledge/review--bot-operations.md
+++ b/.reinguard/knowledge/review--bot-operations.md
@@ -12,22 +12,26 @@ triggers:
   - "@codex review"
   - rate limit recovery
 when:
-  or:
+  and:
     - op: eq
-      path: github.reviews.bot_review_diagnostics.bot_review_blocked
+      path: github.pull_requests.pr_exists_for_branch
       value: true
-    - op: eq
-      path: github.reviews.bot_review_diagnostics.bot_review_trigger_awaiting_ack
-      value: true
-    - op: eq
-      path: github.reviews.bot_review_diagnostics.bot_review_pending
-      value: true
-    - op: eq
-      path: github.reviews.bot_review_diagnostics.bot_review_failed
-      value: true
-    - op: eq
-      path: github.reviews.bot_review_diagnostics.bot_review_stale
-      value: true
+    - or:
+        - op: eq
+          path: github.reviews.bot_review_diagnostics.bot_review_blocked
+          value: true
+        - op: eq
+          path: github.reviews.bot_review_diagnostics.bot_review_trigger_awaiting_ack
+          value: true
+        - op: eq
+          path: github.reviews.bot_review_diagnostics.bot_review_pending
+          value: true
+        - op: eq
+          path: github.reviews.bot_review_diagnostics.bot_review_failed
+          value: true
+        - op: eq
+          path: github.reviews.bot_review_diagnostics.bot_review_stale
+          value: true
 ---
 
 # Bot Review Operations (PR-side)
@@ -37,9 +41,11 @@ CodeRabbit and Codex on GitHub — trigger, detection, timing, rate limits,
 re-review, and polling cadence for `wait-bot-review` / `review-address`.
 
 This card is selected by active bot-review diagnostics rather than by PR
-existence alone. Use keyword retrieval (for example `rgd knowledge pack
---query 'CodeRabbit trigger'`) when you need the general reference outside a
-bot-review wait or re-review situation.
+existence alone: `bot_review_blocked`,
+`bot_review_trigger_awaiting_ack`, `bot_review_pending`,
+`bot_review_failed`, or `bot_review_stale`. Use keyword retrieval (for
+example `rgd knowledge pack --query 'CodeRabbit trigger'`) when you need the
+general reference outside a bot-review wait or re-review situation.
 
 **Pre-PR** local CodeRabbit CLI (`check-local-review.sh`) is **not** covered
 here; see `.reinguard/knowledge/review--local-coderabbit-cli.md`.

--- a/.reinguard/knowledge/review--github-thread-api.md
+++ b/.reinguard/knowledge/review--github-thread-api.md
@@ -9,9 +9,13 @@ triggers:
   - thread resolution API
   - gh api graphql
 when:
-  op: eq
-  path: github.pull_requests.pr_exists_for_branch
-  value: true
+  or:
+    - op: gt
+      path: github.reviews.review_threads_unresolved
+      value: 0
+    - op: gt
+      path: github.reviews.review_decisions_changes_requested
+      value: 0
 ---
 
 # GitHub review thread API (REST vs GraphQL)

--- a/.reinguard/knowledge/review--github-thread-api.md
+++ b/.reinguard/knowledge/review--github-thread-api.md
@@ -9,13 +9,17 @@ triggers:
   - thread resolution API
   - gh api graphql
 when:
-  or:
-    - op: gt
-      path: github.reviews.review_threads_unresolved
-      value: 0
-    - op: gt
-      path: github.reviews.review_decisions_changes_requested
-      value: 0
+  and:
+    - op: eq
+      path: github.pull_requests.pr_exists_for_branch
+      value: true
+    - or:
+        - op: gt
+          path: github.reviews.review_threads_unresolved
+          value: 0
+        - op: gt
+          path: github.reviews.review_decisions_changes_requested
+          value: 0
 ---
 
 # GitHub review thread API (REST vs GraphQL)

--- a/.reinguard/knowledge/review--github-thread-api.md
+++ b/.reinguard/knowledge/review--github-thread-api.md
@@ -9,17 +9,9 @@ triggers:
   - thread resolution API
   - gh api graphql
 when:
-  and:
-    - op: eq
-      path: github.pull_requests.pr_exists_for_branch
-      value: true
-    - or:
-        - op: gt
-          path: github.reviews.review_threads_unresolved
-          value: 0
-        - op: gt
-          path: github.reviews.review_decisions_changes_requested
-          value: 0
+  op: eq
+  path: github.pull_requests.pr_exists_for_branch
+  value: true
 ---
 
 # GitHub review thread API (REST vs GraphQL)

--- a/.reinguard/knowledge/review--incremental-fix-flow.md
+++ b/.reinguard/knowledge/review--incremental-fix-flow.md
@@ -9,9 +9,23 @@ triggers:
   - CodeRabbit incremental
   - batch review fixes
 when:
-  op: eq
-  path: github.pull_requests.pr_exists_for_branch
-  value: true
+  and:
+    - op: eq
+      path: github.pull_requests.pr_exists_for_branch
+      value: true
+    - or:
+        - op: eq
+          path: git.working_tree_clean
+          value: false
+        - op: gt
+          path: github.reviews.review_threads_unresolved
+          value: 0
+        - op: gt
+          path: github.reviews.review_decisions_changes_requested
+          value: 0
+        - op: eq
+          path: github.reviews.bot_review_diagnostics.non_thread_findings_present
+          value: true
 ---
 
 # Incremental fix flow (review-sourced changes)

--- a/.reinguard/knowledge/review--incremental-fix-flow.md
+++ b/.reinguard/knowledge/review--incremental-fix-flow.md
@@ -48,6 +48,8 @@ Normative disposition and resolve rules remain in `.reinguard/policy/review--con
 |------------------|---------|
 | `github.pull_requests.pr_exists_for_branch` true | On a PR branch |
 | `github.reviews.review_threads_unresolved` > 0 | Thread disposition work remains (typical with this flow) |
+| `github.reviews.review_decisions_changes_requested` > 0 | At least one review has formally requested changes |
+| `github.reviews.bot_review_diagnostics.non_thread_findings_present` true | Required-bot non-thread findings remain to classify and address |
 | `git.working_tree_clean` false | Uncommitted or unstaged work — run **review-address Step 0** before relying on disposition-only steps |
 
 ## Procedure outline

--- a/.reinguard/knowledge/review--incremental-fix-flow.md
+++ b/.reinguard/knowledge/review--incremental-fix-flow.md
@@ -14,9 +14,6 @@ when:
       path: github.pull_requests.pr_exists_for_branch
       value: true
     - or:
-        - op: eq
-          path: git.working_tree_clean
-          value: false
         - op: gt
           path: github.reviews.review_threads_unresolved
           value: 0

--- a/.reinguard/knowledge/review--multi-source-review-signals.md
+++ b/.reinguard/knowledge/review--multi-source-review-signals.md
@@ -41,7 +41,7 @@ Normative disposition and resolve rules stay in `.reinguard/policy/review--conse
 | **blocking** | Must clear before merge consideration (policy + branch protection) | Failing required checks; formal `CHANGES_REQUESTED`; unresolved review threads that need disposition |
 | **actionable** | Should classify and reply (or fix) in this PR | Inline review comments; bot threads; human review threads |
 | **duplicate_suppressed** | CodeRabbit re-detected an issue but did not post a new thread (`♻️ Duplicate comments (N)` in the review body); treat as actionable content, not noise | `github.reviews.bot_review_diagnostics.duplicate_findings_detected`; per-bot duplicate count on each `github.reviews.bot_reviewer_status[]` element as `duplicate_findings_count` (`docs/cli.md`; `coderabbit` enrichment also emits legacy `cr_duplicate_findings_count`) |
-| **bot_aggregate** | Required-bot aggregate that turns non-thread or duplicate findings into review-triage work | `github.reviews.bot_review_diagnostics.non_thread_findings_present` or `duplicate_findings_detected` (documented in `docs/cli.md` § Bot review diagnostics) |
+| **bot_aggregate** | Required-bot aggregate that turns non-thread or duplicate findings into review-triage work | `github.reviews.bot_review_diagnostics.non_thread_findings_present` or `github.reviews.bot_review_diagnostics.duplicate_findings_detected` (documented in `docs/cli.md` § Bot review diagnostics) |
 | **informational** | Context only unless it contains a concrete finding | Clean-bill summaries; meta comments without new findings |
 
 ## Source kinds

--- a/.reinguard/knowledge/review--multi-source-review-signals.md
+++ b/.reinguard/knowledge/review--multi-source-review-signals.md
@@ -49,6 +49,7 @@ Normative disposition and resolve rules stay in `.reinguard/policy/review--conse
 | **blocking** | Must clear before merge consideration (policy + branch protection) | Failing required checks; formal `CHANGES_REQUESTED`; unresolved review threads that need disposition |
 | **actionable** | Should classify and reply (or fix) in this PR | Inline review comments; bot threads; human review threads |
 | **duplicate_suppressed** | CodeRabbit re-detected an issue but did not post a new thread (`♻️ Duplicate comments (N)` in the review body); treat as actionable content, not noise | `github.reviews.bot_review_diagnostics.duplicate_findings_detected`; per-bot duplicate count on each `github.reviews.bot_reviewer_status[]` element as `duplicate_findings_count` (`docs/cli.md`; `coderabbit` enrichment also emits legacy `cr_duplicate_findings_count`) |
+| **bot_lifecycle** | Required bot state that changes whether review work should be addressed, retried, or waited on | `github.reviews.bot_review_diagnostics.bot_review_blocked`, `bot_review_pending`, `bot_review_failed`, `bot_review_stale`, and `non_thread_findings_present` (all documented in `docs/cli.md` § Bot review diagnostics) |
 | **informational** | Context only unless it contains a concrete finding | Clean-bill summaries; meta comments without new findings |
 
 ## Source kinds

--- a/.reinguard/knowledge/review--multi-source-review-signals.md
+++ b/.reinguard/knowledge/review--multi-source-review-signals.md
@@ -9,9 +9,31 @@ triggers:
   - checks vs review
   - review signal priority
 when:
-  op: eq
-  path: github.pull_requests.pr_exists_for_branch
-  value: true
+  or:
+    - op: gt
+      path: github.reviews.review_threads_unresolved
+      value: 0
+    - op: gt
+      path: github.reviews.review_decisions_changes_requested
+      value: 0
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.non_thread_findings_present
+      value: true
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.duplicate_findings_detected
+      value: true
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.bot_review_blocked
+      value: true
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.bot_review_pending
+      value: true
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.bot_review_failed
+      value: true
+    - op: eq
+      path: github.reviews.bot_review_diagnostics.bot_review_stale
+      value: true
 ---
 
 # Multi-source review signals (single inbox)

--- a/.reinguard/knowledge/review--multi-source-review-signals.md
+++ b/.reinguard/knowledge/review--multi-source-review-signals.md
@@ -9,31 +9,23 @@ triggers:
   - checks vs review
   - review signal priority
 when:
-  or:
-    - op: gt
-      path: github.reviews.review_threads_unresolved
-      value: 0
-    - op: gt
-      path: github.reviews.review_decisions_changes_requested
-      value: 0
+  and:
     - op: eq
-      path: github.reviews.bot_review_diagnostics.non_thread_findings_present
+      path: github.pull_requests.pr_exists_for_branch
       value: true
-    - op: eq
-      path: github.reviews.bot_review_diagnostics.duplicate_findings_detected
-      value: true
-    - op: eq
-      path: github.reviews.bot_review_diagnostics.bot_review_blocked
-      value: true
-    - op: eq
-      path: github.reviews.bot_review_diagnostics.bot_review_pending
-      value: true
-    - op: eq
-      path: github.reviews.bot_review_diagnostics.bot_review_failed
-      value: true
-    - op: eq
-      path: github.reviews.bot_review_diagnostics.bot_review_stale
-      value: true
+    - or:
+        - op: gt
+          path: github.reviews.review_threads_unresolved
+          value: 0
+        - op: gt
+          path: github.reviews.review_decisions_changes_requested
+          value: 0
+        - op: eq
+          path: github.reviews.bot_review_diagnostics.non_thread_findings_present
+          value: true
+        - op: eq
+          path: github.reviews.bot_review_diagnostics.duplicate_findings_detected
+          value: true
 ---
 
 # Multi-source review signals (single inbox)
@@ -49,7 +41,7 @@ Normative disposition and resolve rules stay in `.reinguard/policy/review--conse
 | **blocking** | Must clear before merge consideration (policy + branch protection) | Failing required checks; formal `CHANGES_REQUESTED`; unresolved review threads that need disposition |
 | **actionable** | Should classify and reply (or fix) in this PR | Inline review comments; bot threads; human review threads |
 | **duplicate_suppressed** | CodeRabbit re-detected an issue but did not post a new thread (`♻️ Duplicate comments (N)` in the review body); treat as actionable content, not noise | `github.reviews.bot_review_diagnostics.duplicate_findings_detected`; per-bot duplicate count on each `github.reviews.bot_reviewer_status[]` element as `duplicate_findings_count` (`docs/cli.md`; `coderabbit` enrichment also emits legacy `cr_duplicate_findings_count`) |
-| **bot_lifecycle** | Required bot state that changes whether review work should be addressed, retried, or waited on | `github.reviews.bot_review_diagnostics.bot_review_blocked`, `bot_review_pending`, `bot_review_failed`, `bot_review_stale`, and `non_thread_findings_present` (all documented in `docs/cli.md` § Bot review diagnostics) |
+| **bot_aggregate** | Required-bot aggregate that turns non-thread or duplicate findings into review-triage work | `github.reviews.bot_review_diagnostics.non_thread_findings_present` and `duplicate_findings_detected` (documented in `docs/cli.md` § Bot review diagnostics) |
 | **informational** | Context only unless it contains a concrete finding | Clean-bill summaries; meta comments without new findings |
 
 ## Source kinds

--- a/.reinguard/knowledge/review--multi-source-review-signals.md
+++ b/.reinguard/knowledge/review--multi-source-review-signals.md
@@ -41,7 +41,7 @@ Normative disposition and resolve rules stay in `.reinguard/policy/review--conse
 | **blocking** | Must clear before merge consideration (policy + branch protection) | Failing required checks; formal `CHANGES_REQUESTED`; unresolved review threads that need disposition |
 | **actionable** | Should classify and reply (or fix) in this PR | Inline review comments; bot threads; human review threads |
 | **duplicate_suppressed** | CodeRabbit re-detected an issue but did not post a new thread (`♻️ Duplicate comments (N)` in the review body); treat as actionable content, not noise | `github.reviews.bot_review_diagnostics.duplicate_findings_detected`; per-bot duplicate count on each `github.reviews.bot_reviewer_status[]` element as `duplicate_findings_count` (`docs/cli.md`; `coderabbit` enrichment also emits legacy `cr_duplicate_findings_count`) |
-| **bot_aggregate** | Required-bot aggregate that turns non-thread or duplicate findings into review-triage work | `github.reviews.bot_review_diagnostics.non_thread_findings_present` and `duplicate_findings_detected` (documented in `docs/cli.md` § Bot review diagnostics) |
+| **bot_aggregate** | Required-bot aggregate that turns non-thread or duplicate findings into review-triage work | `github.reviews.bot_review_diagnostics.non_thread_findings_present` or `duplicate_findings_detected` (documented in `docs/cli.md` § Bot review diagnostics) |
 | **informational** | Context only unless it contains a concrete finding | Clean-bill summaries; meta comments without new findings |
 
 ## Source kinds

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -222,6 +222,127 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
 			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
 		},
 		{
+			name: "failed_bot_review",
+			observation: `{
+  "schema_version": "0.8.0",
+  "signals": {
+    "git": {"detached_head": false, "working_tree_clean": true},
+    "github": {
+      "pull_requests": {"pr_exists_for_branch": true, "merge_state_status": "clean"},
+      "ci": {"ci_status": "success"},
+      "reviews": {
+        "review_threads_unresolved": 0,
+        "review_decisions_changes_requested": 0,
+        "bot_reviewer_status": [],
+        "bot_review_diagnostics": {
+          "bot_review_blocked": false,
+          "bot_review_block_reason": "",
+          "bot_review_trigger_awaiting_ack": false,
+          "bot_review_pending": false,
+          "bot_review_failed": true,
+          "bot_review_stale": false,
+          "non_thread_findings_present": false
+        }
+      }
+    }
+  },
+  "degraded": false
+}`,
+			wantIDs:   []string{"review-bot-operations", "review-multi-source-review-signals"},
+			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
+		},
+		{
+			name: "stale_bot_review",
+			observation: `{
+  "schema_version": "0.8.0",
+  "signals": {
+    "git": {"detached_head": false, "working_tree_clean": true},
+    "github": {
+      "pull_requests": {"pr_exists_for_branch": true, "merge_state_status": "clean"},
+      "ci": {"ci_status": "success"},
+      "reviews": {
+        "review_threads_unresolved": 0,
+        "review_decisions_changes_requested": 0,
+        "bot_reviewer_status": [],
+        "bot_review_diagnostics": {
+          "bot_review_blocked": false,
+          "bot_review_block_reason": "",
+          "bot_review_trigger_awaiting_ack": false,
+          "bot_review_pending": false,
+          "bot_review_failed": false,
+          "bot_review_stale": true,
+          "non_thread_findings_present": false
+        }
+      }
+    }
+  },
+  "degraded": false
+}`,
+			wantIDs:   []string{"review-bot-operations", "review-multi-source-review-signals"},
+			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
+		},
+		{
+			name: "non_thread_findings",
+			observation: `{
+  "schema_version": "0.8.0",
+  "signals": {
+    "git": {"detached_head": false, "working_tree_clean": true},
+    "github": {
+      "pull_requests": {"pr_exists_for_branch": true, "merge_state_status": "clean"},
+      "ci": {"ci_status": "success"},
+      "reviews": {
+        "review_threads_unresolved": 0,
+        "review_decisions_changes_requested": 0,
+        "bot_reviewer_status": [],
+        "bot_review_diagnostics": {
+          "bot_review_blocked": false,
+          "bot_review_block_reason": "",
+          "bot_review_trigger_awaiting_ack": false,
+          "bot_review_pending": false,
+          "bot_review_failed": false,
+          "bot_review_stale": false,
+          "non_thread_findings_present": true
+        }
+      }
+    }
+  },
+  "degraded": false
+}`,
+			wantIDs:   []string{"review-multi-source-review-signals", "review-incremental-fix-flow"},
+			absentIDs: []string{"review-bot-operations", "review-github-thread-api"},
+		},
+		{
+			name: "duplicate_findings",
+			observation: `{
+  "schema_version": "0.8.0",
+  "signals": {
+    "git": {"detached_head": false, "working_tree_clean": true},
+    "github": {
+      "pull_requests": {"pr_exists_for_branch": true, "merge_state_status": "clean"},
+      "ci": {"ci_status": "success"},
+      "reviews": {
+        "review_threads_unresolved": 0,
+        "review_decisions_changes_requested": 0,
+        "bot_reviewer_status": [],
+        "bot_review_diagnostics": {
+          "bot_review_blocked": false,
+          "bot_review_block_reason": "",
+          "bot_review_trigger_awaiting_ack": false,
+          "bot_review_pending": false,
+          "bot_review_failed": false,
+          "bot_review_stale": false,
+          "duplicate_findings_detected": true,
+          "non_thread_findings_present": false
+        }
+      }
+    }
+  },
+  "degraded": false
+}`,
+			wantIDs:   []string{"review-multi-source-review-signals"},
+			absentIDs: []string{"review-bot-operations", "review-incremental-fix-flow", "review-github-thread-api"},
+		},
+		{
 			name: "non_bot_pr_review_surface",
 			observation: `{
   "schema_version": "0.8.0",

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -154,8 +154,8 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   },
   "degraded": false
 }`,
-			wantIDs:   []string{"review-bot-operations", "review-multi-source-review-signals"},
-			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
+			wantIDs:   []string{"review-bot-operations"},
+			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
 		},
 		{
 			name: "paused_bot_review",
@@ -186,8 +186,8 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   },
   "degraded": false
 }`,
-			wantIDs:   []string{"review-bot-operations", "review-multi-source-review-signals"},
-			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
+			wantIDs:   []string{"review-bot-operations"},
+			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
 		},
 		{
 			name: "bot_review_trigger_awaiting_ack",
@@ -218,8 +218,8 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   },
   "degraded": false
 }`,
-			wantIDs:   []string{"review-bot-operations", "review-multi-source-review-signals"},
-			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
+			wantIDs:   []string{"review-bot-operations"},
+			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
 		},
 		{
 			name: "failed_bot_review",
@@ -248,8 +248,8 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   },
   "degraded": false
 }`,
-			wantIDs:   []string{"review-bot-operations", "review-multi-source-review-signals"},
-			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
+			wantIDs:   []string{"review-bot-operations"},
+			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
 		},
 		{
 			name: "stale_bot_review",
@@ -278,8 +278,8 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   },
   "degraded": false
 }`,
-			wantIDs:   []string{"review-bot-operations", "review-multi-source-review-signals"},
-			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
+			wantIDs:   []string{"review-bot-operations"},
+			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
 		},
 		{
 			name: "non_thread_findings",
@@ -366,6 +366,37 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
           "bot_review_stale": false,
           "duplicate_findings_detected": false,
           "non_thread_findings_present": false
+        }
+      }
+    }
+  },
+  "degraded": false
+}`,
+			wantIDs:   []string{},
+			absentIDs: []string{"review-bot-operations", "review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
+		},
+		{
+			name: "no_pr_with_review_shaped_signals",
+			observation: `{
+  "schema_version": "0.8.0",
+  "signals": {
+    "git": {"detached_head": false, "working_tree_clean": true},
+    "github": {
+      "pull_requests": {"pr_exists_for_branch": false},
+      "ci": {"ci_status": "pending"},
+      "reviews": {
+        "review_threads_unresolved": 1,
+        "review_decisions_changes_requested": 1,
+        "bot_reviewer_status": [],
+        "bot_review_diagnostics": {
+          "bot_review_blocked": false,
+          "bot_review_block_reason": "",
+          "bot_review_trigger_awaiting_ack": false,
+          "bot_review_pending": false,
+          "bot_review_failed": false,
+          "bot_review_stale": true,
+          "duplicate_findings_detected": true,
+          "non_thread_findings_present": true
         }
       }
     }

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -115,6 +115,176 @@ when:
 	}
 }
 
+func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
+	t.Parallel()
+	// Given/When/Then: repository knowledge predicates include review/bot cards only for targeted review diagnostics.
+	cfgDir := reinguardConfigDir(t)
+	tests := []struct {
+		name        string
+		observation string
+		wantIDs     []string
+		absentIDs   []string
+	}{
+		{
+			name: "rate_limited_bot_review",
+			observation: `{
+  "schema_version": "0.8.0",
+  "signals": {
+    "git": {"detached_head": false, "working_tree_clean": true},
+    "github": {
+      "pull_requests": {"pr_exists_for_branch": true, "merge_state_status": "unstable"},
+      "ci": {"ci_status": "pending"},
+      "reviews": {
+        "review_threads_unresolved": 0,
+        "review_decisions_changes_requested": 0,
+        "bot_reviewer_status": [
+          {"login": "coderabbitai[bot]", "required": true, "status": "rate_limited", "contains_rate_limit": true}
+        ],
+        "bot_review_diagnostics": {
+          "bot_review_blocked": true,
+          "bot_review_block_reason": "rate_limited",
+          "bot_review_trigger_awaiting_ack": false,
+          "bot_review_pending": false,
+          "bot_review_failed": false,
+          "bot_review_stale": false,
+          "non_thread_findings_present": false
+        }
+      }
+    }
+  },
+  "degraded": false
+}`,
+			wantIDs:   []string{"review-bot-operations", "review-multi-source-review-signals"},
+			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
+		},
+		{
+			name: "paused_bot_review",
+			observation: `{
+  "schema_version": "0.8.0",
+  "signals": {
+    "git": {"detached_head": false, "working_tree_clean": true},
+    "github": {
+      "pull_requests": {"pr_exists_for_branch": true, "merge_state_status": "clean"},
+      "ci": {"ci_status": "success"},
+      "reviews": {
+        "review_threads_unresolved": 0,
+        "review_decisions_changes_requested": 0,
+        "bot_reviewer_status": [
+          {"login": "coderabbitai[bot]", "required": true, "status": "review_paused", "contains_review_paused": true}
+        ],
+        "bot_review_diagnostics": {
+          "bot_review_blocked": true,
+          "bot_review_block_reason": "review_paused",
+          "bot_review_trigger_awaiting_ack": false,
+          "bot_review_pending": false,
+          "bot_review_failed": false,
+          "bot_review_stale": false,
+          "non_thread_findings_present": false
+        }
+      }
+    }
+  },
+  "degraded": false
+}`,
+			wantIDs:   []string{"review-bot-operations", "review-multi-source-review-signals"},
+			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
+		},
+		{
+			name: "bot_review_trigger_awaiting_ack",
+			observation: `{
+  "schema_version": "0.8.0",
+  "signals": {
+    "git": {"detached_head": false, "working_tree_clean": true},
+    "github": {
+      "pull_requests": {"pr_exists_for_branch": true, "merge_state_status": "clean"},
+      "ci": {"ci_status": "pending"},
+      "reviews": {
+        "review_threads_unresolved": 0,
+        "review_decisions_changes_requested": 0,
+        "bot_reviewer_status": [
+          {"login": "coderabbitai[bot]", "required": true, "status": "pending", "review_trigger_awaiting_ack": true}
+        ],
+        "bot_review_diagnostics": {
+          "bot_review_blocked": false,
+          "bot_review_block_reason": "",
+          "bot_review_trigger_awaiting_ack": true,
+          "bot_review_pending": true,
+          "bot_review_failed": false,
+          "bot_review_stale": false,
+          "non_thread_findings_present": false
+        }
+      }
+    }
+  },
+  "degraded": false
+}`,
+			wantIDs:   []string{"review-bot-operations", "review-multi-source-review-signals"},
+			absentIDs: []string{"review-incremental-fix-flow", "review-github-thread-api"},
+		},
+		{
+			name: "non_bot_pr_review_surface",
+			observation: `{
+  "schema_version": "0.8.0",
+  "signals": {
+    "git": {"detached_head": false, "working_tree_clean": true},
+    "github": {
+      "pull_requests": {"pr_exists_for_branch": true, "merge_state_status": "clean"},
+      "ci": {"ci_status": "success"},
+      "reviews": {
+        "review_threads_unresolved": 0,
+        "pagination_incomplete": false,
+        "review_decisions_changes_requested": 0,
+        "review_decisions_truncated": false,
+        "bot_reviewer_status": [],
+        "bot_review_diagnostics": {
+          "bot_review_blocked": false,
+          "bot_review_block_reason": "",
+          "bot_review_trigger_awaiting_ack": false,
+          "bot_review_pending": false,
+          "bot_review_failed": false,
+          "bot_review_stale": false,
+          "duplicate_findings_detected": false,
+          "non_thread_findings_present": false
+        }
+      }
+    }
+  },
+  "degraded": false
+}`,
+			wantIDs:   []string{},
+			absentIDs: []string{"review-bot-operations", "review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			obsPath := filepath.Join(t.TempDir(), "obs.json")
+			writeFile(t, obsPath, []byte(tc.observation))
+			var buf bytes.Buffer
+			app := NewApp("test")
+			app.Writer = &buf
+			if err := app.Run([]string{"rgd", "context", "build", "--config-dir", cfgDir, "--observation-file", obsPath, "--compact"}); err != nil {
+				t.Fatal(err)
+			}
+			var out map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+				t.Fatalf("json: %v raw=%s", err, buf.String())
+			}
+			gotIDs := knowledgeEntryIDSet(t, out)
+			for _, id := range tc.wantIDs {
+				if !gotIDs[id] {
+					t.Fatalf("expected knowledge entry %q; got ids=%v", id, gotIDs)
+				}
+			}
+			for _, id := range tc.absentIDs {
+				if gotIDs[id] {
+					t.Fatalf("did not expect knowledge entry %q; got ids=%v", id, gotIDs)
+				}
+			}
+		})
+	}
+}
+
 func TestRunContextBuild_githubAuthFails_keepsStateAndRoute(t *testing.T) {
 	// Given: live collect with git + github; gh auth fails; repo identity from origin only (sandbox-like)
 	if runtime.GOOS == "windows" {
@@ -608,6 +778,25 @@ func mustSlice(t *testing.T, v any, label string) []any {
 		t.Fatalf("%s: %v", label, v)
 	}
 	return s
+}
+
+func knowledgeEntryIDSet(t *testing.T, out map[string]any) map[string]bool {
+	t.Helper()
+	knowledge := mustMap(t, out["knowledge"], "knowledge")
+	entries, ok := knowledge["entries"].([]any)
+	if !ok {
+		t.Fatalf("knowledge.entries: %T", knowledge["entries"])
+	}
+	ids := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		entryMap := mustMap(t, entry, "knowledge.entries[]")
+		id, ok := entryMap["id"].(string)
+		if !ok {
+			t.Fatalf("knowledge entry id: %T", entryMap["id"])
+		}
+		ids[id] = true
+	}
+	return ids
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/internal/rgdcli/rgdcli_context_test.go
+++ b/internal/rgdcli/rgdcli_context_test.go
@@ -155,7 +155,7 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   "degraded": false
 }`,
 			wantIDs:   []string{"review-bot-operations"},
-			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
+			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow"},
 		},
 		{
 			name: "paused_bot_review",
@@ -187,7 +187,7 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   "degraded": false
 }`,
 			wantIDs:   []string{"review-bot-operations"},
-			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
+			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow"},
 		},
 		{
 			name: "bot_review_trigger_awaiting_ack",
@@ -219,7 +219,7 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   "degraded": false
 }`,
 			wantIDs:   []string{"review-bot-operations"},
-			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
+			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow"},
 		},
 		{
 			name: "failed_bot_review",
@@ -249,7 +249,7 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   "degraded": false
 }`,
 			wantIDs:   []string{"review-bot-operations"},
-			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
+			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow"},
 		},
 		{
 			name: "stale_bot_review",
@@ -279,7 +279,7 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   "degraded": false
 }`,
 			wantIDs:   []string{"review-bot-operations"},
-			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
+			absentIDs: []string{"review-multi-source-review-signals", "review-incremental-fix-flow"},
 		},
 		{
 			name: "non_thread_findings",
@@ -309,7 +309,7 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   "degraded": false
 }`,
 			wantIDs:   []string{"review-multi-source-review-signals", "review-incremental-fix-flow"},
-			absentIDs: []string{"review-bot-operations", "review-github-thread-api"},
+			absentIDs: []string{"review-bot-operations"},
 		},
 		{
 			name: "duplicate_findings",
@@ -340,7 +340,7 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   "degraded": false
 }`,
 			wantIDs:   []string{"review-multi-source-review-signals"},
-			absentIDs: []string{"review-bot-operations", "review-incremental-fix-flow", "review-github-thread-api"},
+			absentIDs: []string{"review-bot-operations", "review-incremental-fix-flow"},
 		},
 		{
 			name: "non_bot_pr_review_surface",
@@ -373,7 +373,7 @@ func TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics(t *testing.T) {
   "degraded": false
 }`,
 			wantIDs:   []string{},
-			absentIDs: []string{"review-bot-operations", "review-multi-source-review-signals", "review-incremental-fix-flow", "review-github-thread-api"},
+			absentIDs: []string{"review-bot-operations", "review-multi-source-review-signals", "review-incremental-fix-flow"},
 		},
 		{
 			name: "no_pr_with_review_shaped_signals",


### PR DESCRIPTION
## Summary

- Tightens review/bot knowledge `when` predicates so bot-operation guidance appears only for PR-scoped active bot-review diagnostics.
- Narrows review triage and incremental fix guidance to actionable review signals while keeping general thread API reference PR-scoped.
- Adds context-build coverage for bot blocked, paused, trigger-awaiting-ack, failed, stale, non-thread, duplicate, non-bot PR, and no-PR observations.

## Traceability

Closes #150

Refs: #131
Refs: #133

## Definition of Done

- [x] Tests added or updated (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. `go test ./internal/rgdcli -run TestRunContextBuild_reviewBotKnowledgeFollowsDiagnostics` passed.
2. `bash .reinguard/scripts/with-repo-local-state.sh -- go test ./... -race` passed.
3. `bash .reinguard/scripts/with-repo-local-state.sh -- go vet ./...` passed.
4. `bash .reinguard/scripts/with-repo-local-state.sh -- golangci-lint run` passed.
5. `bash .reinguard/scripts/with-repo-local-state.sh -- pre-commit run markdownlint-cli2 --all-files` passed.
6. `go run ./cmd/rgd config validate` passed.
7. `bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- bash .reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit` passed with no findings.

## Risk / Impact

- Affects which `.reinguard/knowledge` entries appear in `rgd context build` / knowledge filtering for PR review situations. The risk is under-surfacing review guidance for an edge diagnostic shape; focused fixture coverage protects the documented bot and review signals.

## Rollback Plan

- Revert this PR to restore the previous broader PR-existence knowledge predicates and manifest contents.

## Exception

- Type: N/A
- Justification: N/A
