### PR TITLE
feat(config): validate procedure reads references

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -767,7 +767,13 @@ The command shells out to `gh api graphql` with a single
 ## `rgd config validate`
 
 Validates `reinguard.yaml`, `control/{states,routes,guards}/*.yaml`, `procedure/*.md` procedure front matter (when the directory exists), and `knowledge/manifest.json` when
-present, against embedded JSON Schemas and mapping consistency rules. Also **builds enabled observation providers** (same path as `rgd observe`) so invalid `providers[].options` (e.g. unknown `bot_reviewers[].enrich` names) fail validation. Non-zero exit on hard validation
+present, against embedded JSON Schemas and mapping consistency rules. Procedure
+front matter validation includes state mapping consistency and `reads:` entries:
+each `reads:` path must be relative to the declaring procedure file, resolve
+inside the repository root, and point to an existing file rather than a
+directory. Also **builds enabled observation providers** (same path as
+`rgd observe`) so invalid `providers[].options` (e.g. unknown
+`bot_reviewers[].enrich` names) fail validation. Non-zero exit on hard validation
 errors. **Deprecated** configuration keys (marked in JSON Schema) emit **warnings
 on stderr** but still exit **0** when validation succeeds.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -767,15 +767,18 @@ The command shells out to `gh api graphql` with a single
 ## `rgd config validate`
 
 Validates `reinguard.yaml`, `control/{states,routes,guards}/*.yaml`, `procedure/*.md` procedure front matter (when the directory exists), and `knowledge/manifest.json` when
-present, against embedded JSON Schemas and mapping consistency rules. Procedure
-front matter validation includes state mapping consistency and `reads:` entries:
-each `reads:` path must be relative to the declaring procedure file, resolve
-inside the repository root, and point to an existing file rather than a
-directory. Also **builds enabled observation providers** (same path as
-`rgd observe`) so invalid `providers[].options` (e.g. unknown
-`bot_reviewers[].enrich` names) fail validation. Non-zero exit on hard validation
-errors. **Deprecated** configuration keys (marked in JSON Schema) emit **warnings
-on stderr** but still exit **0** when validation succeeds.
+present, against embedded JSON Schemas and mapping consistency rules.
+
+Procedure front matter validation includes state mapping consistency and
+`reads:` path validation. Each `reads:` path must be relative to the declaring
+procedure file, resolve inside the repository root, and point to an existing
+regular file rather than a directory or symlink.
+
+Provider validation also **builds enabled observation providers**, using the
+same code path as `rgd observe`, so invalid `providers[].options` (e.g. unknown
+`bot_reviewers[].enrich` names) fail validation. Non-zero exit on hard
+validation errors. **Deprecated** configuration keys (marked in JSON Schema)
+emit **warnings on stderr** but still exit **0** when validation succeeds.
 
 `config validate` does **not** validate `.reinguard/local/`; runtime gate
 artifacts use the dedicated `rgd gate` schema and commands instead.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -769,16 +769,17 @@ The command shells out to `gh api graphql` with a single
 Validates `reinguard.yaml`, `control/{states,routes,guards}/*.yaml`, `procedure/*.md` procedure front matter (when the directory exists), and `knowledge/manifest.json` when
 present, against embedded JSON Schemas and mapping consistency rules.
 
