### PR TITLE
docs(adapter): bootstrap AGENTS.md hub and Claude Code adapter

### DIFF
--- a/.claude/commands/claude-plan.md
+++ b/.claude/commands/claude-plan.md
@@ -1,0 +1,71 @@
+# claude-plan
+
+Claude Code **planning** entry: exhaust design decisions with clarifying
+questions (recursive, with trade-offs explained for every option), then
+crystallize into a single written plan before editing the repo.
+
+When the outcome is **issue-first** (GitHub Issue before implementation), embed
+the Issue-creation checklist in the plan todos so acceptance is a single gate,
+then execute those steps after the user accepts.
+
+Adapter layer: reference Semantics paths only for policy; do not duplicate
+normative policy body text (ADR-0001). Shared review norms: [`AGENTS.md`](../../AGENTS.md).
+
+## Context (open as needed)
+
+- [`.reinguard/policy/workflow--pr-discipline.md`](../../.reinguard/policy/workflow--pr-discipline.md) — Issue sections, PR body constraints
+- [`.reinguard/policy/coding--standards.md`](../../.reinguard/policy/coding--standards.md) — change scope, ADR/CLI authority
+- [`.reinguard/policy/safety--agent-invariants.md`](../../.reinguard/policy/safety--agent-invariants.md) — HS-*
+
+## Phase 1 — Gather
+
+1. **User goal** — If the prompt is vague, ask one narrowing question before heavy research.
+2. **Existing Issue (optional)** — If `#N` is given:
+
+   ```bash
+   gh issue view <N> --json title,body,labels,state
+   ```
+
+3. **Codebase** — Search the repository for relevant packages, tests, and config. Prefer evidence over assumptions.
+4. **Knowledge** — When building an implementation plan:
+
+   ```bash
+   rgd context build
+   ```
+
+   Use `knowledge.entries` from stdout JSON. Otherwise triage [`.reinguard/knowledge/manifest.json`](../../.reinguard/knowledge/manifest.json) by `description` / `triggers`.
+
+## Phase 2 — Interrogate (recursive)
+
+Maintain an internal **decision ledger**: each row is one design choice with status `open` or `resolved`.
+
+1. **Identify open decisions** — architecture, scope, API shape, migration, test strategy, rollout, etc.
+2. **Explain trade-offs** — before each question batch, describe what each option means, pros, cons, and blast radius.
+3. **Ask in small batches** — prefer 1–2 questions at a time.
+4. **Propagate** — new answers may create new open decisions; loop until resolved or user caps scope.
+
+## Phase 3 — Crystallize (single plan)
+
+**Single output:** one written plan per run. Choose the plan shape from context:
+
+| Plan shape | When | Plan must contain |
+|------------|------|-------------------|
+| **Implementation** | Next step is in-repo code/docs/tests | Overview, file-scoped todos, test/preflight hints |
+| **Issue-first** | Next step is a new GitHub Issue | Same as above, plus Phase 3B Issue-creation todos |
+
+Do not create Issues or edit the repo until the user accepts the plan.
+
+### Phase 3B — Issue creation (embed in plan todos)
+
+When **Issue-first**, embed end-to-end Issue creation in plan todos. Required sections, labels, templates: [`.reinguard/policy/workflow--pr-discipline.md`](../../.reinguard/policy/workflow--pr-discipline.md). Labels: [`.reinguard/labels.yaml`](../../.reinguard/labels.yaml). Script: [`.reinguard/scripts/check-issue-policy.sh`](../../.reinguard/scripts/check-issue-policy.sh).
+
+## Guard
+
+- **Plan mode:** Do not modify the workspace until the user accepts the plan; read-only exploration only.
+- **Execution handoff:** After plan acceptance, follow [`CLAUDE.md`](../../CLAUDE.md) § **Workflow** (`rgd-next` + `next-orchestration.md` loop).
+- Issue creation is **never** the standalone output — only steps inside the accepted plan.
+
+## Output
+
+- Summary of **resolved decisions** in the plan body.
+- **Exactly one plan artifact** per run. For Issue-first work, final todo outcome is the new Issue URL/number.

