### PR TITLE
docs(onboarding): document rgd install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,18 @@ macOS, and Windows on `amd64` and `arm64`:
 1. Download the asset for your platform from
    [GitHub Releases](https://github.com/k-shibuki/reinguard/releases), for
    example `rgd_v1.0.0_linux_amd64`.
-2. Download the matching `.sha256` file and verify it with `sha256sum -c`.
+2. Download the matching `.sha256` file and verify it:
+   - Linux/macOS: `sha256sum -c rgd_v1.0.0_linux_amd64.sha256`
+   - Windows PowerShell:
+     `(Get-FileHash rgd_v1.0.0_windows_amd64.exe).Hash -eq (Get-Content rgd_v1.0.0_windows_amd64.exe.sha256).Split()[0]`
 3. Rename the binary to `rgd` (`rgd.exe` on Windows), make it executable on
    Unix-like systems, and place it in a directory on `PATH`.
-4. Run `rgd version` and `rgd config validate` from a repository that owns a
-   `.reinguard/` configuration.
+4. Verify the installation with `rgd version`. After bootstrapping a repository
+   with `.reinguard/` configuration, run `rgd config validate` to verify that
+   repository setup.
 
 There is no `rgd init` command in `v1.0.0`. To bootstrap a repository, copy or
-adapt a repository-owned `.reinguard/` directory, then run
+adapt this repository's `.reinguard/` directory as a template, then run
 `rgd config validate` and commit the Semantics files that define that
 repository's policies, knowledge, workflow states, routes, guards, procedures,
 and runtime gate roles. The canonical Adapter bootstrap examples are

--- a/README.md
+++ b/README.md
@@ -159,6 +159,40 @@ inspection, review thread transport, schema export, and config validation.
 Full command behavior, flags, stdout/stderr rules, and exit codes:
 [docs/cli.md](docs/cli.md).
 
+## Install `rgd`
+
+Use Go when you want the latest tagged module build:
+
+```bash
+go install github.com/k-shibuki/reinguard/cmd/rgd@latest
+rgd version
+```
+
+Make sure your Go binary directory is on `PATH`. If `go env GOBIN` is empty,
+Go installs commands under `$(go env GOPATH)/bin`.
+
+Tagged GitHub Releases also publish standalone `rgd` binaries for Linux,
+macOS, and Windows on `amd64` and `arm64`:
+
+1. Download the asset for your platform from
+   [GitHub Releases](https://github.com/k-shibuki/reinguard/releases), for
+   example `rgd_v1.0.0_linux_amd64`.
+2. Download the matching `.sha256` file and verify it with `sha256sum -c`.
+3. Rename the binary to `rgd` (`rgd.exe` on Windows), make it executable on
+   Unix-like systems, and place it in a directory on `PATH`.
+4. Run `rgd version` and `rgd config validate` from a repository that owns a
+   `.reinguard/` configuration.
+
+There is no `rgd init` command in `v1.0.0`. To bootstrap a repository, copy or
+adapt a repository-owned `.reinguard/` directory, then run
+`rgd config validate` and commit the Semantics files that define that
+repository's policies, knowledge, workflow states, routes, guards, procedures,
+and runtime gate roles. The canonical Adapter bootstrap examples are
+[`AGENTS.md`](AGENTS.md) for agent/reviewer instructions and
+[`.cursor/rules/reinguard-bridge.mdc`](.cursor/rules/reinguard-bridge.mdc)
+for Cursor. Those Adapter files should point at `.reinguard/` instead of
+duplicating Semantics-layer policy text.
+
 ## Repository Runtime Expectations
 
 - **Product release**: `v1.0.0` stability promise


### PR DESCRIPTION
## Summary

- Document the supported `rgd` installation paths for Go installs and tagged GitHub Release binaries.
- Clarify that v1.0.0 does not include `rgd init`, so repository bootstrap starts by copying or adapting repo-owned `.reinguard/` Semantics.
- Name `AGENTS.md` and the Cursor bridge as the canonical Adapter bootstrap examples without duplicating Semantics policy text.

## Traceability

Closes #141

Refs: #138

## Definition of Done

- [x] Tests added or updated (`go test ./...`) - not applicable; docs-only README change.
- [x] `go vet ./...` clean - not applicable; no Go code changed.
- [x] Lint clean (golangci-lint / CI) - markdown lint passed locally.
- [x] Documentation updated if behavior or public CLI surface changed.

## Test plan

1. `bash .reinguard/scripts/with-repo-local-state.sh -- pre-commit run markdownlint-cli2 --all-files` - passed.
2. `go run ./cmd/rgd config validate` - passed.
3. Local CodeRabbit review via `.reinguard/scripts/check-local-review.sh --base main --retry-on-rate-limit` - completed with no findings.

## Risk / Impact

- Docs-only onboarding change. Main risk is inaccurate install or bootstrap guidance; commands and artifact names were aligned with the release workflow and current CLI behavior.

## Rollback Plan

- Revert the README documentation commit.

## Exception

- Type: N/A
- Justification: N/A