-Procedure front matter validation includes state mapping consistency and
-`reads:` path validation. Each `reads:` path must be relative to the declaring
-procedure file, resolve inside the repository root, and point to an existing
-regular file rather than a directory or symlink.
+Procedure front matter validation includes state mapping consistency
+(`applies_to.state_ids` must reference declared workflow states) and `reads:`
+path validation. Each `reads:` path must be relative to the declaring procedure
+file, resolve inside the repository root, and point to an existing regular file
+rather than a directory or symlink.
 
 Provider validation also **builds enabled observation providers**, using the
 same code path as `rgd observe`, so invalid `providers[].options` (e.g. unknown
-`bot_reviewers[].enrich` names) fail validation. Non-zero exit on hard
-validation errors. **Deprecated** configuration keys (marked in JSON Schema)
-emit **warnings on stderr** but still exit **0** when validation succeeds.
+`bot_reviewers[].enrich` names) fail validation with a non-zero exit.
+**Deprecated** configuration keys (marked in JSON Schema) emit **warnings on
+stderr** but still exit **0** when validation succeeds.
 
 `config validate` does **not** validate `.reinguard/local/`; runtime gate
 artifacts use the dedicated `rgd gate` schema and commands instead.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1219,6 +1219,10 @@ rules:
 	if err := os.MkdirAll(procDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(dir, "policy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "policy", "required.md"), []byte("# Required\n"))
 	writeFile(t, filepath.Join(procDir, "p.md"), []byte(`---
 id: procedure-test
 purpose: Test procedure.
@@ -1226,6 +1230,8 @@ applies_to:
   state_ids:
     - working_no_pr
   route_ids: []
+reads:
+  - ../policy/required.md
 ---
 `))
 	res, err := Load(dir)
@@ -1234,6 +1240,51 @@ applies_to:
 	}
 	if !res.ProcedurePresent || len(res.ProcedureEntries) != 1 {
 		t.Fatalf("procedure: present=%v entries=%+v", res.ProcedurePresent, res.ProcedureEntries)
+	}
+}
+
+func TestLoad_procedureReadsMissingRejected(t *testing.T) {
+	t.Parallel()
+	// Given: a valid state rule and a procedure declaring a missing reads target
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "reinguard.yaml"), reinguardYAMLMinimal())
+	statesDir := filepath.Join(dir, "control", "states")
+	if err := os.MkdirAll(statesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(statesDir, "t.yaml"), []byte(fmt.Sprintf(`schema_version: %q
+rules:
+  - type: state
+    id: only
+    priority: 10
+    when:
+      op: eq
+      path: git.branch
+      value: main
+    state_id: working_no_pr
+`, schema.CurrentSchemaVersion)))
+	procDir := filepath.Join(dir, "procedure")
+	if err := os.MkdirAll(procDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(procDir, "p.md"), []byte(`---
+id: procedure-test
+purpose: Test procedure.
+applies_to:
+  state_ids:
+    - working_no_pr
+  route_ids: []
+reads:
+  - ../policy/missing.md
+---
+`))
+
+	// When: Load runs
+	_, err := Load(dir)
+
+	// Then: validation names the procedure and missing reads path
+	if err == nil || !strings.Contains(err.Error(), "procedure-test") || !strings.Contains(err.Error(), "../policy/missing.md") {
+		t.Fatalf("got %v", err)
 	}
 }
 

--- a/internal/procedure/catalog.go
+++ b/internal/procedure/catalog.go
@@ -119,7 +119,7 @@ func validateReadReference(repoRootAbs, resolvedRepoRoot, procedureAbsPath, proc
 		return fmt.Errorf("procedure: reads[%d] in procedure %q path %q: %w", index, procedureID, read, err)
 	}
 	if !pathInside(resolvedRepoRoot, resolvedReadPath) {
-		return fmt.Errorf("procedure: reads[%d] in procedure %q escapes repository: %q", index, procedureID, read)
+		return fmt.Errorf("procedure: reads[%d] in procedure %q resolves outside repository: %q", index, procedureID, read)
 	}
 	st, err := os.Lstat(readPath)
 	if err != nil {

--- a/internal/procedure/catalog.go
+++ b/internal/procedure/catalog.go
@@ -91,33 +91,58 @@ func LoadEntries(repoRootAbs, procedureAbsDir string) ([]Entry, bool, error) {
 }
 
 func validateReadReferences(repoRootAbs, procedureAbsPath, procedureID string, reads []string) error {
+	resolvedRepoRoot, err := filepath.EvalSymlinks(repoRootAbs)
+	if err != nil {
+		return fmt.Errorf("procedure: resolve repository root %q: %w", repoRootAbs, err)
+	}
 	for i, read := range reads {
-		if filepath.IsAbs(read) {
-			return fmt.Errorf("procedure: reads[%d] in procedure %q must be relative, got %q", i, procedureID, read)
-		}
-		readPath := filepath.Clean(filepath.Join(filepath.Dir(procedureAbsPath), filepath.FromSlash(read)))
-		rel, err := filepath.Rel(repoRootAbs, readPath)
-		if err != nil {
-			return fmt.Errorf("procedure: reads[%d] in procedure %q path %q: %w", i, procedureID, read, err)
-		}
-		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
-			return fmt.Errorf("procedure: reads[%d] in procedure %q escapes repository: %q", i, procedureID, read)
-		}
-		st, err := os.Lstat(readPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return fmt.Errorf("procedure: reads[%d] in procedure %q path does not exist: %q", i, procedureID, read)
-			}
-			return fmt.Errorf("procedure: reads[%d] in procedure %q path %q: %w", i, procedureID, read, err)
-		}
-		if st.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("procedure: reads[%d] in procedure %q path is a symlink: %q", i, procedureID, read)
-		}
-		if st.IsDir() {
-			return fmt.Errorf("procedure: reads[%d] in procedure %q path is a directory: %q", i, procedureID, read)
+		if err := validateReadReference(repoRootAbs, resolvedRepoRoot, procedureAbsPath, procedureID, i, read); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func validateReadReference(repoRootAbs, resolvedRepoRoot, procedureAbsPath, procedureID string, index int, read string) error {
+	if filepath.IsAbs(read) {
+		return fmt.Errorf("procedure: reads[%d] in procedure %q must be relative, got %q", index, procedureID, read)
+	}
+	readPath := filepath.Clean(filepath.Join(filepath.Dir(procedureAbsPath), filepath.FromSlash(read)))
+	if !pathInside(repoRootAbs, readPath) {
+		return fmt.Errorf("procedure: reads[%d] in procedure %q escapes repository: %q", index, procedureID, read)
+	}
+	resolvedReadPath, err := filepath.EvalSymlinks(readPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("procedure: reads[%d] in procedure %q path does not exist: %q", index, procedureID, read)
+		}
+		return fmt.Errorf("procedure: reads[%d] in procedure %q path %q: %w", index, procedureID, read, err)
+	}
+	if !pathInside(resolvedRepoRoot, resolvedReadPath) {
+		return fmt.Errorf("procedure: reads[%d] in procedure %q escapes repository: %q", index, procedureID, read)
+	}
+	st, err := os.Lstat(readPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("procedure: reads[%d] in procedure %q path does not exist: %q", index, procedureID, read)
+		}
+		return fmt.Errorf("procedure: reads[%d] in procedure %q path %q: %w", index, procedureID, read, err)
+	}
+	if st.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("procedure: reads[%d] in procedure %q path is a symlink: %q", index, procedureID, read)
+	}
+	if st.IsDir() {
+		return fmt.Errorf("procedure: reads[%d] in procedure %q path is a directory: %q", index, procedureID, read)
+	}
+	return nil
+}
+
+func pathInside(rootAbs, pathAbs string) bool {
+	rel, err := filepath.Rel(rootAbs, pathAbs)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
 }
 
 // ValidateStateMapping checks that each state_id appears in at most one procedure entry

--- a/internal/procedure/catalog.go
+++ b/internal/procedure/catalog.go
@@ -103,15 +103,18 @@ func validateReadReferences(repoRootAbs, procedureAbsPath, procedureID string, r
 		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
 			return fmt.Errorf("procedure: reads[%d] in procedure %q escapes repository: %q", i, procedureID, read)
 		}
-		st, err := os.Stat(readPath)
+		st, err := os.Lstat(readPath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return fmt.Errorf("procedure: reads[%d] in procedure %q path does not exist: %s", i, procedureID, read)
+				return fmt.Errorf("procedure: reads[%d] in procedure %q path does not exist: %q", i, procedureID, read)
 			}
 			return fmt.Errorf("procedure: reads[%d] in procedure %q path %q: %w", i, procedureID, read, err)
 		}
+		if st.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("procedure: reads[%d] in procedure %q path is a symlink: %q", i, procedureID, read)
+		}
 		if st.IsDir() {
-			return fmt.Errorf("procedure: reads[%d] in procedure %q path is a directory: %s", i, procedureID, read)
+			return fmt.Errorf("procedure: reads[%d] in procedure %q path is a directory: %q", i, procedureID, read)
 		}
 	}
 	return nil

--- a/internal/procedure/catalog.go
+++ b/internal/procedure/catalog.go
@@ -17,6 +17,7 @@ type Entry struct {
 	Path      string
 	StateIDs  []string
 	RouteIDs  []string
+	Reads     []string
 	Purpose   string
 	AbsSource string
 }
@@ -66,6 +67,9 @@ func LoadEntries(repoRootAbs, procedureAbsDir string) ([]Entry, bool, error) {
 			return nil, true, fmt.Errorf("procedure: duplicate procedure id %q in %s and %s", fm.ID, prev, absPath)
 		}
 		seenProcID[fm.ID] = absPath
+		if err := validateReadReferences(repoRootAbs, absPath, fm.ID, fm.Reads); err != nil {
+			return nil, true, err
+		}
 
 		rel, rerr := filepath.Rel(repoRootAbs, absPath)
 		if rerr != nil {
@@ -78,11 +82,39 @@ func LoadEntries(repoRootAbs, procedureAbsDir string) ([]Entry, bool, error) {
 			Path:      rel,
 			StateIDs:  append([]string(nil), fm.AppliesTo.StateIDs...),
 			RouteIDs:  append([]string(nil), fm.AppliesTo.RouteIDs...),
+			Reads:     append([]string(nil), fm.Reads...),
 			Purpose:   fm.Purpose,
 			AbsSource: absPath,
 		})
 	}
 	return entries, true, nil