--- a/.claude/commands/rgd-next.md
+++ b/.claude/commands/rgd-next.md
@@ -67,6 +67,8 @@ Proposal format and approval gate: [`.reinguard/procedure/next-orchestration.md`
 
 After approval, follow [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Post-approval execution contract** and § **Loop semantics**: drive to Per-unit DoD **without** user prompts that gate progress between iterations.
 
+After the single Execute approval, user-visible output should be only the **final report** (Per-unit DoD evidence) or an **allowed stop** with evidence; keep iteration/progress details adapter-internal.
+
 ```bash
 bash .reinguard/scripts/adapter-rgd-next-resume.sh approve
 ```
@@ -79,7 +81,7 @@ bash .reinguard/scripts/adapter-rgd-next-resume.sh update --state-id <state_id> 
 
 When DoD or an allowed stop is reached, close with `finish --status ... --reason ...`.
 
-**Resumable wait stops:** [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Allowed stops**.
+**Resumable wait stops:** [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Allowed stops** and § **Output**.
 
 ## Guard
 

--- a/.claude/commands/rgd-next.md
+++ b/.claude/commands/rgd-next.md
@@ -1,0 +1,88 @@
+# rgd-next
+
+Single Claude Code entry for workflow procedures: use **substrate** output to pick Semantics docs. This command does **not** embed logic that duplicates `rgd` state/route resolution (ADR-0001).
+
+Shared review norms and the Adapter taxonomy: [`AGENTS.md`](../../AGENTS.md). Claude bridge context: [`CLAUDE.md`](../../CLAUDE.md).
+
+## Sense
+
+Before fresh proposal logic, inspect the Adapter-local resume artifact when present:
+
+```bash
+bash .reinguard/scripts/adapter-rgd-next-resume.sh status
+```
+
+Parse the Adapter-local status JSON (`status`, `resume_eligible`, `resume_reason_codes[]`) before running substrate observation. These diagnostics come from the Adapter-local resume script, not from `rgd context build`.
+
+If that reports `status: "active"` and `resume_eligible: true`, resume the recorded approved Execute path instead of starting a new proposal cycle. Resume eligibility: [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Resume eligibility contract** and ADR-0015.
+
+If it reports `status: "pending_approval"`, continue with **Propose** (do not treat as an approved run). This artifact is **Adapter-local only** (ADR-0015): do **not** feed it into `rgd` state / route evaluation.
+
+1. From repo root:
+
+   ```bash
+   rgd context build
+   ```
+
+   If `rgd` is not on `PATH`: `go run ./cmd/rgd context build` (same flags).
+
+   When the user names a PR number:
+
+   ```bash
+   rgd context build --pr <N>
+   ```
+
+2. Parse `rgd context build` stdout JSON:
+   - `state.state_id`, `state.kind`
+   - `routes[0].kind`, `routes[0].route_id` (when `routes[0].kind` is `resolved`)
+   - `guards` (e.g. `merge-readiness` during **Execute**)
+   - `knowledge.entries`
+   - `observation.signals.git.working_tree_clean` (dirty-tree gate for **Route** / `review-address` Step 0)
+
+## Route
+
+When `state.kind` is `resolved`, choose the procedure under `.reinguard/procedure/` whose YAML front matter `applies_to.state_ids` contains `state.state_id` (and align with `routes[0].route_id` vs `applies_to.route_ids` when procedures scope by route). Mapping is validated by `rgd config validate`; [ADR-0013](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) § 4 describes the mechanism — do not duplicate a routing table here.
+
+**Dirty working tree + `review-address`:** When `observation.signals.git.working_tree_clean` is `false` and the mapped procedure is `review-address`, run **Step 0** in that procedure first. See `.reinguard/knowledge/review--incremental-fix-flow.md`.
+
+When `state.kind` is not `resolved`, follow ADR-0007 handoff — do not invent a winning state.
+
+## Propose
+
+After **Sense** and **Route**, record the Adapter-local **proposal** artifact before the approval gate, present the full-path proposal **exactly once**, then wait for approval.
+
+```bash
+bash .reinguard/scripts/adapter-rgd-next-resume.sh start \
+  --branch <branch> \
+  --state-id <state_id> \
+  [--route-id <route_id>] \
+  --ordered-remainder "<procedure1 -> procedure2 -> ... -> DoD>" \
+  --completion-condition "<Per-unit Definition of Done>" \
+  [--issue <N>] [--pr <N>] [--summary TEXT]
+```
+
+Proposal format and approval gate: [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Full-path proposal format** and § **Approval gate**. Trace through **Per-unit Definition of Done**. **No per-procedure re-approval** after the single gate.
+
+## Execute
+
+After approval, follow [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Post-approval execution contract** and § **Loop semantics**: drive to Per-unit DoD **without** user prompts that gate progress between iterations.
+
+```bash
+bash .reinguard/scripts/adapter-rgd-next-resume.sh approve
+```
+
+Refresh the artifact with:
+
+```bash
+bash .reinguard/scripts/adapter-rgd-next-resume.sh update --state-id <state_id> [--route-id <route_id>]
+```
+
+When DoD or an allowed stop is reached, close with `finish --status ... --reason ...`.
+
+**Resumable wait stops:** [`.reinguard/procedure/next-orchestration.md`](../../.reinguard/procedure/next-orchestration.md) § **Allowed stops**.
+
+## Guard
+
+- FSM and priorities: [`docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md`](../../docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md)
+- Adapter vs Semantics: [`docs/adr/0001-system-positioning.md`](../../docs/adr/0001-system-positioning.md)
+- Preflight SSOT: [`.reinguard/policy/coding--preflight.md`](../../.reinguard/policy/coding--preflight.md)

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -73,8 +73,17 @@ reviews:
         normative policy bodies that belong only under `.reinguard/`.
     - path: "AGENTS.md"
       instructions: |
-        Top-level agent orientation; mirror catalog entry points (`policy/catalog.yaml`, knowledge
-        `manifest.json`) and ADR pointers — not replace `.reinguard/` bodies.
+        agents.md hub: shared review guidelines, project context, and path-only
+        Semantics/Substrate entry. Do not expect client-specific workflow here;
+        see .cursor/ or CLAUDE.md / .claude/.
+    - path: "CLAUDE.md"
+      instructions: |
+        Claude Code Adapter bridge; path references only — same constraints as
+        .cursor/** (point at .reinguard/ and rgd; no policy body duplication).
+    - path: ".claude/**"
+      instructions: |
+        Claude Code workflow commands; must point at .reinguard/ and rgd — do not
+        duplicate long normative policy bodies that belong only under .reinguard/.
     - path: "cmd/**"
       instructions: |
         `rgd` CLI entrypoints and flags. Align with `docs/cli.md` and ADRs; substrate must not embed

--- a/.cursor/rules/reinguard-bridge.mdc
+++ b/.cursor/rules/reinguard-bridge.mdc
@@ -3,8 +3,11 @@ alwaysApply: true
 ---
 # reinguard bridge (Adapter layer)
 
-This file is an **adapter**: it points at the Semantics layer (`.reinguard/`)
-and Substrate (`rgd`). Do not duplicate body text from `.reinguard/` here.
+This file is a **concrete Adapter** for Cursor. It points at the Semantics
+layer (`.reinguard/`) and Substrate (`rgd`). Do not duplicate body text from
+`.reinguard/` here. Shared review norms and the Adapter taxonomy live in
+[`AGENTS.md`](../../AGENTS.md) — read that file when acting as a reviewer;
+this bridge covers Cursor-specific workflow and chat constraints only.
 
 ## Language
 

--- a/.reinguard/README.md
+++ b/.reinguard/README.md
@@ -19,8 +19,9 @@ step.
 
 This directory is the **Semantics layer**: it holds **what the repository
 means**—substrate config, knowledge atoms, policy, control (state / route /
-guard) match rules, and procedure mappings—while **Adapter** (`.cursor/`,
-`AGENTS.md`) integrates clients by path reference only, and **Substrate**
+guard) match rules, and procedure mappings—while **Adapter** (`AGENTS.md` hub;
+concrete surfaces such as `.cursor/` and `CLAUDE.md` / `.claude/`) integrates
+clients by path reference only, and **Substrate**
 (`rgd`) computes current status under that meaning. Normative architecture
 lives in [`docs/adr/`](../docs/adr/). The sections below are an **authoring
 guide** for how *this* repository configures `rgd` and where to place new
@@ -32,6 +33,18 @@ Substrate) and [ADR-0011](../docs/adr/0011-semantic-control-plane-structure.md)
 (knowledge), [ADR-0014](../docs/adr/0014-runtime-gate-artifacts.md) (runtime
 gates), and [ADR-0015](../docs/adr/0015-adapter-local-execute-resume.md)
 (Adapter-local resume).
+
+## Adapter taxonomy
+
+| Surface | Primary consumers | Role |
+|---------|-------------------|------|
+| [`AGENTS.md`](../AGENTS.md) | Codex, CodeRabbit, agents.md tools | **Hub:** review guidelines, project context, Semantics/Substrate entry |
+| [`.coderabbit.yaml`](../.coderabbit.yaml) | CodeRabbit | PR review binding; review norms in `AGENTS.md` |
+| [`.cursor/`](../.cursor/) | Cursor | **Concrete:** bridge rule, `rgd-next`, `cursor-plan` |
+| [`CLAUDE.md`](../CLAUDE.md) / [`.claude/`](../.claude/) | Claude Code | **Concrete:** bridge, `rgd-next`, `claude-plan` |
+
+Codex may consume the hub without a dedicated concrete surface; see issue #163
+for sufficiency validation.
 
 ## Load-bearing pieces declared here
 
@@ -91,7 +104,9 @@ Unified **priority** across all control YAML files: ADR-0004.
 - **Must be followed** (review/merge invariants, etc.) → `policy/` and add an entry to `policy/catalog.yaml`.
 - **Evaluable match rules** → `control/` in the subtree matching `type`, and add an entry to `control/catalog.yaml`.
 - **Procedure mappings** → `procedure/` with front matter aligned to control states / routes.
-- **Client-specific bridge behavior** → `.cursor/` (Adapter layer); do not duplicate policy body text there.
+- **Client-specific bridge behavior** → concrete Adapter layer (`.cursor/`,
+  `CLAUDE.md` / `.claude/`); shared review norms → [`AGENTS.md`](../AGENTS.md)
+  hub
 
 ## Authoring policy
 
@@ -99,7 +114,8 @@ Normative documents for this repository: invariants, review and merge
 discipline, exception policy, and related **must-follow** rules.
 
 - This directory subtree is **not** indexed by `rgd knowledge index`.
-- The Adapter layer (`.cursor/`, `AGENTS.md`) references policy files by path.
+- The Adapter layer (`AGENTS.md` hub and concrete surfaces) references policy
+  files by path.
 - Register every policy file in **`policy/catalog.yaml`** (maintained manually).
 - For judgment aids and background knowledge, use `.reinguard/knowledge/` instead
   (ADR-0010, ADR-0011).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,19 @@
 # AGENTS.md
 
-Configuration for AI reviewers (e.g. CodeRabbit) and agents using this repository.
+**agents.md hub** for tools that read `AGENTS.md` directly (for example Codex,
+CodeRabbit, and other agents.md-native clients). Shared cross-agent metadata:
+project context, review guidelines, and path-only entry to Semantics and
+Substrate. Client-specific workflow bridges live under concrete Adapter
+surfaces (see **Client adapters** below).
 
-- **Semantics (SSOT)**: `.reinguard/` — policy index: [`.reinguard/policy/catalog.yaml`](.reinguard/policy/catalog.yaml); knowledge index: [`.reinguard/knowledge/manifest.json`](.reinguard/knowledge/manifest.json); agent procedures: [`.reinguard/procedure/`](.reinguard/procedure/) (Cursor: [`.cursor/commands/rgd-next.md`](.cursor/commands/rgd-next.md) for FSM workflow; [`.cursor/commands/cursor-plan.md`](.cursor/commands/cursor-plan.md) for deep planning (`CreatePlan` only; Issue steps embedded when needed); FSM: [ADR-0013](docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md)).
-- **Adapter (Cursor)**: single always-active rule `.cursor/rules/reinguard-bridge.mdc` + commands in `.cursor/commands/`; see [ADR-0001](docs/adr/0001-system-positioning.md).
-
-## Project context
+## Architecture
 
 **reinguard** provides repo-owned semantic control for agentic development:
 shared operational context for agents, humans, and the bots reviewing their
 work. Its architecture remains three-layered (Adapter / Semantics / Substrate):
 repository-owned Semantics define meaning, and `rgd` is the Substrate layer, a
 stateless Go CLI runtime that computes operational context via observation and
-declarative rules (see ADR-0001).
+declarative rules (see [ADR-0001](docs/adr/0001-system-positioning.md)).
 
 Authoritative architecture: [docs/adr/](docs/adr/). Especially relevant for review:
 
@@ -29,7 +30,25 @@ Authoritative architecture: [docs/adr/](docs/adr/). Especially relevant for revi
 
 CI: `golangci-lint`, `go vet`, `go test -race`; PRs must pass job **`ci-pass`** (aggregates `gate-policy`, `lint-markdown`, `lint-go`, `test-go`, and dogfood jobs). Branch protection should require **`ci-pass`** and **conversation resolution before merge** — see [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
+## Semantics entry points
+
+Path-only references to the Semantics layer (SSOT). Do not duplicate policy or
+procedure bodies here.
+
+- **Policy catalog:** [`.reinguard/policy/catalog.yaml`](.reinguard/policy/catalog.yaml)
+- **Knowledge catalog:** [`.reinguard/knowledge/manifest.json`](.reinguard/knowledge/manifest.json)
+- **Agent procedures:** [`.reinguard/procedure/`](.reinguard/procedure/) — FSM mapping mechanism: [ADR-0013](docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md)
+
+## Substrate (`rgd`)
+
+Operational context, observation, guards, and knowledge filtering are computed
+by the Substrate CLI. Command surface: [`docs/cli.md`](docs/cli.md).
+
 ## Review guidelines
+
+Shared review norms for AI reviewers and agents. CodeRabbit applies these via
+the agents.md convention; concrete Adapters reference this section rather than
+duplicating it.
 
 ### Finding scope
 
@@ -56,3 +75,21 @@ CI: `golangci-lint`, `go vet`, `go test -race`; PRs must pass job **`ci-pass`** 
 Normative: [`.reinguard/policy/review--consensus-protocol.md`](.reinguard/policy/review--consensus-protocol.md) (dispositions, thread and non-thread resolution, [**HS-REVIEW-RESOLVE**](.reinguard/policy/safety--agent-invariants.md)); [`.reinguard/policy/review--disposition-categories.md`](.reinguard/policy/review--disposition-categories.md) (classification for local review, self-inspection, and PR review).
 
 [**HS-NO-DISMISS**](.reinguard/policy/safety--agent-invariants.md) · [**HS-MERGE-CONSENSUS**](.reinguard/policy/safety--agent-invariants.md)
+
+## Client adapters
+
+| Surface | Primary consumers | Role |
+|---------|-------------------|------|
+| `AGENTS.md` | Codex, CodeRabbit, agents.md tools | **Hub** (this file): review guidelines, project context, Semantics/Substrate entry |
+| `.coderabbit.yaml` | CodeRabbit | PR review binding and path-specific bot instructions; review norms in `AGENTS.md` |
+| `.cursor/` | Cursor | **Concrete** Adapter: [`reinguard-bridge.mdc`](.cursor/rules/reinguard-bridge.mdc), [`rgd-next`](.cursor/commands/rgd-next.md), [`cursor-plan`](.cursor/commands/cursor-plan.md) |
+| [`CLAUDE.md`](CLAUDE.md) / [`.claude/`](.claude/) | Claude Code | **Concrete** Adapter: bridge + workflow entry |
+
+Codex may consume this hub without a dedicated concrete Adapter surface;
+sufficiency validation is tracked separately ([#163](https://github.com/k-shibuki/reinguard/issues/163)).
+
+## Workflow by client
+
+- **Cursor:** [`.cursor/commands/rgd-next.md`](.cursor/commands/rgd-next.md) — Sense (`rgd context build`), Route, Propose, Execute per [`.reinguard/procedure/next-orchestration.md`](.reinguard/procedure/next-orchestration.md). Planning: [`.cursor/commands/cursor-plan.md`](.cursor/commands/cursor-plan.md).
+- **Claude Code:** [`.claude/commands/rgd-next.md`](.claude/commands/rgd-next.md) — same Semantics loop; see [`CLAUDE.md`](CLAUDE.md). Planning: [`.claude/commands/claude-plan.md`](.claude/commands/claude-plan.md).
+- **agents.md-native (no workflow client):** run `rgd context build`, open the mapped procedure under [`.reinguard/procedure/`](.reinguard/procedure/) per [ADR-0013](docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) § 4.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# reinguard bridge (Claude Code Adapter)
+
+This file is a **concrete Adapter** for Claude Code. It points at the Semantics
+layer (`.reinguard/`) and Substrate (`rgd`). Do not duplicate body text from
+`.reinguard/` or review guidelines from [`AGENTS.md`](AGENTS.md).
+
+## Shared hub
+
+Review norms, project context, and the Adapter taxonomy live in
+[`AGENTS.md`](AGENTS.md). Read that file when acting as a reviewer; this bridge
+covers Claude-specific workflow entry only.
+
+## Entry points
+
+- **Substrate config:** [`.reinguard/reinguard.yaml`](.reinguard/reinguard.yaml) — `schema_version`, `default_branch`, `providers` (ADR-0008, ADR-0009).
+- **Label SSOT:** [`.reinguard/labels.yaml`](.reinguard/labels.yaml) — GitHub label categories and `commit_prefix` (ADR-0008).
+- **Knowledge catalog:** [`.reinguard/knowledge/manifest.json`](.reinguard/knowledge/manifest.json) — `entries[]` with `id`, `path`, `description`, `triggers`, `when` (ADR-0010).
+- **Policy catalog:** [`.reinguard/policy/catalog.yaml`](.reinguard/policy/catalog.yaml) — normative documents; bodies under [`.reinguard/policy/`](.reinguard/policy/).
+- **Control catalog:** [`.reinguard/control/catalog.yaml`](.reinguard/control/catalog.yaml) — human-maintained index; rule YAML under [`.reinguard/control/states/`](.reinguard/control/states/), [routes/](.reinguard/control/routes/), [guards/](.reinguard/control/guards/).
+- **Procedures:** [`.reinguard/procedure/`](.reinguard/procedure/) — Claude: [`.claude/commands/rgd-next.md`](.claude/commands/rgd-next.md), [`.claude/commands/claude-plan.md`](.claude/commands/claude-plan.md).
+
+## Always-active policy
+
+Follow these policy documents in every interaction (path references only):
+
+- [safety--agent-invariants.md](.reinguard/policy/safety--agent-invariants.md) — **HARD STOPS (HS-*)**
+- [coding--standards.md](.reinguard/policy/coding--standards.md) — English artifacts, change scope, ADR/CLI authority
+- [workflow--pr-discipline.md](.reinguard/policy/workflow--pr-discipline.md) — Issue-driven work, PR discipline
+- [commit--format.md](.reinguard/policy/commit--format.md) — Conventional Commits, `Refs` in message body
+
+## Workflow
+
+Follow [`.reinguard/policy/workflow--pr-discipline.md`](.reinguard/policy/workflow--pr-discipline.md). Procedure mapping is defined in each procedure's YAML front matter (`applies_to`) under [`.reinguard/procedure/`](.reinguard/procedure/); [ADR-0013](docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) § 4 documents the mechanism.
+
+**Claude workflow entry:** [`.claude/commands/rgd-next.md`](.claude/commands/rgd-next.md) — Sense (`rgd context build`), Route, Propose, Execute per [`.reinguard/procedure/next-orchestration.md`](.reinguard/procedure/next-orchestration.md).
+
+**Planning entry:** [`.claude/commands/claude-plan.md`](.claude/commands/claude-plan.md) — research and design interrogation before implementation; execution handoff uses `rgd-next` loop semantics.
+
+## GitHub and git observation
+
+- **Primary:** `rgd observe` and `rgd context build` — see [`docs/cli.md`](docs/cli.md), ADR-0006, ADR-0009.
+- **Supplementary:** `gh` and `git` for read-only facts when needed (ADR-0006).
+
+## Knowledge retrieval
+
+See [`docs/cli.md`](docs/cli.md) (`rgd context build`, `knowledge pack`). After changing knowledge front matter: `rgd knowledge index`, commit `manifest.json`, then `rgd config validate`.
+
+## Normative references
+
+- [ADR-0001](docs/adr/0001-system-positioning.md) (Adapter / Semantics / Substrate)
+- [ADR-0013](docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md) (FSM states, routes, Adapter mapping)
+- [`docs/cli.md`](docs/cli.md)

--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ context stable enough for agentic development.
 
 ## How It Is Structured
 
-`reinguard` spans three layers, plus AI-facing reference:
+`reinguard` spans three layers:
 
-- **Adapter** — client-specific procedures and bridge files (`.cursor/`)
+- **Adapter** — client integration: [`AGENTS.md`](AGENTS.md) **hub** (shared review norms and Semantics entry) plus **concrete** surfaces (`.cursor/` for Cursor, [`CLAUDE.md`](CLAUDE.md) / [`.claude/`](.claude/) for Claude Code, [`.coderabbit.yaml`](.coderabbit.yaml) for CodeRabbit review binding)
 - **Semantics** — repository meaning: knowledge, policy, states, routes, guards, and procedures (`.reinguard/`)
 - **Substrate** — the `rgd` runtime that computes operational context from observation and declared rules
 
-Additionally, [`AGENTS.md`](AGENTS.md) provides reviewer and agent configuration — read by AI bots and agents, not part of the layered runtime. See [ADR-0001](docs/adr/0001-system-positioning.md) and [ADR-0011](docs/adr/0011-semantic-control-plane-structure.md).
+See [ADR-0001](docs/adr/0001-system-positioning.md) and [ADR-0011](docs/adr/0011-semantic-control-plane-structure.md) for hub vs concrete Adapter boundaries.
 
 ## `rgd` At A Glance
 
@@ -191,11 +191,10 @@ There is no `rgd init` command in `v1.0.0`. To bootstrap a repository, copy or
 adapt this repository's `.reinguard/` directory as a template, then run
 `rgd config validate` and commit the Semantics files that define that
 repository's policies, knowledge, workflow states, routes, guards, procedures,
-and runtime gate roles. The canonical Adapter bootstrap examples are
-[`AGENTS.md`](AGENTS.md) for agent/reviewer instructions and
-[`.cursor/rules/reinguard-bridge.mdc`](.cursor/rules/reinguard-bridge.mdc)
-for Cursor. Those Adapter files should point at `.reinguard/` instead of
-duplicating Semantics-layer policy text.
+and runtime gate roles. Adapter bootstrap:
+
+- **[`AGENTS.md`](AGENTS.md)** — agents.md **hub**: shared review guidelines, project context, and path-only entry to `.reinguard/` and `rgd` (for Codex, CodeRabbit, and other agents.md-native tools).
+- **Concrete Adapter examples** — [`.cursor/rules/reinguard-bridge.mdc`](.cursor/rules/reinguard-bridge.mdc) (Cursor), [`CLAUDE.md`](CLAUDE.md) / [`.claude/`](.claude/) (Claude Code). Each concrete surface signposts workflow entry and references the hub and Semantics layer instead of duplicating policy text.
 
 ## Repository Runtime Expectations
 

--- a/docs/adr/0001-system-positioning.md
+++ b/docs/adr/0001-system-positioning.md
@@ -62,9 +62,16 @@ means**, and **how the runtime substrate evaluates**:
 
 | Layer | Name | Verb | Location | SSOT for | Feedback role |
 |-------|------|------|----------|----------|---------------|
-| 3 | **Adapter** | adapt | `.cursor/`, `AGENTS.md` | Client-specific procedures, behavioral rules, bridge references | `internalize`: review findings → Semantics update |
+| 3 | **Adapter** | adapt | `AGENTS.md` (hub); concrete: `.cursor/`, `CLAUDE.md` / `.claude/`, `.coderabbit.yaml` | Hub: shared review norms and Semantics entry; concrete: client-specific bridges and workflow entry | `internalize`: review findings → Semantics update |
 | 2 | **Semantics** | declare | `.reinguard/` | Knowledge, policy, and control definitions (see ADR-0011) | Correction target |
 | 1 | **Substrate** | compute | `rgd` | Observation engine, rule/evaluator runtime, schema tooling, CLI | None (stateless, non-adaptive) |
+
+**Adapter hub vs concrete:** `AGENTS.md` is the **agents.md hub** — review
+guidelines, project context, and path-only Semantics/Substrate entry for
+tools that consume `AGENTS.md` directly (for example Codex and CodeRabbit).
+**Concrete** Adapters (`.cursor/`, Claude Code surfaces, CodeRabbit binding)
+signpost workflow and client-specific behavior; they reference the hub and
+`.reinguard/` rather than duplicating normative policy bodies.
 
 **Dependency direction:** Adapter → Semantics → Substrate. Upper layers
 may reference lower layers; lower layers do not depend on upper layers.

--- a/docs/adr/0011-semantic-control-plane-structure.md
+++ b/docs/adr/0011-semantic-control-plane-structure.md
@@ -11,7 +11,8 @@ Without explicit structure:
   knowledge pack`).
 - The name `rules/` is overloaded (policy rules, control rules, linter
   rules, interaction rules).
-- The Adapter layer (`.cursor/`) may grow thick with duplicated semantics.
+- The Adapter layer (concrete surfaces such as `.cursor/`) may grow thick
+  with duplicated semantics.
 
 ## Decision
 
@@ -32,10 +33,10 @@ Without explicit structure:
    - `procedure/` — agent **action-card** bodies (Markdown with YAML front
      matter: `id`, `purpose`, `applies_to`, `reads`, `sense`, `act`, `output`,
      `done_when`, `escalate_when`). SSOT for procedural steps lives here
-     (ADR-0013). Cursor: `rgd-next` maps substrate output to these paths
-     (`.cursor/commands/rgd-next.md`); `cursor-plan` handles deep planning via
-     `CreatePlan` only, embedding Issue-creation steps when issue-first
-     (`.cursor/commands/cursor-plan.md`).
+     (ADR-0013). Concrete Adapters map substrate output to these paths — for
+     example Cursor (`.cursor/commands/rgd-next.md`) and Claude Code
+     (`.claude/commands/rgd-next.md`); planning entries are client-specific
+     (`.cursor/commands/cursor-plan.md`, `.claude/commands/claude-plan.md`).
    - `local/` — **gitignored operational state** written by the Substrate or
      Adapter when a bounded runtime contract explicitly allows it (for example
      runtime gate artifacts and Adapter resume state; see ADR-0014 and
@@ -62,11 +63,13 @@ Without explicit structure:
    - State / route / guard meaning in match YAML → `control/`
    - Repeatable agent procedure bound to state/route → `procedure/`
    - Substrate or Adapter operational state under bounded contract → `local/`
-   - Client-specific bridge only (no SSOT prose) → Adapter layer (`.cursor/`)
+   - Client-specific bridge only (no SSOT prose) → concrete Adapter layer
+     (`.cursor/`, `CLAUDE.md` / `.claude/`, etc.)
 
-1. **Adapter layer** — `.cursor/` remains thin: bridge files and commands
-   reference `.reinguard/` paths; they do not restate Semantics-layer body
-   text as SSOT.
+1. **Adapter layer** — `AGENTS.md` is the **hub** (shared review norms and
+   Semantics entry). Concrete Adapters remain thin: bridge files and commands
+   reference `.reinguard/` paths and `AGENTS.md` where appropriate; they do
+   not restate Semantics-layer body text as SSOT.
 
 ## Consequences
 

--- a/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
+++ b/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
@@ -128,6 +128,8 @@ Post-review learning: `.reinguard/procedure/internalize.md`.
 
 **Cursor entries:** `.cursor/commands/rgd-next.md` — Sense (`rgd context build`), Route using procedure front matter as above, then Propose / Execute per `.reinguard/procedure/next-orchestration.md` (do not duplicate a mapping table in Adapter files). `.cursor/commands/cursor-plan.md` — planning only (`AskQuestion` / `CreatePlan`); not part of the FSM.
 
+**Claude Code entries:** `CLAUDE.md` — thin bridge referencing Semantics paths and [`AGENTS.md`](../AGENTS.md) for shared review norms. `.claude/commands/rgd-next.md` — same Sense / Route / Propose / Execute contract as Cursor (Semantics SSOT unchanged). `.claude/commands/claude-plan.md` — planning entry; not part of the FSM.
+
 ### 5. Extension contract (state / route / Adapter)
 
 When adding or changing FSM wiring, keep these touchpoints consistent:

--- a/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
+++ b/docs/adr/0013-fsm-workflow-states-and-adapter-mapping.md
@@ -128,7 +128,7 @@ Post-review learning: `.reinguard/procedure/internalize.md`.
 
 **Cursor entries:** `.cursor/commands/rgd-next.md` — Sense (`rgd context build`), Route using procedure front matter as above, then Propose / Execute per `.reinguard/procedure/next-orchestration.md` (do not duplicate a mapping table in Adapter files). `.cursor/commands/cursor-plan.md` — planning only (`AskQuestion` / `CreatePlan`); not part of the FSM.
 
-**Claude Code entries:** `CLAUDE.md` — thin bridge referencing Semantics paths and [`AGENTS.md`](../AGENTS.md) for shared review norms. `.claude/commands/rgd-next.md` — same Sense / Route / Propose / Execute contract as Cursor (Semantics SSOT unchanged). `.claude/commands/claude-plan.md` — planning entry; not part of the FSM.
+**Claude Code entries:** `CLAUDE.md` — thin bridge referencing Semantics paths and [`AGENTS.md`](../../AGENTS.md) for shared review norms. `.claude/commands/rgd-next.md` — same Sense / Route / Propose / Execute contract as Cursor (Semantics SSOT unchanged). `.claude/commands/claude-plan.md` — planning entry; not part of the FSM.
 
 ### 5. Extension contract (state / route / Adapter)
 


### PR DESCRIPTION
## Summary

- Restructure `AGENTS.md` as the agents.md hub (preserve review guidelines, remove Cursor-only signposts, add client taxonomy and workflow-by-client section).
- Add Claude Code concrete Adapter (`CLAUDE.md`, `.claude/commands/rgd-next.md`, `.claude/commands/claude-plan.md`) as a thin mirror of Cursor surfaces.
- Update `.coderabbit.yaml` path instructions, amend ADR-0001/0011/0013, and align README / `.reinguard/README.md` for hub vs concrete Adapter boundaries.

## Traceability

Closes #158

Refs: #158

## Definition of Done

- [x] Tests added or updated (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Lint clean (golangci-lint / CI)
- [x] Documentation updated if behavior or public CLI surface changed

## Test plan

1. `pre-commit run markdownlint-cli2 --all-files`
2. `go run ./cmd/rgd config validate`
3. `go run ./cmd/rgd context build --compact`
4. Local CodeRabbit CLI review via `check-local-review.sh`

## Risk / Impact

- Docs-only PR; no Substrate or Semantics runtime contract changes.
- Adapter boundary documentation only; downstream repos copying bootstrap examples should prefer `AGENTS.md` hub + concrete surfaces.

## Rollback Plan

- Revert this PR; no migration or runtime state.

## Exception

- Type:
- Justification:
