### PR TITLE
docs(release): define v1.0 stability promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go version](https://img.shields.io/github/go-mod/go-version/k-shibuki/reinguard)](https://github.com/k-shibuki/reinguard/blob/main/go.mod)
 [![Go Report Card](https://goreportcard.com/badge/github.com/k-shibuki/reinguard)](https://goreportcard.com/report/github.com/k-shibuki/reinguard)
 [![CI](https://github.com/k-shibuki/reinguard/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/k-shibuki/reinguard/actions/workflows/ci.yaml?query=branch%3Amain)
-[![Pre-release](https://img.shields.io/badge/status-pre--release-orange)](https://github.com/k-shibuki/reinguard#status)
+[![Release](https://img.shields.io/badge/status-v1.0.0-blue)](https://github.com/k-shibuki/reinguard#status--license)
 
 **Repo-owned Semantic Control for Agentic Development** — *operational context for bot-aware PR work*.
 
@@ -42,6 +42,49 @@ agent decides what to do next.
 If the instinct is to solve this with an agent orchestrator, `reinguard` takes
 the opposite bet: make the facts deterministic, then leave judgment with the
 agent.
+
+## v1.0.0 Position
+
+Product `v1.0.0` means the core shape of reinguard is ready for early adopters:
+a repo-owned Agent Control Plane as Code substrate that computes operational
+context for humans, agents, and review bots. It does **not** mean the product
+has become a workflow brain. ADR-0001 remains the boundary: `rgd` observes,
+evaluates, and emits deterministic context; agents and maintainers keep
+judgment-heavy planning and review decisions.
+
+The synchronized schema contract is versioned separately from the product
+release. The current `.reinguard/` files and embedded schemas declare contract
+`0.8.0`; that value covers both repository inputs and machine-readable
+operational-context output, as described in ADR-0008. A product tag such as
+`v1.0.0` can ship with schema contract `0.8.0` when the release stabilizes the
+product promise without changing the schema contract.
+
+Stable in `v1.0.0`:
+
+- The Adapter / Semantics / Substrate architecture and the ADR-0001 boundary
+- The `rgd` CLI command tree, flags, stdout/stderr rules, and exit-code contract
+  documented in [docs/cli.md](docs/cli.md)
+- The synchronized schema-contract model from ADR-0008 and
+  `pkg/schema/CurrentSchemaVersion`
+- Repository-owned Semantics under `.reinguard/`: policy, knowledge, workflow
+  states, routes, guards, procedures, and runtime gate roles
+
+Experimental or repository-local in `v1.0.0`:
+
+- The Cursor Adapter and other client-specific bridge files
+- Local runtime proof and Adapter resume artifacts under `.reinguard/local/`
+- Repository maintenance scripts under `.reinguard/scripts/`, including the
+  local CodeRabbit gate
+- Human-facing CLI explainability and richer diagnostics, tracked as Phase 3
+  follow-up work in
+  [#133](https://github.com/k-shibuki/reinguard/issues/133)
+
+Out of scope for `v1.0.0`:
+
+- Agent orchestration, planning, or online learning inside `rgd`
+- Replacing human or agent judgment for architecture, policy exceptions, or
+  review-comment correctness
+- Treating Phase 3 explainability work as a release blocker
 
 ## What Operational Context Looks Like
 
@@ -118,7 +161,8 @@ Full command behavior, flags, stdout/stderr rules, and exit codes:
 
 ## Repository Runtime Expectations
 
-- **Schema**: `0.8.0`
+- **Product release**: `v1.0.0` stability promise
+- **Schema contract**: `0.8.0`
 - **GitHub auth**: `gh` CLI
 - **Go**: 1.25.8+ (CI: 1.26.1; see [`go.mod`](go.mod))
 - **Build**: `go build -o rgd ./cmd/rgd`
@@ -146,5 +190,6 @@ Contribution and workflow policy: [.github/CONTRIBUTING.md](.github/CONTRIBUTING
 
 ## Status / License
 
-**Pre-release.** The CLI and schemas are still evolving. Licensed under
-[Apache-2.0](LICENSE).
+**v1.0.0 positioned.** The core product promise is stable for early adopters;
+schema contract `0.8.0` remains the synchronized machine contract for this
+release line. Licensed under [Apache-2.0](LICENSE).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,6 +5,27 @@ flags, stdout/stderr, and exit codes (ADR-0008). The `rgd` implementation
 must match this document; do not duplicate normative tables in the ADR
 body or README.
 
+## v1.0.0 stability
+
+For product `v1.0.0`, the shipped `rgd` CLI surface documented here is stable:
+command names, flags, machine-readable stdout contracts, stderr placement, and
+exit-code meanings are part of the public early-adopter promise. The command
+tree and flags in this document have been audited against the implemented
+`rgd` command wiring for the v1.0 line.
+
+This stability promise is distinct from the synchronized schema contract.
+Current repository configuration, control files, knowledge manifest, and
+operational-context JSON use schema contract `0.8.0`; `rgd config validate`
+enforces that contract as described in the `schema_version` vs this binary
+section below.
+
+Experimental or follow-up CLI work is not required for v1.0.0. In particular,
+Phase 3 human-facing explainability remains tracked in
+[#133](https://github.com/k-shibuki/reinguard/issues/133) and is not a v1.0
+release blocker. Repository-local scripts under `.reinguard/scripts/` remain
+outside the shipped `rgd` binary unless explicitly documented in this file as
+repository tooling.
+
 ## Common flags
 
 | Flag | Env | Description |


### PR DESCRIPTION
## Summary

- Define the v1.0.0 stability promise in the README without changing the schema contract.
- Clarify which surfaces are stable, experimental, and out of scope for the v1.0 release line.
- Add a CLI SSOT note that the implemented command tree and flags were audited for v1.0 consistency.

## Traceability

Closes #139

Refs: #138, #133

## Definition of Done

- [ ] Tests added or updated (`go test ./...`)
- [ ] `go vet ./...` clean
- [ ] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

Docs-only PR: Go tests, `go vet`, and `golangci-lint` are not applicable because no Go code or schema files changed.

## Test plan

1. `bash .reinguard/scripts/with-repo-local-state.sh -- pre-commit run markdownlint-cli2 --all-files` passed.
2. `go run ./cmd/rgd context build --compact` passed.
3. `go run ./cmd/rgd config validate` passed.
4. `bash .reinguard/scripts/with-repo-local-state.sh --home-subdir cr-home -- bash .reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit` passed with no findings.

## Risk / Impact

- Low risk: documentation-only release positioning update.
- Main risk is overstating the v1.0 promise; the README and CLI docs explicitly preserve ADR-0001 boundaries and schema contract `0.8.0`.

## Rollback Plan

- Revert this PR to restore the previous README and CLI documentation wording.

## Exception

- Type: N/A
- Justification: N/A