+}
+
+func validateReadReferences(repoRootAbs, procedureAbsPath, procedureID string, reads []string) error {
+	for i, read := range reads {
+		if filepath.IsAbs(read) {
+			return fmt.Errorf("procedure: reads[%d] in procedure %q must be relative, got %q", i, procedureID, read)
+		}
+		readPath := filepath.Clean(filepath.Join(filepath.Dir(procedureAbsPath), filepath.FromSlash(read)))
+		rel, err := filepath.Rel(repoRootAbs, readPath)
+		if err != nil {
+			return fmt.Errorf("procedure: reads[%d] in procedure %q path %q: %w", i, procedureID, read, err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			return fmt.Errorf("procedure: reads[%d] in procedure %q escapes repository: %q", i, procedureID, read)
+		}
+		st, err := os.Stat(readPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("procedure: reads[%d] in procedure %q path does not exist: %s", i, procedureID, read)
+			}
+			return fmt.Errorf("procedure: reads[%d] in procedure %q path %q: %w", i, procedureID, read, err)
+		}
+		if st.IsDir() {
+			return fmt.Errorf("procedure: reads[%d] in procedure %q path is a directory: %s", i, procedureID, read)
+		}
+	}
+	return nil
 }
 
 // ValidateStateMapping checks that each state_id appears in at most one procedure entry

--- a/internal/procedure/catalog.go
+++ b/internal/procedure/catalog.go
@@ -134,6 +134,9 @@ func validateReadReference(repoRootAbs, resolvedRepoRoot, procedureAbsPath, proc
 	if st.IsDir() {
 		return fmt.Errorf("procedure: reads[%d] in procedure %q path is a directory: %q", index, procedureID, read)
 	}
+	if !st.Mode().IsRegular() {
+		return fmt.Errorf("procedure: reads[%d] in procedure %q path is not a regular file: %q", index, procedureID, read)
+	}
 	return nil
 }
 

--- a/internal/procedure/catalog_test.go
+++ b/internal/procedure/catalog_test.go
@@ -139,7 +139,7 @@ func TestLoadEntries_readsReferenceValidation(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantErrSubstr: "escapes repository",
+			wantErrSubstr: "resolves outside repository",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/procedure/catalog_test.go
+++ b/internal/procedure/catalog_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -176,6 +177,33 @@ reads:
 				t.Fatalf("present=%v entries=%+v", present, entries)
 			}
 		})
+	}
+}
+
+func TestLoadEntries_readsReferenceRejectsNonRegularFile(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "policy"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(root, "policy", "pipe.md"), 0o600); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+	pdir := filepath.Join(root, "procedure")
+	writeProcFile(t, filepath.Join(pdir, "p.md"), `---
+id: procedure-p
+purpose: P
+applies_to:
+  state_ids: []
+  route_ids: []
+reads:
+  - ../policy/pipe.md
+---
+`)
+
+	_, _, err := LoadEntries(root, pdir)
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("LoadEntries() err=%v, want non-regular file rejection", err)
 	}
 }
 

