### PR TITLE
ci(release): publish tagged rgd binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/install-yq
 
       - name: go test
-        run: go test ./... -race
+        run: go test ./... -race -timeout=10m
 
       - name: go vet
         run: go vet ./...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9.2.0
         with:
+          # Keep release verification aligned with the PR CI lint job.
           version: v2.11.4
           args: --timeout=5m ./...
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,8 @@ jobs:
             -o "dist/${artifact}" \
             ./cmd/rgd
 
+      # The Ubuntu runner can execute only the native linux/amd64 binary; every
+      # matrix target is built with the same VERSION ldflag above.
       - name: Verify stamped version
         if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
         env:
@@ -71,7 +73,15 @@ jobs:
 
       - name: Generate checksum
         working-directory: dist
-        run: sha256sum -- ./* > "rgd_${{ github.ref_name }}_${{ matrix.goos }}_${{ matrix.goarch }}.sha256"
+        env:
+          VERSION: ${{ github.ref_name }}
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          EXT: ${{ matrix.ext }}
+        run: |
+          set -euo pipefail
+          artifact="rgd_${VERSION}_${GOOS}_${GOARCH}${EXT}"
+          sha256sum -- "${artifact}" > "${artifact}.sha256"
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,9 +151,9 @@ jobs:
             exit 1
           fi
           if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
-            gh release upload "${TAG_NAME}" "${artifacts[@]}" --clobber
-          else
-            gh release create "${TAG_NAME}" "${artifacts[@]}" \
-              --title "${TAG_NAME}" \
-              --generate-notes
+            echo "Release ${TAG_NAME} already exists; delete it manually before republishing."
+            exit 1
           fi
+          gh release create "${TAG_NAME}" "${artifacts[@]}" \
+            --title "${TAG_NAME}" \
+            --generate-notes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,42 @@ permissions:
   contents: read
 
 jobs:
+  verify:
+    name: Verify release candidate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Verify module checksums
+        run: go mod verify
+
+      - name: Install mikefarah yq
+        uses: ./.github/actions/install-yq
+
+      - name: go test
+        run: go test ./... -race
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9.2.0
+        with:
+          version: v2.11.4
+          args: --timeout=5m ./...
+
   build:
     name: Build rgd (${{ matrix.goos }}-${{ matrix.goarch }})
+    needs: [verify]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -109,10 +143,16 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          shopt -s nullglob
+          artifacts=(dist/*)
+          if ((${#artifacts[@]} == 0)); then
+            echo "No release artifacts found in dist/"
+            exit 1
+          fi
           if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
-            gh release upload "${TAG_NAME}" dist/* --clobber
+            gh release upload "${TAG_NAME}" "${artifacts[@]}" --clobber
           else
-            gh release create "${TAG_NAME}" dist/* \
+            gh release create "${TAG_NAME}" "${artifacts[@]}" \
               --title "${TAG_NAME}" \
               --generate-notes
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build rgd (${{ matrix.goos }}-${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            ext: ""
+          - goos: linux
+            goarch: arm64
+            ext: ""
+          - goos: darwin
+            goarch: amd64
+            ext: ""
+          - goos: darwin
+            goarch: arm64
+            ext: ""
+          - goos: windows
+            goarch: amd64
+            ext: .exe
+          - goos: windows
+            goarch: arm64
+            ext: .exe
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build release binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+          VERSION: ${{ github.ref_name }}
+          EXT: ${{ matrix.ext }}
+        run: |
+          set -euo pipefail
+          artifact="rgd_${VERSION}_${GOOS}_${GOARCH}${EXT}"
+          mkdir -p dist
+          go build \
+            -trimpath \
+            -ldflags "-s -w -X main.version=${VERSION}" \
+            -o "dist/${artifact}" \
+            ./cmd/rgd
+
+      - name: Verify stamped version
+        if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          got="$("./dist/rgd_${VERSION}_linux_amd64" version)"
+          test "${got}" = "${VERSION}"
+
+      - name: Generate checksum
+        working-directory: dist
+        run: sha256sum -- ./* > "rgd_${{ github.ref_name }}_${{ matrix.goos }}_${{ matrix.goarch }}.sha256"
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: rgd-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub Release
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v7.0.0
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            gh release upload "${TAG_NAME}" dist/* --clobber
+          else
+            gh release create "${TAG_NAME}" dist/* \
+              --title "${TAG_NAME}" \
+              --generate-notes
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,6 +132,8 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v6.0.2
+
       - name: Download release artifacts
         uses: actions/download-artifact@v7.0.0
         with:

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ Full command behavior, flags, stdout/stderr rules, and exit codes:
 - **Build**: `go build -o rgd ./cmd/rgd`
 - **Check**: `make check`
 
+Tagged releases publish `rgd` binaries for Linux, macOS, and Windows on
+`amd64` and `arm64`, plus SHA-256 checksum files for each target. Release
+builds stamp `rgd version` from the Git tag. Package-manager distribution such
+as Homebrew is intentionally deferred outside the v1.0.0 release artifact set.
+
 Smoke check:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ Full command behavior, flags, stdout/stderr rules, and exit codes:
 - **Check**: `make check`
 
 Tagged releases publish `rgd` binaries for Linux, macOS, and Windows on
-`amd64` and `arm64`, plus SHA-256 checksum files for each target. Release
+`amd64` and `arm64`, plus SHA-256 checksum files for each target, from
+[GitHub Releases](https://github.com/k-shibuki/reinguard/releases). Release
 builds stamp `rgd version` from the Git tag. Package-manager distribution such
 as Homebrew is intentionally deferred outside the v1.0.0 release artifact set.
 

--- a/README.md
+++ b/README.md
@@ -169,10 +169,11 @@ Full command behavior, flags, stdout/stderr rules, and exit codes:
 - **Check**: `make check`
 
 Tagged releases publish `rgd` binaries for Linux, macOS, and Windows on
-`amd64` and `arm64`, plus SHA-256 checksum files for each target, from
-[GitHub Releases](https://github.com/k-shibuki/reinguard/releases). Release
-builds stamp `rgd version` from the Git tag. Package-manager distribution such
-as Homebrew is intentionally deferred outside the v1.0.0 release artifact set.
+`amd64` and `arm64` from
+[GitHub Releases](https://github.com/k-shibuki/reinguard/releases). Each
+release includes SHA-256 checksum files for all targets. Release builds stamp
+`rgd version` from the Git tag. Package-manager distribution such as Homebrew is
+intentionally deferred outside the v1.0.0 release artifact set.
 
 Smoke check:
 


### PR DESCRIPTION
## Summary

- Add a tag-triggered release workflow that verifies, builds, checksums, and publishes `rgd` release artifacts.
- Stamp release binaries with the Git tag so `rgd version` reports the published version.
- Document the v1.0 release artifact set and deferred package-manager distribution.

## Traceability

Closes #140

Refs: #138

## Definition of Done

- [x] Tests added or updated (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yaml` passes.
2. `go test ./... -race`, `go vet ./...`, and `golangci-lint run` pass.
3. `go run ./cmd/rgd config validate` and `go run ./cmd/rgd context build --compact` pass.
4. `pre-commit run markdownlint-cli2 --all-files` passes.
5. Cross-build Linux, macOS, and Windows `amd64`/`arm64` release-style binaries with `-X main.version=v1.0.0-test`, generate SHA-256 files, and verify the native Linux binary reports `v1.0.0-test`.
6. Local CodeRabbit review passes on the current head with no findings.

## Risk / Impact

- Release tags will now create GitHub Releases and upload binaries/checksums, so mistakes in tag publication affect release assets.
- The workflow fails if a release already exists to avoid silently overwriting previously published assets.

## Rollback Plan

- Revert this PR to remove the tag-triggered release workflow and README release artifact text.

## Exception

- Type: N/A
- Justification: N/A