--- a/internal/procedure/catalog_test.go
+++ b/internal/procedure/catalog_test.go
@@ -33,6 +33,7 @@ func TestLoadEntries_okAndSorted(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	pdir := filepath.Join(root, "procedure")
+	writeProcFile(t, filepath.Join(root, "policy", "required.md"), "# Required\n")
 	writeProcFile(t, filepath.Join(pdir, "b.md"), `---
 id: procedure-b
 purpose: B
@@ -41,6 +42,8 @@ applies_to:
     - merge_ready
   route_ids:
     - user-merge
+reads:
+  - ../policy/required.md
 ---
 `)
 	writeProcFile(t, filepath.Join(pdir, "a.md"), `---
@@ -64,6 +67,86 @@ applies_to:
 	}
 	if entries[0].Path != "procedure/a.md" {
 		t.Fatalf("path %q", entries[0].Path)
+	}
+	if len(entries[1].Reads) != 1 || entries[1].Reads[0] != "../policy/required.md" {
+		t.Fatalf("reads %+v", entries[1].Reads)
+	}
+}
+
+func TestLoadEntries_readsReferenceValidation(t *testing.T) {
+	t.Parallel()
+	// Given/When/Then: each fixture loads a procedure reads entry and expects success or a precise validation error.
+	tests := []struct {
+		name          string
+		read          string
+		setup         func(t *testing.T, root string)
+		wantErrSubstr string
+	}{
+		{
+			name: "existing_relative_file_succeeds",
+			read: "../policy/required.md",
+			setup: func(t *testing.T, root string) {
+				writeProcFile(t, filepath.Join(root, "policy", "required.md"), "# Required\n")
+			},
+		},
+		{
+			name:          "missing_file_fails",
+			read:          "../policy/missing.md",
+			wantErrSubstr: "path does not exist",
+		},
+		{
+			name:          "absolute_path_fails",
+			read:          "/tmp/required.md",
+			wantErrSubstr: "must be relative",
+		},
+		{
+			name:          "escaping_repo_fails",
+			read:          "../../../outside.md",
+			wantErrSubstr: "escapes repository",
+		},
+		{
+			name: "directory_path_fails",
+			read: "../policy",
+			setup: func(t *testing.T, root string) {
+				if err := os.MkdirAll(filepath.Join(root, "policy"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErrSubstr: "path is a directory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			if tt.setup != nil {
+				tt.setup(t, root)
+			}
+			pdir := filepath.Join(root, "procedure")
+			writeProcFile(t, filepath.Join(pdir, "p.md"), `---
+id: procedure-p
+purpose: P
+applies_to:
+  state_ids: []
+  route_ids: []
+reads:
+  - `+tt.read+`
+---
+`)
+			entries, present, err := LoadEntries(root, pdir)
+			if tt.wantErrSubstr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrSubstr) {
+					t.Fatalf("LoadEntries() err=%v, want substring %q", err, tt.wantErrSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !present || len(entries) != 1 || len(entries[0].Reads) != 1 {
+				t.Fatalf("present=%v entries=%+v", present, entries)
+			}
+		})
 	}
 }
 

--- a/internal/procedure/catalog_test.go
+++ b/internal/procedure/catalog_test.go
@@ -87,6 +87,7 @@ func TestLoadEntries_readsReferenceValidation(t *testing.T) {
 			read: "../policy/required.md",
 			setup: func(t *testing.T, root string) {
 				writeProcFile(t, filepath.Join(root, "policy", "required.md"), "# Required\n")
+				writeProcFile(t, filepath.Join(root, "policy", "other.md"), "# Other\n")
 			},
 		},
 		{
@@ -114,6 +115,17 @@ func TestLoadEntries_readsReferenceValidation(t *testing.T) {
 			},
 			wantErrSubstr: "path is a directory",
 		},
+		{
+			name: "symlink_path_fails",
+			read: "../policy/link.md",
+			setup: func(t *testing.T, root string) {
+				writeProcFile(t, filepath.Join(root, "policy", "required.md"), "# Required\n")
+				if err := os.Symlink("required.md", filepath.Join(root, "policy", "link.md")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErrSubstr: "path is a symlink",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -131,6 +143,7 @@ applies_to:
   route_ids: []
 reads:
   - `+tt.read+`
+  - ../policy/other.md
 ---
 `)
 			entries, present, err := LoadEntries(root, pdir)
@@ -143,7 +156,7 @@ reads:
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !present || len(entries) != 1 || len(entries[0].Reads) != 1 {
+			if !present || len(entries) != 1 || len(entries[0].Reads) != 2 {
 				t.Fatalf("present=%v entries=%+v", present, entries)
 			}
 		})

--- a/internal/procedure/catalog_test.go
+++ b/internal/procedure/catalog_test.go
@@ -131,6 +131,7 @@ func TestLoadEntries_readsReferenceValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			root := t.TempDir()
+			writeProcFile(t, filepath.Join(root, "policy", "other.md"), "# Other\n")
 			if tt.setup != nil {
 				tt.setup(t, root)
 			}

--- a/internal/procedure/catalog_test.go
+++ b/internal/procedure/catalog_test.go
@@ -126,6 +126,21 @@ func TestLoadEntries_readsReferenceValidation(t *testing.T) {
 			},
 			wantErrSubstr: "path is a symlink",
 		},
+		{
+			name: "intermediate_symlink_escape_fails",
+			read: "../policy/link/secret.md",
+			setup: func(t *testing.T, root string) {
+				outside := filepath.Join(t.TempDir(), "outside")
+				writeProcFile(t, filepath.Join(outside, "secret.md"), "# Secret\n")
+				if err := os.MkdirAll(filepath.Join(root, "policy"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(outside, filepath.Join(root, "policy", "link")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErrSubstr: "escapes repository",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/procedure/frontmatter.go
+++ b/internal/procedure/frontmatter.go
@@ -21,7 +21,8 @@ type FrontMatter struct {
 	ID        string    `yaml:"id"`
 	Purpose   string    `yaml:"purpose"`
 	AppliesTo AppliesTo `yaml:"applies_to"`
-	// Other keys (reads, sense, act, …) are ignored for machine validation.
+	Reads     []string  `yaml:"reads"`
+	// Other keys (sense, act, …) are ignored for machine validation.
 }
 
 // ParseFrontMatter extracts and parses the first YAML front matter block (--- ... ---).
@@ -50,6 +51,7 @@ func ParseFrontMatter(md []byte) (*FrontMatter, error) {
 	fm.Purpose = strings.TrimSpace(fm.Purpose)
 	fm.AppliesTo.StateIDs = trimNonEmptyStrings(fm.AppliesTo.StateIDs)
 	fm.AppliesTo.RouteIDs = trimNonEmptyStrings(fm.AppliesTo.RouteIDs)
+	fm.Reads = trimStrings(fm.Reads)
 	if fm.ID == "" {
 		return nil, fmt.Errorf("procedure: front matter: missing id")
 	}
@@ -62,16 +64,29 @@ func ParseFrontMatter(md []byte) (*FrontMatter, error) {
 	if err := validateUniqueStrings("route_id", fm.ID, fm.AppliesTo.RouteIDs); err != nil {
 		return nil, err
 	}
+	for i, read := range fm.Reads {
+		if read == "" {
+			return nil, fmt.Errorf("procedure: front matter: reads[%d] in procedure id %q is empty", i, fm.ID)
+		}
+	}
 	return &fm, nil
 }
 
 func trimNonEmptyStrings(in []string) []string {
+	trimmed := trimStrings(in)
 	var out []string
-	for _, s := range in {
-		s = strings.TrimSpace(s)
+	for _, s := range trimmed {
 		if s != "" {
 			out = append(out, s)
 		}
+	}
+	return out
+}
+
+func trimStrings(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		out = append(out, strings.TrimSpace(s))
 	}
 	return out
 }

--- a/internal/procedure/frontmatter.go
+++ b/internal/procedure/frontmatter.go
@@ -65,13 +65,13 @@ func ParseFrontMatter(md []byte) (*FrontMatter, error) {
 	if err := validateUniqueStrings("route_id", fm.ID, fm.AppliesTo.RouteIDs); err != nil {
 		return nil, err
 	}
-	if err := validateUniqueStrings("read", fm.ID, fm.Reads); err != nil {
-		return nil, err
-	}
 	for i, read := range fm.Reads {
 		if read == "" {
 			return nil, fmt.Errorf("procedure: front matter: reads[%d] in procedure id %q is empty", i, fm.ID)
 		}
+	}
+	if err := validateUniqueStrings("read", fm.ID, fm.Reads); err != nil {
+		return nil, err
 	}
 	return &fm, nil
 }

--- a/internal/procedure/frontmatter.go
+++ b/internal/procedure/frontmatter.go
@@ -64,6 +64,9 @@ func ParseFrontMatter(md []byte) (*FrontMatter, error) {
 	if err := validateUniqueStrings("route_id", fm.ID, fm.AppliesTo.RouteIDs); err != nil {
 		return nil, err
 	}
+	if err := validateUniqueStrings("read", fm.ID, fm.Reads); err != nil {
+		return nil, err
+	}
 	for i, read := range fm.Reads {
 		if read == "" {
 			return nil, fmt.Errorf("procedure: front matter: reads[%d] in procedure id %q is empty", i, fm.ID)

--- a/internal/procedure/frontmatter.go
+++ b/internal/procedure/frontmatter.go
@@ -51,6 +51,7 @@ func ParseFrontMatter(md []byte) (*FrontMatter, error) {
 	fm.Purpose = strings.TrimSpace(fm.Purpose)
 	fm.AppliesTo.StateIDs = trimNonEmptyStrings(fm.AppliesTo.StateIDs)
 	fm.AppliesTo.RouteIDs = trimNonEmptyStrings(fm.AppliesTo.RouteIDs)
+	// Keep blank reads entries as validation errors because each item names a required file.
 	fm.Reads = trimStrings(fm.Reads)
 	if fm.ID == "" {
 		return nil, fmt.Errorf("procedure: front matter: missing id")

--- a/internal/procedure/frontmatter_test.go
+++ b/internal/procedure/frontmatter_test.go
@@ -60,6 +60,27 @@ applies_to:
 	}
 }
 
+func TestParseFrontMatter_singleRead(t *testing.T) {
+	t.Parallel()
+	md := `---
+id: procedure-single-read
+purpose: Single read.
+applies_to:
+  state_ids: []
+  route_ids: []
+reads:
+  - ../policy/one.md
+---
+`
+	fm, err := ParseFrontMatter([]byte(md))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fm.Reads) != 1 || fm.Reads[0] != "../policy/one.md" {
+		t.Fatalf("reads %+v", fm.Reads)
+	}
+}
+
 func TestParseFrontMatter_blockScalarAllowsIndentedDelimiters(t *testing.T) {
 	t.Parallel()
 	md := `---

--- a/internal/procedure/frontmatter_test.go
+++ b/internal/procedure/frontmatter_test.go
@@ -17,6 +17,7 @@ applies_to:
     - user-implement
 reads:
   - ../policy/coding--standards.md
+  - ../policy/commit--format.md
 ---
 # Body
 `
@@ -33,7 +34,9 @@ reads:
 	if len(fm.AppliesTo.RouteIDs) != 1 || fm.AppliesTo.RouteIDs[0] != "user-implement" {
 		t.Fatalf("route_ids %+v", fm.AppliesTo.RouteIDs)
 	}
-	if len(fm.Reads) != 1 || fm.Reads[0] != "../policy/coding--standards.md" {
+	if len(fm.Reads) != 2 ||
+		fm.Reads[0] != "../policy/coding--standards.md" ||
+		fm.Reads[1] != "../policy/commit--format.md" {
 		t.Fatalf("reads %+v", fm.Reads)
 	}
 }

--- a/internal/procedure/frontmatter_test.go
+++ b/internal/procedure/frontmatter_test.go
@@ -60,6 +60,26 @@ applies_to:
 	}
 }
 
+func TestParseFrontMatter_emptyReads(t *testing.T) {
+	t.Parallel()
+	md := `---
+id: procedure-empty-reads
+purpose: Empty reads.
+applies_to:
+  state_ids: []
+  route_ids: []
+reads: []
+---
+`
+	fm, err := ParseFrontMatter([]byte(md))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fm.Reads) != 0 {
+		t.Fatalf("reads %+v", fm.Reads)
+	}
+}
+
 func TestParseFrontMatter_singleRead(t *testing.T) {
 	t.Parallel()
 	md := `---

--- a/internal/procedure/frontmatter_test.go
+++ b/internal/procedure/frontmatter_test.go
@@ -91,6 +91,7 @@ func TestParseFrontMatter_errors(t *testing.T) {
 		{name: "missing_id", input: "---\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\n---\n", contain: "id"},
 		{name: "missing_purpose", input: "---\nid: x\napplies_to:\n  state_ids: []\n  route_ids: []\n---\n", contain: "purpose"},
 		{name: "empty_reads_entry", input: "---\nid: x\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\nreads:\n  - '  '\n---\n", contain: "reads[0]"},
+		{name: "dup_reads_entry", input: "---\nid: x\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\nreads:\n  - ../a.md\n  - ../a.md\n---\n", contain: "duplicate read"},
 		{name: "dup_state_in_file", input: `---
 id: x
 purpose: p

--- a/internal/procedure/frontmatter_test.go
+++ b/internal/procedure/frontmatter_test.go
@@ -94,6 +94,7 @@ func TestParseFrontMatter_errors(t *testing.T) {
 		{name: "missing_id", input: "---\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\n---\n", contain: "id"},
 		{name: "missing_purpose", input: "---\nid: x\napplies_to:\n  state_ids: []\n  route_ids: []\n---\n", contain: "purpose"},
 		{name: "empty_reads_entry", input: "---\nid: x\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\nreads:\n  - '  '\n---\n", contain: "reads[0]"},
+		{name: "duplicate_empty_reads_entry", input: "---\nid: x\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\nreads:\n  - ''\n  - ''\n---\n", contain: "reads[0]"},
 		{name: "dup_reads_entry", input: "---\nid: x\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\nreads:\n  - ../a.md\n  - ../a.md\n---\n", contain: "duplicate read"},
 		{name: "dup_state_in_file", input: `---
 id: x

--- a/internal/procedure/frontmatter_test.go
+++ b/internal/procedure/frontmatter_test.go
@@ -15,6 +15,8 @@ applies_to:
     - working_no_pr
   route_ids:
     - user-implement
+reads:
+  - ../policy/coding--standards.md
 ---
 # Body
 `
@@ -30,6 +32,9 @@ applies_to:
 	}
 	if len(fm.AppliesTo.RouteIDs) != 1 || fm.AppliesTo.RouteIDs[0] != "user-implement" {
 		t.Fatalf("route_ids %+v", fm.AppliesTo.RouteIDs)
+	}
+	if len(fm.Reads) != 1 || fm.Reads[0] != "../policy/coding--standards.md" {
+		t.Fatalf("reads %+v", fm.Reads)
 	}
 }
 
@@ -85,6 +90,7 @@ func TestParseFrontMatter_errors(t *testing.T) {
 		{name: "missing_close", input: "---\nid: x\npurpose: p\n", contain: "closing"},
 		{name: "missing_id", input: "---\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\n---\n", contain: "id"},
 		{name: "missing_purpose", input: "---\nid: x\napplies_to:\n  state_ids: []\n  route_ids: []\n---\n", contain: "purpose"},
+		{name: "empty_reads_entry", input: "---\nid: x\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\nreads:\n  - '  '\n---\n", contain: "reads[0]"},
 		{name: "dup_state_in_file", input: `---
 id: x
 purpose: p

--- a/internal/procedure/frontmatter_test.go
+++ b/internal/procedure/frontmatter_test.go
@@ -115,7 +115,7 @@ func TestParseFrontMatter_errors(t *testing.T) {
 		{name: "missing_id", input: "---\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\n---\n", contain: "id"},
 		{name: "missing_purpose", input: "---\nid: x\napplies_to:\n  state_ids: []\n  route_ids: []\n---\n", contain: "purpose"},
 		{name: "empty_reads_entry", input: "---\nid: x\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\nreads:\n  - '  '\n---\n", contain: "reads[0]"},
-		{name: "duplicate_empty_reads_entry", input: "---\nid: x\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\nreads:\n  - ''\n  - ''\n---\n", contain: "reads[0]"},
+		{name: "empty_reads_entry_as_empty_string", input: "---\nid: x\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\nreads:\n  - ''\n  - ''\n---\n", contain: "reads[0]"},
 		{name: "dup_reads_entry", input: "---\nid: x\npurpose: p\napplies_to:\n  state_ids: []\n  route_ids: []\nreads:\n  - ../a.md\n  - ../a.md\n---\n", contain: "duplicate read"},
 		{name: "dup_state_in_file", input: `---
 id: x

--- a/internal/rgdcli/workflow_fsm_test.go
+++ b/internal/rgdcli/workflow_fsm_test.go
@@ -18,10 +18,12 @@ func reinguardConfigDir(t *testing.T) string {
 	}
 	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
 	src := filepath.Join(root, ".reinguard")
-	dst := filepath.Join(t.TempDir(), ".reinguard")
+	fixtureRoot := t.TempDir()
+	dst := filepath.Join(fixtureRoot, ".reinguard")
 	if err := copyTree(t, src, dst); err != nil {
 		t.Fatalf("copy .reinguard: %v", err)
 	}
+	writeFile(t, filepath.Join(fixtureRoot, ".github", "PULL_REQUEST_TEMPLATE.md"), []byte("# Pull Request\n"))
 	// Isolate FSM scenario tests from developer-local .reinguard/local artifacts (hermetic fixtures).
 	_ = os.RemoveAll(filepath.Join(dst, "local"))
 	return dst

--- a/internal/rgdcli/workflow_fsm_test.go
+++ b/internal/rgdcli/workflow_fsm_test.go
@@ -23,6 +23,7 @@ func reinguardConfigDir(t *testing.T) string {
 	if err := copyTree(t, src, dst); err != nil {
 		t.Fatalf("copy .reinguard: %v", err)
 	}
+	// Some procedure reads entries intentionally point at repo files outside .reinguard.
 	writeFile(t, filepath.Join(fixtureRoot, ".github", "PULL_REQUEST_TEMPLATE.md"), []byte("# Pull Request\n"))
 	// Isolate FSM scenario tests from developer-local .reinguard/local artifacts (hermetic fixtures).
 	_ = os.RemoveAll(filepath.Join(dst, "local"))

--- a/internal/rgdcli/workflow_fsm_test.go
+++ b/internal/rgdcli/workflow_fsm_test.go
@@ -23,7 +23,7 @@ func reinguardConfigDir(t *testing.T) string {
 	if err := copyTree(t, src, dst); err != nil {
 		t.Fatalf("copy .reinguard: %v", err)
 	}
-	// Some procedure reads entries intentionally point at repo files outside .reinguard.
+	// Some procedure definitions reference files outside .reinguard (for example, PR templates).
 	writeFile(t, filepath.Join(fixtureRoot, ".github", "PULL_REQUEST_TEMPLATE.md"), []byte("# Pull Request\n"))
 	// Isolate FSM scenario tests from developer-local .reinguard/local artifacts (hermetic fixtures).
 	_ = os.RemoveAll(filepath.Join(dst, "local"))


### PR DESCRIPTION
## Summary

- Validate procedure `reads:` front matter so required reading references must resolve to existing regular files inside the repository.
- Add focused coverage for valid, missing, absolute, escaping, symlink, directory, duplicate, empty, and boundary reads entries.
- Document the new `rgd config validate` coverage for procedure reads metadata.

## Traceability

Closes #151

Refs: #131
Refs: #133

## Definition of Done

- [x] Tests added or updated (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. `bash .reinguard/scripts/with-repo-local-state.sh -- go test ./... -race` passed.
2. `bash .reinguard/scripts/with-repo-local-state.sh -- go vet ./...` passed.
3. `bash .reinguard/scripts/with-repo-local-state.sh -- golangci-lint run` passed.
4. `bash .reinguard/scripts/with-repo-local-state.sh -- pre-commit run markdownlint-cli2 --all-files` passed.
5. `go run ./cmd/rgd config validate` passed.
6. `bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- bash .reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit` passed; final optional table-consolidation note accepted by design.

## Risk / Impact

- Low risk. This tightens validation for procedure metadata and may newly reject invalid `reads:` entries, including paths that are missing, absolute, outside the repository, symlinks, or directories.

## Rollback Plan

- Revert this PR to restore the previous procedure front matter validation behavior.

## Exception

- Type: N/A
- Justification: N/A
